### PR TITLE
feat: add lazy boot restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ─── Node / Electron ────────────────────────────────────────────────────────
 node_modules/
+.pnpm-store/
 out/
 dist/
 release/

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -2,6 +2,7 @@
 import { computed, defineAsyncComponent, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import ViewPanel, { type LayoutMode } from './components/ViewPanel.vue'
 import TerminalPane from './components/TerminalPane.vue'
+import RestoredPanePlaceholder from './components/RestoredPanePlaceholder.vue'
 import AgentHistoryModal from './components/AgentHistoryModal.vue'
 import ReconnectSessionModal, { type OrphanSession } from './components/ReconnectSessionModal.vue'
 import ControlPane, {
@@ -172,8 +173,10 @@ onMounted(() => {
   // user disabling it from the native quit dialog's "don't show again".
   pushQuitConfirmConfig()
   window.agentTeam?.onQuitConfirmDisabled?.(() => { confirmBeforeClose.value = false })
-  // Clicking a system notification focuses the window on the originating pane.
-  window.agentTeam?.onFocusPane?.((paneId) => { onFocusPane(paneId) })
+  // Clicking a system notification focuses and activates the originating pane.
+  window.agentTeam?.onFocusPane?.((paneId) => {
+    onFocusPane(paneId)
+  })
   // Plan window "execute" dispatch routed to this workspace's window.
   window.agentTeam?.onPlanExecutionDispatch?.((payload) => { void onPlanExecutionDispatch(payload) })
   // Editor-window AI Chat fetches a CLI pane's scrollback through the main
@@ -368,6 +371,9 @@ const currentWorkspace = ref<string>(
     }
   })()
 )
+// Placeholder creation changes the visible-pane computed state. Suppress its
+// watcher until hydration has selected and painted the initial screen.
+let hydratingColdRestore = false
 const workspaceSelected = ref<boolean>(
   _bootWorkspace !== '' ||
   (() => {
@@ -628,6 +634,10 @@ interface RunGroup {
 
 interface ActivePane {
   id: string
+  /** False while a persisted pane is represented by a cold-restore placeholder. */
+  realized: boolean
+  /** Runtime-only restore marker cleared after the first live output. */
+  restoring?: boolean
   agentKey: string
   agentLabel: string
   /** User-set display name from the rename action. Overrides agentLabel in all
@@ -702,6 +712,8 @@ interface ActivePane {
   /** Epoch ms of the heuristic quota-reset estimate (runtime-only): loop start
    *  + 5h Claude session window, shown on the running badge as approximate. */
   loopEstimateResetAt?: number | null
+  /** Cold-restore metadata retained until the placeholder is explicitly opened. */
+  deferredRestore?: DeferredRestoreMetadata
 }
 
 const panes = ref<ActivePane[]>([])
@@ -1185,7 +1197,9 @@ function syncViews(): void {
       roleLabel: roleLabel(p.roleKey),
       stageId: p.stageId,
       command: p.command,
-      status: (ref?.displayStatus as string | undefined) ?? (ref?.status as string | undefined) ?? 'starting',
+      status: p.realized
+        ? (ref?.displayStatus as string | undefined) ?? (ref?.status as string | undefined) ?? 'starting'
+        : 'waiting',
       error: ref?.error as string | undefined,
       injectionStatus: p.injectionStatus,
       preparationStatus: p.preparationStatus,
@@ -1197,11 +1211,18 @@ function syncViews(): void {
       isMinimized: minimizedPanes.value.has(p.id),
       loopActive: p.loopActive,
       loopWaitUntil: p.loopWaitUntil,
-      rebuildVisible: paneRebuildVisible(p),
-      canRebuild: paneCanRebuild(p),
-      rebuilding: paneRebuilding(p)
+      rebuildVisible: p.realized && paneRebuildVisible(p),
+      canRebuild: p.realized && paneCanRebuild(p),
+      rebuilding: p.realized && paneRebuilding(p)
     }
   })
+}
+
+function onPaneFirstOutput(paneId: string): void {
+  const pane = panes.value.find((p) => p.id === paneId)
+  if (!pane?.restoring) return
+  pane.restoring = false
+  syncViews()
 }
 
 let _syncViewsTimer: number | null = null
@@ -1382,6 +1403,7 @@ async function injectPane(
   preserveNewlines = false,
   shouldAbort?: () => boolean
 ): Promise<boolean> {
+  if (!panes.value.find((p) => p.id === paneId)?.realized) return false
   const ref = paneRefs[paneId]
   if (!ref?.sessionId) return false
   return injectText(ref.sessionId, text, logLabel, preserveNewlines, shouldAbort)
@@ -1417,7 +1439,19 @@ function mentionCandidatesFor(paneId: string): string[] {
 async function injectPaneContext(sourcePaneId: string, targetPaneId: string): Promise<void> {
   const sourcePane = panes.value.find((p) => p.id === sourcePaneId)
   const sourceRef = paneRefs[sourcePaneId]
-
+  const targetSessionId = paneRefs[targetPaneId]?.sessionId as string | undefined
+  // Preserve the established relay fallback for an absent source or a live
+  // source whose local ref was torn down. A local placeholder has no buffer to
+  // share, however, so never ask another window to provide stale context for it.
+  if (!sourcePane || !sourceRef) {
+    if (!sourcePane || sourcePane.realized) {
+      await injectExternalPaneContext(sourcePaneId, targetPaneId)
+    }
+    return
+  }
+  // Placeholders have no live PTY/buffer. A target placeholder cannot accept a
+  // paste either.
+  if (!sourcePane.realized || !panes.value.find((p) => p.id === targetPaneId)?.realized || !targetSessionId) return
   // Mention mode: an "@" typed immediately before the drop means "insert just
   // this pane's messaging name", completing e.g. "傳給 @" + drop → "傳給 @codex-1 ".
   // Falls through to the full context share when the source has no name
@@ -1425,17 +1459,6 @@ async function injectPaneContext(sourcePaneId: string, targetPaneId: string): Pr
   const lineBeforeCursor = paneRefs[targetPaneId]?.readLineBeforeCursor?.()
   if (lineBeforeCursor !== undefined && endsWithMentionTrigger(lineBeforeCursor) && sourcePane?.messagingName) {
     await pastePaneContext(targetPaneId, sourcePane.messagingName + ' ')
-    return
-  }
-
-  if (!sourcePane || !sourceRef) {
-    // Source pane is not in this window: Chromium DOES deliver same-app
-    // cross-window drops directly to this window's drop targets, so a drag
-    // from another workspace window lands here with a pane id this window
-    // does not own. Fetch its context through the pane-buffer relay instead.
-    // (Also covers source-closed-mid-drag: the relay answers not-found and
-    // the user gets a toast rather than silence.)
-    await injectExternalPaneContext(sourcePaneId, targetPaneId)
     return
   }
 
@@ -1524,7 +1547,7 @@ function bumpLoopGen(paneId: string): number {
 
 async function togglePaneLoop(paneId: string): Promise<void> {
   const pane = panes.value.find((p) => p.id === paneId)
-  if (!pane) return
+  if (!pane?.realized) return
   if (pane.loopActive) {
     pane.loopActive = false
     pane.loopWaitUntil = null
@@ -2390,6 +2413,8 @@ interface SpawnInternal {
    *  marker bootstrap, whose dismissStartupDialog + pasted marker + Enter
    *  would inject input into the CLI's interactive sign-in wizard. */
   isLogin?: boolean
+  /** Runtime-only restore marker kept on replacement panes until first output. */
+  restoring?: boolean
 }
 
 /** Trailing line embedded in a Codex/Antigravity kickoff so the backend can match
@@ -2490,6 +2515,8 @@ async function spawnPane(opts: SpawnInternal): Promise<string | null> {
       : ''
   const pane: ActivePane = {
     id,
+    realized: true,
+    restoring: opts.restoring,
     agentKey: opts.agentKey,
     agentLabel: spec.label,
     customName: opts.customName,
@@ -2519,13 +2546,13 @@ async function spawnPane(opts: SpawnInternal): Promise<string | null> {
   if (sessionMarker && pane.kickoffPrompt) {
     pane.kickoffPrompt += sessionMarkerLine(sessionMarker)
   }
-  
+
   if (opts.replacePaneId) {
     const wasFocused = focusPaneId.value === opts.replacePaneId
     const idx = panes.value.findIndex(p => p.id === opts.replacePaneId)
     if (idx >= 0) panes.value.splice(idx, 1, pane)
     else panes.value.push(pane)
-    if (wasFocused) focusPaneId.value = id
+    if (wasFocused) selectPane(id, { userInitiated: false })
   } else {
     panes.value.push(pane)
   }
@@ -2792,7 +2819,7 @@ async function dispatchPlanToPane(relPath: string, agentKey: string): Promise<Pl
     currentWorkspace.value
   )
   if (reusable) {
-    onFocusPane(reusable.id)
+    selectPane(reusable.id, { userInitiated: false })
     const injected = await injectPane(reusable.id, prompt, 'plan-execute', true)
     return injected ? { ok: true } : { ok: false, reason: 'inject-failed' }
   }
@@ -2834,7 +2861,7 @@ async function dispatchPlanToPane(relPath: string, agentKey: string): Promise<Pl
   })
   const pane = panes.value.find((p) => p.id === paneId)
   if (!pane) return { ok: false, reason: 'pane-spawn-failed' }
-  onFocusPane(paneId)
+  selectPane(paneId, { userInitiated: false })
   const bootstrapped = await sendSessionMarkerBootstrap(pane, `[pane ${paneId.slice(0, 8)}]`)
   if (!bootstrapped) {
     // No marker/hint text to send (or the send failed): settle CLI startup
@@ -2921,7 +2948,7 @@ async function onManualResume(payload: { agentKey: string, workspacePath: string
  */
 async function onAnalyzeNow(paneId: string): Promise<void> {
   const pane = panes.value.find((p) => p.id === paneId)
-  if (!pane) return
+  if (!pane?.realized) return
   const stageIndex = stagesApi.stages.value.findIndex((s) => s.id === pane.stageId)
   const stage = stagesApi.stages.value[stageIndex]
   if (!stage) return
@@ -2959,7 +2986,7 @@ async function onAnalyzeNow(paneId: string): Promise<void> {
 
 async function onReinject(paneId: string): Promise<void> {
   const pane = panes.value.find((p) => p.id === paneId)
-  if (!pane) return
+  if (!pane?.realized) return
   if (pane.injectionTimer !== null) {
     window.clearTimeout(pane.injectionTimer)
     pane.injectionTimer = null
@@ -2994,7 +3021,10 @@ async function onKill(paneId: string, opts: { markRemoved?: boolean, force?: boo
   }
   let stageIndex = -1
   if (pane) {
-    stageIndex = stagesApi.stages.value.findIndex((s) => s.id === pane.stageId)
+    const savedStageIndex = pane.deferredRestore?.saved.stage_index
+    stageIndex = typeof savedStageIndex === 'number' && savedStageIndex >= 0
+      ? savedStageIndex
+      : stagesApi.stages.value.findIndex((s) => s.id === pane.stageId)
     if (stageIndex >= 0) cancelWatcher(paneId)
   }
   if (activeQuestion.value?.paneId === paneId) activeQuestion.value = null
@@ -3072,12 +3102,12 @@ function paneRebuilding(pane: ActivePane): boolean {
 
 /** Rebuildable panes in the active tab only — drives the tab bar's rebuild button. */
 const rebuildablePaneCount = computed(
-  () => panes.value.filter((p) => tabFilteredPaneIds.value.has(p.id) && paneCanRebuild(p)).length
+  () => panes.value.filter((p) => p.realized && tabFilteredPaneIds.value.has(p.id) && paneCanRebuild(p)).length
 )
 
 /** Rebuildable panes across all tabs — drives the sidebar's rebuild-all button. */
 const rebuildableAllPaneCount = computed(
-  () => panes.value.filter((p) => paneCanRebuild(p)).length
+  () => panes.value.filter((p) => p.realized && paneCanRebuild(p)).length
 )
 
 async function rebuildPaneViaResume(
@@ -3085,7 +3115,7 @@ async function rebuildPaneViaResume(
   opts?: { suppressBusyToast?: boolean }
 ): Promise<'busy' | undefined> {
   const pane = panes.value.find((p) => p.id === paneId)
-  if (!pane) return
+  if (!pane?.realized) return
   // If the CLI is actively working, skip rebuild so we don't kill in-flight work.
   // The PTY is alive and the pane is already bound — nothing to reattach, just leave it.
   // Judged purely on displayStatus: it is built from CLEANED output bursts, so an
@@ -3243,7 +3273,7 @@ async function rebuildPanesViaResume(scope: 'tab' | 'all'): Promise<void> {
   if (rebuildingTabPanes.value) return
   // Rebuild replaces pane ids, so capture the batch up front.
   const ids = panes.value
-    .filter((p) => (scope === 'all' || tabFilteredPaneIds.value.has(p.id)) && paneCanRebuild(p))
+    .filter((p) => p.realized && (scope === 'all' || tabFilteredPaneIds.value.has(p.id)) && paneCanRebuild(p))
     .map((pane) => pane.id)
   if (!ids.length) return
 
@@ -3274,7 +3304,7 @@ async function rebuildPanesViaResume(scope: 'tab' | 'all'): Promise<void> {
 
 async function rebuildPaneClean(paneId: string): Promise<void> {
   const pane = panes.value.find((p) => p.id === paneId)
-  if (!pane) return
+  if (!pane?.realized) return
   // Same session-aware lock as rebuildPaneViaResume: mid-resume the
   // replacement pane (new id, same session) is already live, and its clear
   // shortcut / respawn button route here — without the session key a clean
@@ -3353,6 +3383,7 @@ async function rebuildPaneClean(paneId: string): Promise<void> {
 }
 
 async function onInterrupt(paneId: string): Promise<void> {
+  if (!panes.value.find((p) => p.id === paneId)?.realized) return
   const ref = paneRefs[paneId]
   if (!ref?.sessionId) return
   try {
@@ -3671,13 +3702,25 @@ function revealPaneTab(paneId: string): void {
   if (stageTabs.value.some((t) => t.key === key)) activeTab.value = key
 }
 
+interface PaneSelectionOptions {
+  userInitiated: boolean
+  scrollIntoView?: boolean
+}
+
+function selectPane(paneId: string | null, options: PaneSelectionOptions): void {
+  focusPaneId.value = paneId
+  if (paneId && options.userInitiated) void realizeRestoredPane(paneId)
+  if (paneId && options.scrollIntoView) {
+    void nextTick(() => {
+      const el = document.querySelector(`[data-pane-id="${paneId}"]`)
+      el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    })
+  }
+}
+
 function onFocusPane(paneId: string): void {
   revealPaneTab(paneId)
-  focusPaneId.value = paneId
-  nextTick(() => {
-    const el = document.querySelector(`[data-pane-id="${paneId}"]`)
-    el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-  })
+  selectPane(paneId, { userInitiated: true, scrollIntoView: true })
 }
 
 const previewLogContent = ref<string>('')
@@ -3927,6 +3970,122 @@ interface ProjectPayload {
   resume_index?: number
 }
 
+interface ColdRestoreBatch {
+  workspacePath: string
+  records: ProjectPane[]
+  /** All persisted claims stay available for reconnect exclusion checks. */
+  savedClaims: ProjectPane[]
+  usedFreshSessionIds: Set<string>
+  decisionPromise?: Promise<RestoreDecision>
+}
+
+interface DeferredRestoreMetadata {
+  saved: ProjectPane
+  workspacePath: string
+  batch: ColdRestoreBatch
+}
+
+interface RestoredPaneSpawnOptions {
+  saved: ProjectPane
+  workspacePath: string
+  runGroupId?: string
+  sessionHomeId?: string
+  /** Persisted CLI account pin; restores must stay on the same isolated home. */
+  profileId?: string
+  commandOverride: string
+  fallbackCommand: string
+  isResume: boolean
+  resumeSessionId: string
+  sessionKnownOnDisk: boolean
+  freshSessionId?: string
+  freshPipelineFallbackSessionId: string
+  replacePaneId?: string
+  restoring?: boolean
+  /** Check replacement ownership before its new record is persisted. */
+  shouldPersist?: (paneId: string) => boolean
+}
+
+interface RestoredPaneSpawnResult {
+  paneId: string
+}
+
+/** Spawn an already-decided restore and persist its new pane record. Restore
+ * policy (probe, resume/fresh choice, reconnect, and stale checks) stays with
+ * the eager/lazy callers; this only keeps their spawn metadata in sync. */
+async function spawnRestoredPane(opts: RestoredPaneSpawnOptions): Promise<RestoredPaneSpawnResult | null> {
+  const { saved } = opts
+  const paneId = await spawnPane({
+    agentKey: saved.agent as AgentKey,
+    roleKey: saved.role,
+    stageId: (saved.stage_id ?? '') as StageId,
+    slotLabel: saved.slot_label,
+    customName: saved.custom_name || undefined,
+    autoName: saved.auto_name || undefined,
+    commandOverride: opts.commandOverride,
+    workspacePath: opts.workspacePath,
+    origin: saved.origin,
+    runGroupId: opts.runGroupId,
+    isResume: opts.isResume,
+    skipRoleInjection: opts.isResume,
+    stageIndex: saved.stage_index ?? -1,
+    restoreMode: opts.isResume ? 'memory-resume' : 'fresh',
+    sessionHomeId: opts.sessionHomeId,
+    profileId: opts.profileId,
+    resumeSessionId: opts.resumeSessionId,
+    sessionKnownOnDisk: opts.sessionKnownOnDisk,
+    freshSessionId: opts.freshSessionId,
+    preferredMessagingName: persistedMessagingName(saved.pane_id),
+    replacePaneId: opts.replacePaneId,
+    restoring: opts.restoring,
+  })
+  if (!paneId) return null
+  if (opts.shouldPersist && !opts.shouldPersist(paneId)) {
+    await onKill(paneId, { markRemoved: false })
+    return null
+  }
+  if (saved.pane_id !== paneId) dropPersistedMessagingName(saved.pane_id)
+
+  const pinnedSessionId = panes.value.find((p) => p.id === paneId)?.pinnedSessionId ?? ''
+  if (saved.origin === 'pipeline') {
+    await sendQuiet('pipeline.slot_spawn', {
+      workspace_path: opts.workspacePath,
+      stage_index: saved.stage_index,
+      slot_label: saved.slot_label,
+      pane_id: paneId,
+      agent: saved.agent,
+      role: saved.role,
+      session_id: opts.isResume
+        ? opts.resumeSessionId
+        : (pinnedSessionId || opts.freshPipelineFallbackSessionId),
+      session_home_id: opts.sessionHomeId ?? '',
+      profile_id: opts.profileId ?? '',
+      run_group_id: opts.runGroupId ?? '',
+    })
+  } else {
+    await sendQuiet<ProjectPayload>('manual_pane.spawn', {
+      workspace_path: opts.workspacePath,
+      pane_id: paneId,
+      previous_pane_id: saved.pane_id,
+      agent: saved.agent,
+      role: saved.role,
+      command: opts.fallbackCommand,
+      session_id: opts.isResume ? opts.resumeSessionId : pinnedSessionId,
+      session_home_id: opts.sessionHomeId ?? '',
+      profile_id: opts.profileId ?? '',
+      run_group_id: opts.runGroupId,
+      output_log_file: panes.value.find((p) => p.id === paneId)?.outputLogFile ?? '',
+    })
+    if (opts.resumeSessionId && !opts.isResume && !pinnedSessionId) {
+      await sendQuiet('manual_pane.session', {
+        workspace_path: opts.workspacePath,
+        pane_id: paneId,
+        session_id: '',
+      })
+    }
+  }
+  return { paneId }
+}
+
 interface SessionExistsPayload {
   exists: boolean
 }
@@ -4148,32 +4307,42 @@ async function onWorkspaceCheck(path: string): Promise<void> {
         })
       }
     }
-    activeTab.value = (savedTab && stageTabs.value.some((t) => t.key === savedTab))
-      ? savedTab
-      : (stageTabs.value[0]?.key ?? '')
-    if (suppressPaneRestoreOnce) {
-      // First load of a duplicated window: open the same workspace as a clean
-      // view without re-resuming the source window's live agent sessions.
-      suppressPaneRestoreOnce = false
-    } else {
-      // isStale lets restore bail if a newer workspace-check superseded this one
-      // while the 'ask' resume dialog was open (the await can span a user pause).
-      await restoreWorkspacePanes(resp, path, undefined, () => seq !== workspaceCheckSeq)
-    }
-    // If the active tab has no panes (e.g. old project.json panes landed in a
-    // different group via fallback), switch to the first tab that has panes so
-    // the user is not greeted with an empty grid.
-    if (activeTab.value && stageTabs.value.length > 0) {
-      const paneCountByGroup: Record<string, number> = {}
-      for (const p of panes.value) {
-        const groupKey = p.runGroupId || 'manual'
-        paneCountByGroup[groupKey] = (paneCountByGroup[groupKey] ?? 0) + 1
+    hydratingColdRestore = true
+    try {
+      activeTab.value = (savedTab && stageTabs.value.some((t) => t.key === savedTab))
+        ? savedTab
+        : (stageTabs.value[0]?.key ?? '')
+      if (suppressPaneRestoreOnce) {
+        // First load of a duplicated window: open the same workspace as a clean
+        // view without re-resuming the source window's live agent sessions.
+        suppressPaneRestoreOnce = false
+      } else {
+        // isStale lets restore bail if a newer workspace-check superseded this one
+        // before or during restore (the await can span a user pause).
+        await restoreWorkspacePanes(resp, path, undefined, () => seq !== workspaceCheckSeq)
       }
-      const activeHasPanes = (paneCountByGroup[activeTab.value] ?? 0) > 0
-      if (!activeHasPanes) {
-        const firstFull = stageTabs.value.find((t) => (paneCountByGroup[t.key] ?? 0) > 0)
-        if (firstFull) activeTab.value = firstFull.key
+      // If the active tab has no panes (e.g. old project.json panes landed in a
+      // different group via fallback), switch to the first tab that has panes so
+      // the user is not greeted with an empty grid.
+      if (activeTab.value && stageTabs.value.length > 0) {
+        const paneCountByGroup: Record<string, number> = {}
+        for (const p of panes.value) {
+          const groupKey = p.runGroupId || 'manual'
+          paneCountByGroup[groupKey] = (paneCountByGroup[groupKey] ?? 0) + 1
+        }
+        const activeHasPanes = (paneCountByGroup[activeTab.value] ?? 0) > 0
+        if (!activeHasPanes) {
+          const firstFull = stageTabs.value.find((t) => (paneCountByGroup[t.key] ?? 0) > 0)
+          if (firstFull) activeTab.value = firstFull.key
+        }
       }
+      // Let the selected tab/layout paint before starting only the panes that
+      // are actually on screen. Minimized panes and other tabs stay lazy.
+      focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null
+      await nextTick()
+      realizeOnScreenPanes()
+    } finally {
+      hydratingColdRestore = false
     }
   }
 }
@@ -4189,18 +4358,14 @@ watch(
   }
 )
 
-/** Re-spawn CLI panes for all slots recorded in project.json.
- *  Called on workspace load so terminal screens appear immediately without
- *  waiting for the user to click Resume.
- *
- *  Slots with a persisted session_id are relaunched with the CLI's resume
- *  command so the agent's prior conversation memory is restored — but nothing
- *  is injected (no role, no kickoff): the pane sits idle with memory loaded
- *  until the user drives it. Slots without an id fall back to a fresh spawn
- *  (role re-injected), the same as before this feature. */
+/** Restore panes recorded in project.json.
+ *  Full cold loads create placeholders; explicit activation realizes and
+ *  resumes (or fresh-spawns) one record at a time. Detached/group reattachments
+ *  remain eager so their live PTYs reconnect immediately. */
 async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: string, onlyGroupId?: string, isStale?: () => boolean): Promise<void> {
   // Don't restore if pipeline is active or paused — panes are already alive.
   if (pipeline.state === 'running' || pipeline.state === 'aborted') return
+  if (isStale?.() || currentWorkspace.value !== workspacePath) return
 
   // Build unified pane list. Prefer project.panes[] (new format); fall back to
   // migrating stages[].slots[] + manual_panes[] for old project.json files that
@@ -4271,31 +4436,9 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
   if (toRestore.length > 0) pipelineLog(`↩ Restoring ${toRestore.length} pane(s)`)
   pipeline.workspacePath = workspacePath
 
-  // Resume-behavior preference: 'always' resumes (legacy behavior), 'never'
-  // spawns every pane fresh, 'ask' prompts once. Only a full cold restore is
-  // subject to it — a group reattach (onlyGroupId) or detached child window is
-  // handing back panes whose PTYs are already alive, never a resume decision.
-  let forceFresh = false
-  if (onlyGroupId === undefined && !isDetachedWindow) {
-    const decision = await resolveRestoreDecision({
-      behavior: normalizeResumeBehavior(settingsGet(RESUME_BEHAVIOR_SETTING_KEY, 'always')),
-      restorableCount: toRestore.length,
-      workspacePath,
-      decisionCache: restoreDecisionCache,
-      ask: () => notifyRestore.confirm(
-        i18n.global.t('restore.resume-prompt-message', { count: toRestore.length }),
-        {
-          title: i18n.global.t('restore.resume-prompt-title'),
-          confirmText: i18n.global.t('restore.resume-prompt-confirm'),
-          cancelText: i18n.global.t('restore.resume-prompt-cancel'),
-        }
-      ),
-    })
-    // The 'ask' dialog can span a user pause; bail if a newer workspace-check
-    // superseded this restore so we don't spawn panes into a stale workspace.
-    if (isStale?.()) return
-    forceFresh = decision === 'fresh'
-  }
+  // Ghost/reconnect detection applies only to a full cold restore — a group
+  // reattach or detached child window hands back panes whose PTYs are alive.
+  const fullRestore = onlyGroupId === undefined && !isDetachedWindow
 
   // Lazily create one group to house restored pipeline panes whose saved
   // run_group_id no longer maps to an existing tab (e.g. localStorage cleared
@@ -4333,15 +4476,78 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
   // reuse it — a second `--session-id <same>` would collide.
   const usedFreshSessionIds = new Set<string>()
 
-  // Ghost/reconnect detection applies only to a full cold restore — a group
-  // reattach or detached child window hands back panes whose PTYs are alive.
-  const fullRestore = onlyGroupId === undefined && !isDetachedWindow
+  const coldBatch: ColdRestoreBatch | null = fullRestore
+    ? {
+        workspacePath,
+        records: toRestore,
+        savedClaims: allProjectPanes,
+        usedFreshSessionIds,
+      }
+    : null
   if (fullRestore) {
     reconnectedCount.value = 0
     disconnectedPaneIds.value = []
     reconnectBannerDismissed.value = false
+
+    // Cold restore is deliberately split: persisted records become inert UI
+    // rows now, while probes/decision/spawn happen only from explicit activation.
+    for (const saved of toRestore) {
+      const existing = panes.value.find((p) => p.id === saved.pane_id)
+      if (existing?.realized) continue
+      const spec = agentSpecs.find((s) => s.agentKey === saved.agent)
+      const rawSessionId = (saved.session_id ?? '').trim()
+      const sessionId = normalizeResumeSessionId(saved.agent, rawSessionId)
+      const sessionHomeId = saved.agent === 'codex'
+        ? ((saved.session_home_id ?? '').trim() || saved.pane_id)
+        : ''
+      const savedGid = saved.run_group_id || ''
+      const runGroupId = savedGid
+        ? ensureSavedGroup(savedGid)
+        : (saved.origin === 'pipeline' ? ensureRestoreGroup() : '')
+      const placeholder: ActivePane = {
+        id: saved.pane_id,
+        realized: false,
+        agentKey: saved.agent,
+        agentLabel: spec?.label ?? saved.agent,
+        customName: saved.custom_name || undefined,
+        autoName: saved.auto_name || undefined,
+        roleKey: saved.role as RoleKey,
+        stageId: (saved.stage_id ?? '') as StageId,
+        slotLabel: saved.slot_label ?? '',
+        command: saved.command ?? '',
+        workspacePath,
+        origin: saved.origin,
+        outputLogFile: saved.output_log_file || undefined,
+        runGroupId: runGroupId || undefined,
+        injectionStatus: 'pending',
+        preparationStatus: 'starting',
+        injectionTimer: null,
+        kickoffStatus: saved.kickoff_status === 'sent' || saved.kickoff_status === 'failed'
+          ? saved.kickoff_status
+          : 'none',
+        kickoffPrompt: '',
+        skipRoleInjection: true,
+        pinnedSessionId: sessionId || undefined,
+        sessionHomeId: sessionHomeId || undefined,
+        deferredRestore: { saved, workspacePath, batch: coldBatch! },
+      }
+      if (existing) {
+        const index = panes.value.findIndex((p) => p.id === saved.pane_id)
+        if (index >= 0) panes.value.splice(index, 1, placeholder)
+      } else {
+        panes.value.push(placeholder)
+      }
+      if (saved.is_minimized) {
+        minimizedPanes.value = new Set([...minimizedPanes.value, saved.pane_id])
+      }
+    }
+    syncViews()
   }
 
+  // Detached/only-group restores keep the existing eager behaviour. Cold
+  // placeholders return through the history backfill below without probing or
+  // creating any PTY.
+  if (!fullRestore) {
   await Promise.all(toRestore.map(async (saved, restoreIdx) => {
     const rawSessionId = (saved.session_id ?? '').trim()
     const sessionId = normalizeResumeSessionId(saved.agent, rawSessionId)
@@ -4356,25 +4562,14 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
     const savedGid = saved.run_group_id || ''
     const runGroupId = savedGid
       ? ensureSavedGroup(savedGid)
-      : (saved.origin === 'pipeline' ? ensureRestoreGroup() : (runGroups.value[0]?.id ?? ''))
+      : (saved.origin === 'pipeline' ? ensureRestoreGroup() : '')
 
     // Unified session-resume logic for all pane types. Tri-state: true /
     // false (definitively absent) / null (probe failed — unknown).
-    // forceFresh (user chose "start fresh") takes the fresh-spawn path for
-    // every pane — including Codex, which is normally preserved when its
-    // rollout is missing — but the probe still runs: a CONFIRMED transcript
-    // (=== true) is pinned on the fresh pane via sessionKnownOnDisk below so
-    // the Rebuild (resume) button stays enabled after restart. Under
-    // forceFresh the probe is best-effort — cap it at 2.5s so a cold-boot
-    // backend storm can't stall every fresh spawn for the full 10s default
-    // (a timed-out null is discarded on this path anyway).
-    const canResume = await canResumeSession(
-      saved.agent, workspacePath, sessionId,
-      forceFresh ? { timeoutMs: 2500 } : undefined
-    )
+    const canResume = await canResumeSession(saved.agent, workspacePath, sessionId)
     // Codex preserve-untouched applies whenever the rollout is not CONFIRMED
     // present (false and null alike) — unchanged pre-tri-state behavior.
-    if (!forceFresh && shouldPreserveMissingSessionOnRestore(saved.agent, rawSessionId, canResume === true)) {
+    if (shouldPreserveMissingSessionOnRestore(saved.agent, rawSessionId, canResume === true)) {
       // Never turn a saved Codex conversation into a replacement conversation
       // merely because its rollout is temporarily unavailable. In particular,
       // do not reach manual_pane.spawn/session below, which would overwrite the
@@ -4386,99 +4581,32 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
     // saved id (if the transcript exists it resumes perfectly; if not the CLI
     // errors for one boot, but the id mapping survives); only a definitive
     // false falls back to a fresh spawn reusing the saved id below.
-    // forceFresh always routes fresh regardless of the probe.
-    const attemptResume = !forceFresh && shouldAttemptResume(canResume)
+    const attemptResume = shouldAttemptResume(canResume)
     let resumeCmd = attemptResume ? buildResumeCommand(saved.agent, sessionId, skipFlag) : ''
-    // A pane whose transcript is DEFINITIVELY gone would otherwise fall back to
-    // a fresh conversation. Before that, attempt a deterministic reconnect from
-    // spawn-history provenance (Claude only — it alone carries the pinned-id
-    // provenance the resolver uses). A unique still-resumable match is adopted
-    // and resumed; zero/ambiguous is deferred to the manual reconnect banner.
-    // Never touch a pane whose own id resumes (attemptResume) — I1 invariant.
-    const ghostConfirmed = !forceFresh && shouldWarnMissingResume(
-      saved.agent, rawSessionId, attemptResume,
-      looksLikeResumeCommand(saved.agent, saved.command || '')
-    )
-    let reconnectId = ''
-    if (fullRestore && ghostConfirmed && saved.agent === 'claude') {
-      reconnectId = await resolveReconnectForPane(saved, workspacePath, allProjectPanes)
-    }
-    let wasDisconnected = false
-    if (reconnectId) {
-      // Unique provenance match: point the saved record at the resolved id
-      // (backend backs up project.json first) and resume it in place.
-      await sendQuiet('pane.reconnect_session', {
-        workspace_path: workspacePath,
-        pane_id: saved.pane_id,
-        session_id: reconnectId,
-      })
-      resumeCmd = buildResumeCommand(saved.agent, reconnectId, skipFlag)
-      reconnectedCount.value++
-      pipelineLog(`↩ ${saved.agent}: auto-reconnected ${saved.pane_id} → ${reconnectId}`)
-    } else if (ghostConfirmed) {
-      // Zero/ambiguous provenance: keep the fresh fallback (surface instead of
-      // silently swapping a new conversation) and flag the pane for the manual
-      // reconnect banner/picker.
-      wasDisconnected = fullRestore
-      pipelineLog(
-        `⚠ ${saved.agent}: previous conversation ${sessionId} not found at ${workspacePath}; opened a fresh one`
-      )
-      notifyRestore.toast(
-        i18n.global.t('restore.session-not-found', { agent: saved.agent }),
-        { type: 'error', duration: 8000 }
-      )
-    }
-    const effectiveResumeId = reconnectId || sessionId
+    const effectiveResumeId = sessionId
     const savedFallbackCommand = saved.command && !looksLikeResumeCommand(saved.agent, saved.command)
       ? saved.command : ''
-    // Start-fresh must not inherit a hand-written --session-id from the saved
-    // command: that id's transcript still exists, so it would resume (and
-    // re-persist) the old conversation instead of minting a new one.
-    const fallbackCommand = forceFresh ? stripPinnedSessionId(savedFallbackCommand) : savedFallbackCommand
+    const fallbackCommand = savedFallbackCommand
     const commandOverride = resumeCmd || fallbackCommand || ''
     const isResume = !!resumeCmd
 
-    const paneId = await spawnPane({
-      agentKey: saved.agent as AgentKey,
-      roleKey: saved.role,
-      stageId: (saved.stage_id ?? '') as StageId,
-      slotLabel: saved.slot_label,
-      customName: saved.custom_name || undefined,
-      autoName: saved.auto_name || undefined,
-      commandOverride,
+    const restored = await spawnRestoredPane({
+      saved,
       workspacePath,
-      origin: saved.origin,
       runGroupId: runGroupId || undefined,
-      isResume,
-      skipRoleInjection: isResume,
-      stageIndex: saved.stage_index ?? -1,
-      restoreMode: isResume ? 'memory-resume' : 'fresh',
       sessionHomeId,
       profileId: saved.profile_id,
+      commandOverride,
+      fallbackCommand,
+      isResume,
       resumeSessionId: effectiveResumeId,
-      // Probe CONFIRMED the saved transcript on disk but the spawn is fresh
-      // (forceFresh): keep the saved id pinned so Rebuild stays enabled.
-      // Strictly === true — null (probe failed) is unknown, not known-on-disk.
-      // Only for agents whose stale pin self-heals (see RESTORE_PIN_AGENTS).
-      sessionKnownOnDisk:
-        !isResume && canResume === true && RESTORE_PIN_AGENTS.includes(saved.agent),
-      // Not-resumable fallback ("opened a fresh one"): reuse the saved id for
-      // the fresh spawn so cold-start restore is idempotent instead of
-      // rotating a new ghost id every boot. No-op when isResume. Duplicate
-      // saved ids: only the first record claims the id; later ones get '' and
-      // mint a new uuid (claim is synchronous — safe across the Promise.all).
-      // forceFresh is different: the saved transcript still exists, so reusing
-      // its id would collide — mint a brand-new id instead.
-      freshSessionId: forceFresh ? undefined : claimFreshSessionId(usedFreshSessionIds, sessionId),
-      preferredMessagingName: persistedMessagingName(saved.pane_id),
+      sessionKnownOnDisk: !isResume && canResume === true && RESTORE_PIN_AGENTS.includes(saved.agent),
+      freshSessionId: claimFreshSessionId(usedFreshSessionIds, sessionId),
+      freshPipelineFallbackSessionId: sessionId,
     })
-
-    if (!paneId) return
+    if (!restored) return
+    const { paneId } = restored
     restoredPaneIds[restoreIdx] = paneId
-    // The messaging name is now re-keyed under the fresh pane id — drop the
-    // stale entry for the previous id.
-    if (saved.pane_id !== paneId) dropPersistedMessagingName(saved.pane_id)
-    if (wasDisconnected) disconnectedPaneIds.value = [...disconnectedPaneIds.value, paneId]
 
     // Re-apply the persisted collapsed-to-sidebar state to the new pane id.
     if (saved.is_minimized) {
@@ -4490,52 +4618,6 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
     // sets the composable AFTER that reset. No persist here — reading stored
     // truth, not issuing a new stop action (see loop-avoidance invariants).
     if (saved.stopped) paneRefs[paneId]?.setStopped(true)
-
-    // Fresh (non-resume) Claude spawns pin a brand-new --session-id; persist
-    // it with the record so the next restart can resume the new conversation
-    // instead of keeping a stale (or empty) id.
-    const newPinnedId = panes.value.find((p) => p.id === paneId)?.pinnedSessionId ?? ''
-
-    if (saved.origin === 'pipeline') {
-      await sendQuiet('pipeline.slot_spawn', {
-        workspace_path: workspacePath,
-        stage_index: saved.stage_index,
-        slot_label: saved.slot_label,
-        pane_id: paneId,
-        agent: saved.agent,
-        role: saved.role,
-        // forceFresh abandons the saved conversation: persist the pane's
-        // pinned id — the saved id when its transcript was CONFIRMED on disk
-        // (kept for the Rebuild button, see sessionKnownOnDisk), else a
-        // freshly pinned id (empty until a non-Claude CLI's new session is
-        // detected).
-        session_id: isResume ? effectiveResumeId : (newPinnedId || (forceFresh ? '' : sessionId)),
-        session_home_id: sessionHomeId,
-        profile_id: saved.profile_id ?? '',
-        run_group_id: runGroupId,
-      })
-    } else {
-      await sendQuiet<ProjectPayload>('manual_pane.spawn', {
-        workspace_path: workspacePath,
-        pane_id: paneId,
-        previous_pane_id: saved.pane_id,
-        agent: saved.agent,
-        role: saved.role,
-        command: fallbackCommand,
-        session_id: isResume ? effectiveResumeId : newPinnedId,
-        session_home_id: sessionHomeId,
-        profile_id: saved.profile_id ?? '',
-        run_group_id: runGroupId,
-        output_log_file: panes.value.find((p) => p.id === paneId)?.outputLogFile ?? '',
-      })
-      if (sessionId && !isResume && !newPinnedId) {
-        await sendQuiet('manual_pane.session', {
-          workspace_path: workspacePath,
-          pane_id: paneId,
-          session_id: '',
-        })
-      }
-    }
   }))
 
   // The parallel spawns above push into panes.value in completion order, which
@@ -4544,13 +4626,6 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
   // (e.g. already-live ones on a group reattach) keep their positions.
   sortByIdOrder(panes.value, restoredPaneIds.filter((id): id is string => !!id))
 
-  // Notify once for the batch: auto-reconnected ghosts get a success toast;
-  // the disconnected (deferred) panes are surfaced by the status-bar banner.
-  if (fullRestore && reconnectedCount.value > 0) {
-    notifyRestore.toast(
-      i18n.global.t('reconnect.auto-toast', { count: reconnectedCount.value }),
-      { type: 'success' }
-    )
   }
 
   // Backfill removed manual panes into spawnHistory so Agent History shows past sessions.
@@ -4618,6 +4693,187 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
   }
 }
 
+function deferredPaneStillCurrent(
+  paneId: string,
+  workspacePath: string,
+  batch: ColdRestoreBatch,
+): ActivePane | null {
+  if (currentWorkspace.value !== workspacePath) return null
+  const pane = panes.value.find((p) => p.id === paneId)
+  if (!pane || pane.realized || pane.workspacePath !== workspacePath) return null
+  return pane.deferredRestore?.batch === batch ? pane : null
+}
+
+// A placeholder can receive activation from both a click and a pipeline resume
+// path in the same tick. Keep one completion promise per pane so every caller
+// waits for the same restore attempt instead of treating an in-flight restore as
+// an immediate no-op.
+const restoringPanePromises = new Map<string, Promise<void>>()
+
+async function coldRestoreDecision(batch: ColdRestoreBatch): Promise<RestoreDecision> {
+  if (!batch.decisionPromise) {
+    batch.decisionPromise = resolveRestoreDecision({
+      behavior: normalizeResumeBehavior(settingsGet(RESUME_BEHAVIOR_SETTING_KEY, 'always')),
+      restorableCount: batch.records.length,
+      workspacePath: batch.workspacePath,
+      decisionCache: restoreDecisionCache,
+      ask: () => notifyRestore.confirm(
+        i18n.global.t('restore.resume-prompt-message', { count: batch.records.length }),
+        {
+          title: i18n.global.t('restore.resume-prompt-title'),
+          confirmText: i18n.global.t('restore.resume-prompt-confirm'),
+          cancelText: i18n.global.t('restore.resume-prompt-cancel'),
+        }
+      ),
+    })
+  }
+  return batch.decisionPromise
+}
+
+/** Realize one cold-restore record after explicit user activation. */
+async function realizeRestoredPane(paneId: string): Promise<void> {
+  const pending = restoringPanePromises.get(paneId)
+  if (pending) return pending
+  const promise = performRealizeRestoredPane(paneId)
+  restoringPanePromises.set(paneId, promise)
+  void promise.then(
+    () => {
+      if (restoringPanePromises.get(paneId) === promise) restoringPanePromises.delete(paneId)
+    },
+    () => {
+      if (restoringPanePromises.get(paneId) === promise) restoringPanePromises.delete(paneId)
+    },
+  )
+  return promise
+}
+
+async function performRealizeRestoredPane(paneId: string): Promise<void> {
+  const placeholder = panes.value.find((p) => p.id === paneId)
+  const deferred = placeholder?.deferredRestore
+  if (!placeholder || placeholder.realized || placeholder.restoring || !deferred) return
+
+  const saved = deferred.saved
+  const batch = deferred.batch
+  const sessionId = normalizeResumeSessionId(saved.agent, (saved.session_id ?? '').trim())
+  const lockKeys = [...new Set([paneId, sessionId].filter(Boolean))]
+  if (lockKeys.some((key) => rebuildingPanes.has(key))) return
+  for (const key of lockKeys) rebuildingPanes.add(key)
+  placeholder.restoring = true
+  syncViews()
+
+  try {
+    const decision = await coldRestoreDecision(batch)
+    if (!deferredPaneStillCurrent(paneId, batch.workspacePath, batch)) return
+    const forceFresh = decision === 'fresh'
+    const rawSessionId = (saved.session_id ?? '').trim()
+    const spec = agentSpecs.find((s) => s.agentKey === saved.agent)
+    const skipFlag = yoloEnabled.value ? (spec?.skipPermissionFlag ?? '') : ''
+    const canResume = await canResumeSession(
+      saved.agent,
+      batch.workspacePath,
+      sessionId,
+      forceFresh ? { timeoutMs: 2500 } : undefined,
+    )
+    if (!deferredPaneStillCurrent(paneId, batch.workspacePath, batch)) return
+
+    // Codex records are preserved when the rollout is not confirmed present;
+    // leaving the placeholder intact lets a later activation retry the probe.
+    if (!forceFresh && shouldPreserveMissingSessionOnRestore(saved.agent, rawSessionId, canResume === true)) {
+      pipelineLog(`⚠ ${saved.agent} session ${sessionId} is unavailable; preserving saved pane`)
+      return
+    }
+
+    const attemptResume = !forceFresh && shouldAttemptResume(canResume)
+    let resumeCmd = attemptResume ? buildResumeCommand(saved.agent, sessionId, skipFlag) : ''
+    const ghostConfirmed = !forceFresh && shouldWarnMissingResume(
+      saved.agent,
+      rawSessionId,
+      attemptResume,
+      looksLikeResumeCommand(saved.agent, saved.command || '')
+    )
+    let reconnectId = ''
+    if (ghostConfirmed && saved.agent === 'claude') {
+      reconnectId = await resolveReconnectForPane(saved, batch.workspacePath, batch.savedClaims)
+      if (!deferredPaneStillCurrent(paneId, batch.workspacePath, batch)) return
+    }
+
+    let wasDisconnected = false
+    if (reconnectId) {
+      const repointed = await sendQuiet('pane.reconnect_session', {
+        workspace_path: batch.workspacePath,
+        pane_id: saved.pane_id,
+        session_id: reconnectId,
+      })
+      if (!deferredPaneStillCurrent(paneId, batch.workspacePath, batch)) return
+      if (repointed === null) return
+      resumeCmd = buildResumeCommand(saved.agent, reconnectId, skipFlag)
+      reconnectedCount.value++
+      pipelineLog(`↩ ${saved.agent}: auto-reconnected ${saved.pane_id} → ${reconnectId}`)
+      notifyRestore.toast(
+        i18n.global.t('reconnect.auto-toast', { count: reconnectedCount.value }),
+        { type: 'success' }
+      )
+    } else if (ghostConfirmed) {
+      wasDisconnected = true
+      pipelineLog(
+        `⚠ ${saved.agent}: previous conversation ${sessionId} not found at ${batch.workspacePath}; opened a fresh one`
+      )
+      notifyRestore.toast(
+        i18n.global.t('restore.session-not-found', { agent: saved.agent }),
+        { type: 'error', duration: 8000 }
+      )
+    }
+
+    const effectiveResumeId = reconnectId || sessionId
+    const savedFallbackCommand = saved.command && !looksLikeResumeCommand(saved.agent, saved.command)
+      ? saved.command
+      : ''
+    const fallbackCommand = forceFresh ? stripPinnedSessionId(savedFallbackCommand) : savedFallbackCommand
+    const commandOverride = resumeCmd || fallbackCommand || ''
+    const isResume = !!resumeCmd
+    const wasMinimized = minimizedPanes.value.has(paneId)
+    const restored = await spawnRestoredPane({
+      saved,
+      workspacePath: batch.workspacePath,
+      runGroupId: placeholder.runGroupId || undefined,
+      sessionHomeId: placeholder.sessionHomeId,
+      profileId: saved.profile_id,
+      commandOverride,
+      fallbackCommand,
+      isResume,
+      resumeSessionId: effectiveResumeId,
+      sessionKnownOnDisk: !isResume && canResume === true && RESTORE_PIN_AGENTS.includes(saved.agent),
+      freshSessionId: forceFresh ? undefined : claimFreshSessionId(batch.usedFreshSessionIds, sessionId),
+      freshPipelineFallbackSessionId: forceFresh ? '' : sessionId,
+      replacePaneId: paneId,
+      restoring: true,
+      shouldPersist: (newPaneId) =>
+        currentWorkspace.value === batch.workspacePath && panes.value.some((p) => p.id === newPaneId),
+    })
+    if (!restored) return
+    const { paneId: newId } = restored
+
+    // Replacement panes get a fresh runtime id; carry the user's layout state
+    // across the atomic swap and persist it against the new id.
+    const minimized = new Set(minimizedPanes.value)
+    minimized.delete(paneId)
+    if (wasMinimized) minimized.add(newId)
+    minimizedPanes.value = minimized
+    if (wasMinimized) persistPaneMinimized(newId, true)
+
+    disconnectedPaneIds.value = disconnectedPaneIds.value.filter((id) => id !== paneId)
+    if (wasDisconnected) disconnectedPaneIds.value = [...disconnectedPaneIds.value, newId]
+
+  } finally {
+    const current = panes.value.find((p) => p.id === paneId)
+    if (current && !current.realized && current.deferredRestore === deferred) {
+      current.restoring = false
+    }
+    for (const key of lockKeys) rebuildingPanes.delete(key)
+    syncViews()
+  }
+}
+
 async function onRefreshAnalyzer(): Promise<void> {
   pipelineLog('🧠 refreshing analyzer health + model list')
   const h = await analyzerApi.refreshHealth()
@@ -4663,7 +4919,21 @@ async function onPipelineResume(): Promise<void> {
   applyProjectPaths(resp ?? undefined)
   // Refresh the peek so the banner disappears now that we're running.
   existingProject.value = null
-  // Panes were already restored by restoreWorkspacePanes on workspace load.
+  // Cold restore keeps pipeline panes as placeholders; an explicit pipeline
+  // resume realizes those records before activateStage injects any kickoff.
+  const pendingPipeline = panes.value
+    .filter((p) => !p.realized && p.origin === 'pipeline')
+    .map((p) => p.id)
+  await Promise.all(pendingPipeline.map((id) => realizeRestoredPane(id)))
+  if (pipeline.state !== 'running') return
+  const unresolvedPipeline = panes.value.filter((p) => !p.realized && p.origin === 'pipeline')
+  if (unresolvedPipeline.length > 0) {
+    pipelineLog(
+      `Pipeline resume paused: ${unresolvedPipeline.length} restored pane(s) still await activation or session availability`
+    )
+    await onPipelineAbort('restore-unavailable')
+    return
+  }
   // activateStage builds context from prior stages and injects kickoffs.
   await activateStage(info.nextStageIndex)
 }
@@ -4974,7 +5244,7 @@ function buildStageContext(index: number, forManager: boolean): string {
     const prevStage = stagesApi.stages.value[i]
     if (!prevStage) continue
     const prevPanes = panes.value.filter(
-      (p) => p.stageId === prevStage.id && p.origin === 'pipeline'
+      (p) => p.realized && p.stageId === prevStage.id && p.origin === 'pipeline'
     )
     for (const prevPane of prevPanes) {
       const label = prevPane.slotLabel
@@ -5041,7 +5311,11 @@ async function activateStage(index: number): Promise<void> {
       (p) => p.stageId === stage.id && p.slotLabel === slot.label && p.origin === 'pipeline'
     )
 
-    if (!pane) {
+    if (!pane || !pane.realized) {
+      if (pane && !pane.realized) {
+        pipelineLog(`Stage ${stage.id}/${slot.label} ⏸ waiting for restored pane activation`)
+        return
+      }
       // Fallback: slot was never pre-spawned — spawn it now with kickoff
       pipelineLog(`Stage ${stage.id}/${slot.label} → not pre-spawned, spawning now`)
       const kickoff =
@@ -5359,7 +5633,7 @@ async function waitForStagePanesSettled(
   const stage = stagesApi.stages.value[stageIndex]
   if (!stage) return
   const stagePanes = panes.value.filter(
-    (p) => p.stageId === stage.id && p.origin === 'pipeline'
+    (p) => p.realized && p.stageId === stage.id && p.origin === 'pipeline'
   )
   if (stagePanes.length === 0) return
 
@@ -5396,7 +5670,7 @@ function globalManagerPaneId(): string | null {
   const gm = pipeline.globalManager
   if (!gm) return null
   const pane = panes.value.find(
-    (p) => p.stageId === gm.stageId && p.slotLabel === gm.slotLabel && p.origin === 'pipeline'
+    (p) => p.realized && p.stageId === gm.stageId && p.slotLabel === gm.slotLabel && p.origin === 'pipeline'
   )
   return pane?.id ?? null
 }
@@ -5440,10 +5714,14 @@ async function onPipelineNext(): Promise<void> {
   await activateStage(nextIndex)
 }
 
-async function onPipelineAbort(): Promise<void> {
+async function onPipelineAbort(reason: 'user' | 'restore-unavailable' = 'user'): Promise<void> {
   if (pipeline.state !== 'running') return
   pipeline.state = 'aborted'
-  pipelineLog('Pipeline aborted by user')
+  pipelineLog(
+    reason === 'user'
+      ? 'Pipeline aborted by user'
+      : 'Pipeline paused: restored pane session is unavailable'
+  )
   stopGlobalManagerRouter()
   cancelAllWatchers()
   stageCompletions.clear()
@@ -5457,7 +5735,7 @@ async function onPipelineAbort(): Promise<void> {
   // resumed later via the Resume banner. (Reset is the destructive one.)
   const resp = await sendQuiet<ProjectPayload>('pipeline.abort', {
     workspace_path: pipeline.workspacePath,
-    reason: 'user'
+    reason
   })
   applyProjectPaths(resp ?? undefined)
   // Refresh existingProject so the Resume banner appears immediately in the
@@ -6033,7 +6311,7 @@ function computeStageSlotSignals(stageIndex: number): SlotSignal[] {
   const tracker = stageCompletions.get(stageIndex)
   if (!stage || !tracker) return []
   const stagePanes = panes.value.filter(
-    (p) => p.stageId === stage.id && p.origin === 'pipeline'
+    (p) => p.realized && p.stageId === stage.id && p.origin === 'pipeline'
   )
   // Fewer live panes than slots → some slot never spawned; never "all finished".
   if (stagePanes.length < tracker.expected) return []
@@ -6633,7 +6911,7 @@ async function globalManagerRouterScan(): Promise<void> {
 
   // Scan all active Worker panes (any stage, not the Manager itself) for ASK/REPORT
   const workerPanes = panes.value.filter(
-    (p) => p.origin === 'pipeline' && p.id !== managerPaneId &&
+    (p) => p.realized && p.origin === 'pipeline' && p.id !== managerPaneId &&
            !(p.stageId === gm.stageId && p.slotLabel === gm.slotLabel)
   )
   for (const wp of workerPanes) {
@@ -6664,7 +6942,7 @@ async function globalManagerRouterScan(): Promise<void> {
   if (mNew > mCursor) globalRouterCursors.set(managerPaneId, mNew)
   for (const d of dispatches) {
     const target = panes.value.find(
-      (p) => p.origin === 'pipeline' && p.id !== managerPaneId &&
+      (p) => p.realized && p.origin === 'pipeline' && p.id !== managerPaneId &&
              p.slotLabel.toLowerCase() === d.to.toLowerCase()
     )
     if (!target) {
@@ -6733,6 +7011,7 @@ function onStageSlotCompleted(
       // Find sibling panes that are still running (not in done set)
       const siblingPanes = panes.value.filter(
         (p) =>
+          p.realized &&
           p.stageId === stage.id &&
           p.origin === 'pipeline' &&
           p.id !== paneId &&
@@ -7702,6 +7981,15 @@ const tabVisiblePanes = computed(() =>
   panes.value.filter((p) => tabFilteredPaneIds.value.has(p.id) && !minimizedPanes.value.has(p.id))
 )
 
+async function onUserSelectTab(tabId: string): Promise<void> {
+  activeTab.value = tabId
+  await nextTick()
+  const visible = tabVisiblePanes.value
+  const target = visible.find((p) => p.id === focusPaneId.value)?.id ?? visible[0]?.id
+  if (target) selectPane(target, { userInitiated: false })
+  realizeOnScreenPanes()
+}
+
 // Persist activeTab to project.json keyed by workspace path
 watch(activeTab, (v) => {
   // Detached child windows never own the shared activeTab state; a
@@ -7722,7 +8010,8 @@ watch(activeTab, (v) => {
 function minimizePane(id: string): void {
   minimizedPanes.value = new Set([...minimizedPanes.value, id])
   if (focusPaneId.value === id) {
-    focusPaneId.value = panes.value.find((p) => p.id !== id && !minimizedPanes.value.has(p.id))?.id ?? null
+    const fallback = panes.value.find((p) => p.id !== id && !minimizedPanes.value.has(p.id))?.id ?? null
+    selectPane(fallback, { userInitiated: false })
   }
   persistPaneMinimized(id, true)
   syncViews()
@@ -7732,7 +8021,8 @@ function restorePane(id: string): void {
   const next = new Set(minimizedPanes.value)
   next.delete(id)
   minimizedPanes.value = next
-  if (layoutMode.value !== 'grid') focusPaneId.value = id
+  if (layoutMode.value !== 'grid') selectPane(id, { userInitiated: true })
+  else void realizeRestoredPane(id)
   persistPaneMinimized(id, false)
   syncViews()
 }
@@ -7805,7 +8095,7 @@ function persistPaneStopped(id: string, stopped: boolean): void {
 watch(panes, (newPanes, oldPanes) => {
   const ids = new Set(newPanes.map((p) => p.id))
   if (focusPaneId.value && !ids.has(focusPaneId.value)) {
-    focusPaneId.value = newPanes[0]?.id ?? null
+    selectPane(newPanes[0]?.id ?? null, { userInitiated: false })
   }
   // Drop selected ids for panes that were removed or had their id replaced by a
   // rebuild, so batch actions never reference stale panes.
@@ -7814,7 +8104,7 @@ watch(panes, (newPanes, oldPanes) => {
     if (pruned.size !== selectedPaneIds.value.size) selectedPaneIds.value = pruned
   }
   if (layoutMode.value !== 'grid' && newPanes.length > (oldPanes?.length ?? 0)) {
-    focusPaneId.value = newPanes[newPanes.length - 1].id
+    selectPane(newPanes[newPanes.length - 1].id, { userInitiated: false })
   }
   // If the current tab's run group was removed, fall back to first available group
   if (activeTab.value && stageTabs.value.length > 0) {
@@ -7827,7 +8117,7 @@ watch(panes, (newPanes, oldPanes) => {
 watch(activeTab, () => {
   const visible = tabVisiblePanes.value
   if (focusPaneId.value && !visible.some((p) => p.id === focusPaneId.value)) {
-    focusPaneId.value = visible[0]?.id ?? null
+    selectPane(visible[0]?.id ?? null, { userInitiated: false })
   }
   void nextTick(() => refitAllTerminals())
 })
@@ -7846,14 +8136,13 @@ function onSetFocus(paneId: string, ev?: MouseEvent): void {
     else next.add(paneId)
     selectedPaneIds.value = next
     revealPaneTab(paneId)
-    focusPaneId.value = paneId
+    selectPane(paneId, { userInitiated: true })
     return
   }
   selectedPaneIds.value = new Set()
   revealPaneTab(paneId)
-  focusPaneId.value = paneId
+  selectPane(paneId, { userInitiated: true })
 }
-
 // Pane right-click context menu, shared by the agent list, spotlight thumbnails,
 // and pane headers. The menu is rendered once in this component; each surface only
 // raises an open request with the pane id and pointer coords.
@@ -8434,6 +8723,34 @@ const dualFocusActive = computed(
 const dualFocusSecondaryId = computed<string | null>(
   () => (dualFocusActive.value ? runningPaneIds.value[1] : null)
 )
+
+// Single source of truth for panes currently rendered in the stage. Fullscreen
+// deliberately keeps its existing v-show behavior; floatPaneStyle handles its
+// visual hiding separately.
+const onScreenPaneIds = computed<Set<string>>(() => {
+  const visibleIds = new Set(tabVisiblePanes.value.map((p) => p.id))
+  if (effectiveLayoutMode.value === 'grid') {
+    return new Set([...gridPagePaneIds.value].filter((id) => visibleIds.has(id)))
+  }
+  if (effectiveLayoutMode.value === 'sidebar' || effectiveLayoutMode.value === 'spotlight') {
+    const ids = new Set<string>()
+    if (effectiveFocusPaneId.value && visibleIds.has(effectiveFocusPaneId.value)) ids.add(effectiveFocusPaneId.value)
+    if (dualFocusSecondaryId.value && visibleIds.has(dualFocusSecondaryId.value)) ids.add(dualFocusSecondaryId.value)
+    return ids
+  }
+  return visibleIds
+})
+
+// User-driven layout or grid navigation is the lazy-restore activation
+// boundary. Focus changes can be automatic, so they must not start a CLI.
+function realizeOnScreenPanes(): void {
+  for (const paneId of onScreenPaneIds.value) void realizeRestoredPane(paneId)
+}
+
+watch([effectiveLayoutMode, gridPreset, gridPage], () => {
+  if (!hydratingColdRestore) realizeOnScreenPanes()
+})
+
 const dualFocusHandlePos = computed(() => {
   if (dualFocusSplitPx.value > 0) return `${dualFocusSplitPx.value}px`
   const meetingW = effectiveLayoutMode.value === 'sidebar' ? 220 : 0
@@ -8676,7 +8993,7 @@ function paneIsCommander(p: ActivePane): boolean {
       @pipeline-resume="onPipelineResume"
       @pipeline-restart="onPipelineRestart"
       @refresh-analyzer="onRefreshAnalyzer"
-      @focus-pane="onFocusPane"
+      @focus-pane="selectPane($event, { userInitiated: true, scrollIntoView: true })"
       @reorder-pane="reorderPane"
       @open-settings="showSettings = true"
       @open-git-accounts="openSettingsAccounts"
@@ -8812,7 +9129,7 @@ function paneIsCommander(p: ActivePane): boolean {
       <StageTabBar
         v-if="stageTabs.length > 0"
         :tabs="stageTabs"
-        v-model="activeTab"
+        :model-value="activeTab"
         :can-rebuild-all="rebuildablePaneCount > 0"
         :rebuilding-all="rebuildingTabPanes"
         :rebuild-all-title="$t('action.rebuild-tab-cli-panes')"
@@ -8824,6 +9141,7 @@ function paneIsCommander(p: ActivePane): boolean {
         @move-pane="(paneId, targetKey) => movePaneToGroup(paneId, targetKey)"
         @reorder-tab="(fromKey, toKey) => reorderRunGroupTab(fromKey, toKey)"
         @detach="(key, x, y) => onDetachGroup(key, x, y)"
+        @update:model-value="onUserSelectTab"
       />
       <div v-if="panes.length === 0" class="empty">
         <!-- Pipeline is starting but the first pane hasn't appeared yet.
@@ -8919,10 +9237,10 @@ function paneIsCommander(p: ActivePane): boolean {
           :style="{ left: dualFocusHandlePos }"
           @mousedown.prevent="onGridHandleStart($event, 'dual-focus', 0)"
         />
+        <template v-for="p in panes" :key="p.id">
         <TerminalPane
-          v-for="p in panes"
-          :key="p.id"
-          v-show="tabFilteredPaneIds.has(p.id) && !minimizedPanes.has(p.id) && !(effectiveLayoutMode === 'grid' && !gridPagePaneIds.has(p.id)) && !(effectiveLayoutMode === 'sidebar' && p.id !== effectiveFocusPaneId && p.id !== dualFocusSecondaryId) && !(effectiveLayoutMode === 'spotlight' && p.id !== effectiveFocusPaneId && p.id !== dualFocusSecondaryId)"
+          v-if="p.realized"
+          v-show="onScreenPaneIds.has(p.id)"
           :style="{ ...floatPaneStyle(p.id), ...dualFocusStyle(p.id) }"
           :ref="(el) => setPaneRef(p.id, el)"
           :data-pane-id="p.id"
@@ -8949,7 +9267,9 @@ function paneIsCommander(p: ActivePane): boolean {
           :loop-active="p.loopActive"
           :loop-wait-until="p.loopWaitUntil"
           :loop-estimate-reset-at="p.loopEstimateResetAt"
+          :restoring="p.restoring"
           @set-focus="(ev) => onSetFocus(p.id, ev)"
+          @first-output="onPaneFirstOutput(p.id)"
           @minimize="minimizePane(p.id)"
           @rebuild="rebuildPaneViaResume(p.id)"
           @rebuild-clean="rebuildPaneClean(p.id)"
@@ -8962,6 +9282,22 @@ function paneIsCommander(p: ActivePane): boolean {
           @loop-resume-now="resumeLoopNow(p.id)"
           @user-resume="persistPaneStopped(p.id, false)"
         />
+        <RestoredPanePlaceholder
+          v-else
+          v-show="onScreenPaneIds.has(p.id)"
+          :style="{ ...floatPaneStyle(p.id), ...dualFocusStyle(p.id) }"
+          :data-pane-id="p.id"
+          :pane-id="p.id"
+          :title="p.customName || p.agentLabel"
+          :subtitle="paneSubtitle(p)"
+          :pipe-tag="p.origin === 'pipeline' && p.stageId ? `P${p.stageId}` : undefined"
+          :is-focus="p.id === effectiveFocusPaneId"
+          :realizing="p.restoring"
+          @activate="selectPane(p.id, { userInitiated: true })"
+          @minimize="minimizePane(p.id)"
+          @context-menu="(ev) => openPaneCtxMenu(ev, p.id)"
+        />
+        </template>
         <!-- Auto/sidebar mode: meeting-style agent list on the right -->
         <div v-if="effectiveLayoutMode === 'sidebar'" class="auto-meeting-list" :style="dualFocusActive ? { gridColumn: '3' } : {}">
           <div

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -371,9 +371,6 @@ const currentWorkspace = ref<string>(
     }
   })()
 )
-// Placeholder creation changes the visible-pane computed state. Suppress its
-// watcher until hydration has selected and painted the initial screen.
-let hydratingColdRestore = false
 const workspaceSelected = ref<boolean>(
   _bootWorkspace !== '' ||
   (() => {
@@ -3999,6 +3996,8 @@ interface RestoredPaneSpawnOptions {
   sessionKnownOnDisk: boolean
   freshSessionId?: string
   freshPipelineFallbackSessionId: string
+  /** Keep a saved session pointer when a fresh CLI follows an unknown probe. */
+  preserveSessionPointer?: boolean
   replacePaneId?: string
   restoring?: boolean
   /** Check replacement ownership before its new record is persisted. */
@@ -4054,7 +4053,7 @@ async function spawnRestoredPane(opts: RestoredPaneSpawnOptions): Promise<Restor
       pane_id: paneId,
       agent: saved.agent,
       role: saved.role,
-      session_id: opts.isResume
+      session_id: opts.isResume || opts.preserveSessionPointer
         ? opts.resumeSessionId
         : (pinnedSessionId || opts.freshPipelineFallbackSessionId),
       session_home_id: opts.sessionHomeId ?? '',
@@ -4069,13 +4068,13 @@ async function spawnRestoredPane(opts: RestoredPaneSpawnOptions): Promise<Restor
       agent: saved.agent,
       role: saved.role,
       command: opts.fallbackCommand,
-      session_id: opts.isResume ? opts.resumeSessionId : pinnedSessionId,
+      session_id: opts.isResume || opts.preserveSessionPointer ? opts.resumeSessionId : pinnedSessionId,
       session_home_id: opts.sessionHomeId ?? '',
       profile_id: opts.profileId ?? '',
       run_group_id: opts.runGroupId,
       output_log_file: panes.value.find((p) => p.id === paneId)?.outputLogFile ?? '',
     })
-    if (opts.resumeSessionId && !opts.isResume && !pinnedSessionId) {
+    if (opts.resumeSessionId && !opts.isResume && !pinnedSessionId && !opts.preserveSessionPointer) {
       await sendQuiet('manual_pane.session', {
         workspace_path: opts.workspacePath,
         pane_id: paneId,
@@ -4307,43 +4306,34 @@ async function onWorkspaceCheck(path: string): Promise<void> {
         })
       }
     }
-    hydratingColdRestore = true
-    try {
-      activeTab.value = (savedTab && stageTabs.value.some((t) => t.key === savedTab))
-        ? savedTab
-        : (stageTabs.value[0]?.key ?? '')
-      if (suppressPaneRestoreOnce) {
-        // First load of a duplicated window: open the same workspace as a clean
-        // view without re-resuming the source window's live agent sessions.
-        suppressPaneRestoreOnce = false
-      } else {
-        // isStale lets restore bail if a newer workspace-check superseded this one
-        // before or during restore (the await can span a user pause).
-        await restoreWorkspacePanes(resp, path, undefined, () => seq !== workspaceCheckSeq)
-      }
-      // If the active tab has no panes (e.g. old project.json panes landed in a
-      // different group via fallback), switch to the first tab that has panes so
-      // the user is not greeted with an empty grid.
-      if (activeTab.value && stageTabs.value.length > 0) {
-        const paneCountByGroup: Record<string, number> = {}
-        for (const p of panes.value) {
-          const groupKey = p.runGroupId || 'manual'
-          paneCountByGroup[groupKey] = (paneCountByGroup[groupKey] ?? 0) + 1
-        }
-        const activeHasPanes = (paneCountByGroup[activeTab.value] ?? 0) > 0
-        if (!activeHasPanes) {
-          const firstFull = stageTabs.value.find((t) => (paneCountByGroup[t.key] ?? 0) > 0)
-          if (firstFull) activeTab.value = firstFull.key
-        }
-      }
-      // Let the selected tab/layout paint before starting only the panes that
-      // are actually on screen. Minimized panes and other tabs stay lazy.
-      focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null
-      await nextTick()
-      realizeOnScreenPanes()
-    } finally {
-      hydratingColdRestore = false
+    activeTab.value = (savedTab && stageTabs.value.some((t) => t.key === savedTab))
+      ? savedTab
+      : (stageTabs.value[0]?.key ?? '')
+    if (suppressPaneRestoreOnce) {
+      // First load of a duplicated window: open the same workspace as a clean
+      // view without re-resuming the source window's live agent sessions.
+      suppressPaneRestoreOnce = false
+    } else {
+      // isStale lets restore bail if a newer workspace-check superseded this one
+      // before or during restore (the await can span a user pause).
+      await restoreWorkspacePanes(resp, path, undefined, () => seq !== workspaceCheckSeq)
     }
+    // If the active tab has no panes (e.g. old project.json panes landed in a
+    // different group via fallback), switch to the first tab that has panes so
+    // the user is not greeted with an empty grid.
+    if (activeTab.value && stageTabs.value.length > 0) {
+      const paneCountByGroup: Record<string, number> = {}
+      for (const p of panes.value) {
+        const groupKey = p.runGroupId || 'manual'
+        paneCountByGroup[groupKey] = (paneCountByGroup[groupKey] ?? 0) + 1
+      }
+      const activeHasPanes = (paneCountByGroup[activeTab.value] ?? 0) > 0
+      if (!activeHasPanes) {
+        const firstFull = stageTabs.value.find((t) => (paneCountByGroup[t.key] ?? 0) > 0)
+        if (firstFull) activeTab.value = firstFull.key
+      }
+    }
+    focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null
   }
 }
 
@@ -4845,6 +4835,7 @@ async function performRealizeRestoredPane(paneId: string): Promise<void> {
       sessionKnownOnDisk: !isResume && canResume === true && RESTORE_PIN_AGENTS.includes(saved.agent),
       freshSessionId: forceFresh ? undefined : claimFreshSessionId(batch.usedFreshSessionIds, sessionId),
       freshPipelineFallbackSessionId: forceFresh ? '' : sessionId,
+      preserveSessionPointer: forceFresh && canResume !== false,
       replacePaneId: paneId,
       restoring: true,
       shouldPersist: (newPaneId) =>
@@ -7987,7 +7978,6 @@ async function onUserSelectTab(tabId: string): Promise<void> {
   const visible = tabVisiblePanes.value
   const target = visible.find((p) => p.id === focusPaneId.value)?.id ?? visible[0]?.id
   if (target) selectPane(target, { userInitiated: false })
-  realizeOnScreenPanes()
 }
 
 // Persist activeTab to project.json keyed by workspace path
@@ -8741,16 +8731,6 @@ const onScreenPaneIds = computed<Set<string>>(() => {
   return visibleIds
 })
 
-// User-driven layout or grid navigation is the lazy-restore activation
-// boundary. Focus changes can be automatic, so they must not start a CLI.
-function realizeOnScreenPanes(): void {
-  for (const paneId of onScreenPaneIds.value) void realizeRestoredPane(paneId)
-}
-
-watch([effectiveLayoutMode, gridPreset, gridPage], () => {
-  if (!hydratingColdRestore) realizeOnScreenPanes()
-})
-
 const dualFocusHandlePos = computed(() => {
   if (dualFocusSplitPx.value > 0) return `${dualFocusSplitPx.value}px`
   const meetingW = effectiveLayoutMode.value === 'sidebar' ? 220 : 0
@@ -8993,7 +8973,7 @@ function paneIsCommander(p: ActivePane): boolean {
       @pipeline-resume="onPipelineResume"
       @pipeline-restart="onPipelineRestart"
       @refresh-analyzer="onRefreshAnalyzer"
-      @focus-pane="selectPane($event, { userInitiated: true, scrollIntoView: true })"
+      @focus-pane="onFocusPane"
       @reorder-pane="reorderPane"
       @open-settings="showSettings = true"
       @open-git-accounts="openSettingsAccounts"

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -4333,7 +4333,12 @@ async function onWorkspaceCheck(path: string): Promise<void> {
         if (firstFull) activeTab.value = firstFull.key
       }
     }
-    focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null
+    // Cold load seeds a focus so a placeholder is on screen in sidebar/spotlight.
+    // onWorkspaceCheck also runs on a pipeline abort and on WS reconnect, so only
+    // seed when the current focus is gone — never steal a focus the user set.
+    if (!focusPaneId.value || !tabVisiblePanes.value.some((p) => p.id === focusPaneId.value)) {
+      focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null
+    }
   }
 }
 
@@ -4538,84 +4543,83 @@ async function restoreWorkspacePanes(payload: ProjectPayload, workspacePath: str
   // placeholders return through the history backfill below without probing or
   // creating any PTY.
   if (!fullRestore) {
-  await Promise.all(toRestore.map(async (saved, restoreIdx) => {
-    const rawSessionId = (saved.session_id ?? '').trim()
-    const sessionId = normalizeResumeSessionId(saved.agent, rawSessionId)
-    const sessionHomeId = saved.agent === 'codex'
-      ? ((saved.session_home_id ?? '').trim() || saved.pane_id)
-      : ''
-    const spec = agentSpecs.find((s) => s.agentKey === saved.agent)
-    const skipFlag = yoloEnabled.value ? (spec?.skipPermissionFlag ?? '') : ''
-    // A pane with a saved group keeps it, recreating the tab if it is missing
-    // (ensureSavedGroup). Only panes that never had a group fall back: pipeline
-    // panes collapse into one restore group, manual panes go to the first tab.
-    const savedGid = saved.run_group_id || ''
-    const runGroupId = savedGid
-      ? ensureSavedGroup(savedGid)
-      : (saved.origin === 'pipeline' ? ensureRestoreGroup() : '')
+    await Promise.all(toRestore.map(async (saved, restoreIdx) => {
+      const rawSessionId = (saved.session_id ?? '').trim()
+      const sessionId = normalizeResumeSessionId(saved.agent, rawSessionId)
+      const sessionHomeId = saved.agent === 'codex'
+        ? ((saved.session_home_id ?? '').trim() || saved.pane_id)
+        : ''
+      const spec = agentSpecs.find((s) => s.agentKey === saved.agent)
+      const skipFlag = yoloEnabled.value ? (spec?.skipPermissionFlag ?? '') : ''
+      // A pane with a saved group keeps it, recreating the tab if it is missing
+      // (ensureSavedGroup). Only panes that never had a group fall back: pipeline
+      // panes collapse into one restore group, manual panes go to the first tab.
+      const savedGid = saved.run_group_id || ''
+      const runGroupId = savedGid
+        ? ensureSavedGroup(savedGid)
+        : (saved.origin === 'pipeline' ? ensureRestoreGroup() : '')
 
-    // Unified session-resume logic for all pane types. Tri-state: true /
-    // false (definitively absent) / null (probe failed — unknown).
-    const canResume = await canResumeSession(saved.agent, workspacePath, sessionId)
-    // Codex preserve-untouched applies whenever the rollout is not CONFIRMED
-    // present (false and null alike) — unchanged pre-tri-state behavior.
-    if (shouldPreserveMissingSessionOnRestore(saved.agent, rawSessionId, canResume === true)) {
-      // Never turn a saved Codex conversation into a replacement conversation
-      // merely because its rollout is temporarily unavailable. In particular,
-      // do not reach manual_pane.spawn/session below, which would overwrite the
-      // persisted id with an empty fresh-session value.
-      pipelineLog(`⚠ ${saved.agent} session ${sessionId} is unavailable; preserving saved pane`)
-      return
-    }
-    // Routing: true → resume; null (unknown) → STILL attempt --resume with the
-    // saved id (if the transcript exists it resumes perfectly; if not the CLI
-    // errors for one boot, but the id mapping survives); only a definitive
-    // false falls back to a fresh spawn reusing the saved id below.
-    const attemptResume = shouldAttemptResume(canResume)
-    let resumeCmd = attemptResume ? buildResumeCommand(saved.agent, sessionId, skipFlag) : ''
-    const effectiveResumeId = sessionId
-    const savedFallbackCommand = saved.command && !looksLikeResumeCommand(saved.agent, saved.command)
-      ? saved.command : ''
-    const fallbackCommand = savedFallbackCommand
-    const commandOverride = resumeCmd || fallbackCommand || ''
-    const isResume = !!resumeCmd
+      // Unified session-resume logic for all pane types. Tri-state: true /
+      // false (definitively absent) / null (probe failed — unknown).
+      const canResume = await canResumeSession(saved.agent, workspacePath, sessionId)
+      // Codex preserve-untouched applies whenever the rollout is not CONFIRMED
+      // present (false and null alike) — unchanged pre-tri-state behavior.
+      if (shouldPreserveMissingSessionOnRestore(saved.agent, rawSessionId, canResume === true)) {
+        // Never turn a saved Codex conversation into a replacement conversation
+        // merely because its rollout is temporarily unavailable. In particular,
+        // do not reach manual_pane.spawn/session below, which would overwrite the
+        // persisted id with an empty fresh-session value.
+        pipelineLog(`⚠ ${saved.agent} session ${sessionId} is unavailable; preserving saved pane`)
+        return
+      }
+      // Routing: true → resume; null (unknown) → STILL attempt --resume with the
+      // saved id (if the transcript exists it resumes perfectly; if not the CLI
+      // errors for one boot, but the id mapping survives); only a definitive
+      // false falls back to a fresh spawn reusing the saved id below.
+      const attemptResume = shouldAttemptResume(canResume)
+      let resumeCmd = attemptResume ? buildResumeCommand(saved.agent, sessionId, skipFlag) : ''
+      const effectiveResumeId = sessionId
+      const savedFallbackCommand = saved.command && !looksLikeResumeCommand(saved.agent, saved.command)
+        ? saved.command : ''
+      const fallbackCommand = savedFallbackCommand
+      const commandOverride = resumeCmd || fallbackCommand || ''
+      const isResume = !!resumeCmd
 
-    const restored = await spawnRestoredPane({
-      saved,
-      workspacePath,
-      runGroupId: runGroupId || undefined,
-      sessionHomeId,
-      profileId: saved.profile_id,
-      commandOverride,
-      fallbackCommand,
-      isResume,
-      resumeSessionId: effectiveResumeId,
-      sessionKnownOnDisk: !isResume && canResume === true && RESTORE_PIN_AGENTS.includes(saved.agent),
-      freshSessionId: claimFreshSessionId(usedFreshSessionIds, sessionId),
-      freshPipelineFallbackSessionId: sessionId,
-    })
-    if (!restored) return
-    const { paneId } = restored
-    restoredPaneIds[restoreIdx] = paneId
+      const restored = await spawnRestoredPane({
+        saved,
+        workspacePath,
+        runGroupId: runGroupId || undefined,
+        sessionHomeId,
+        profileId: saved.profile_id,
+        commandOverride,
+        fallbackCommand,
+        isResume,
+        resumeSessionId: effectiveResumeId,
+        sessionKnownOnDisk: !isResume && canResume === true && RESTORE_PIN_AGENTS.includes(saved.agent),
+        freshSessionId: claimFreshSessionId(usedFreshSessionIds, sessionId),
+        freshPipelineFallbackSessionId: sessionId,
+      })
+      if (!restored) return
+      const { paneId } = restored
+      restoredPaneIds[restoreIdx] = paneId
 
-    // Re-apply the persisted collapsed-to-sidebar state to the new pane id.
-    if (saved.is_minimized) {
-      minimizedPanes.value = new Set([...minimizedPanes.value, paneId])
-    }
+      // Re-apply the persisted collapsed-to-sidebar state to the new pane id.
+      if (saved.is_minimized) {
+        minimizedPanes.value = new Set([...minimizedPanes.value, paneId])
+      }
 
-    // Reflect the persisted STOP badge onto the freshly-spawned pane. spawnPane
-    // above already awaited ref.spawn() (which resets isStopped=false), so this
-    // sets the composable AFTER that reset. No persist here — reading stored
-    // truth, not issuing a new stop action (see loop-avoidance invariants).
-    if (saved.stopped) paneRefs[paneId]?.setStopped(true)
-  }))
+      // Reflect the persisted STOP badge onto the freshly-spawned pane. spawnPane
+      // above already awaited ref.spawn() (which resets isStopped=false), so this
+      // sets the composable AFTER that reset. No persist here — reading stored
+      // truth, not issuing a new stop action (see loop-avoidance invariants).
+      if (saved.stopped) paneRefs[paneId]?.setStopped(true)
+    }))
 
-  // The parallel spawns above push into panes.value in completion order, which
-  // is nondeterministic — re-sort the restored panes back to the saved
-  // project.panes order (toRestore mirrors it). Panes outside this restore
-  // (e.g. already-live ones on a group reattach) keep their positions.
-  sortByIdOrder(panes.value, restoredPaneIds.filter((id): id is string => !!id))
-
+    // The parallel spawns above push into panes.value in completion order, which
+    // is nondeterministic — re-sort the restored panes back to the saved
+    // project.panes order (toRestore mirrors it). Panes outside this restore
+    // (e.g. already-live ones on a group reattach) keep their positions.
+    sortByIdOrder(panes.value, restoredPaneIds.filter((id): id is string => !!id))
   }
 
   // Backfill removed manual panes into spawnHistory so Agent History shows past sessions.
@@ -4799,8 +4803,11 @@ async function performRealizeRestoredPane(paneId: string): Promise<void> {
       resumeCmd = buildResumeCommand(saved.agent, reconnectId, skipFlag)
       reconnectedCount.value++
       pipelineLog(`↩ ${saved.agent}: auto-reconnected ${saved.pane_id} → ${reconnectId}`)
+      // Lazy restore realizes one record at a time, so this toast reports THIS
+      // activation — not the running total, which would read "1", "2", "3…"
+      // across a batch. reconnectedCount still feeds the status-bar banner.
       notifyRestore.toast(
-        i18n.global.t('reconnect.auto-toast', { count: reconnectedCount.value }),
+        i18n.global.t('reconnect.auto-toast', { count: 1 }),
         { type: 'success' }
       )
     } else if (ghostConfirmed) {
@@ -5290,6 +5297,26 @@ async function activateStage(index: number): Promise<void> {
     (managerSlot ? ` · 🎯 Manager: ${managerSlot.label}` : '')
   )
 
+  // A cold-restore placeholder has no PTY, so its slot can never report done —
+  // stageCompletions below expects EVERY slot, and skipping one would stall the
+  // stage forever. Decide this before any kickoff goes out: aborting from inside
+  // the parallel loop below would race the siblings that are already injecting.
+  // Aborting (rather than waiting) matches onPipelineResume, which already
+  // refuses to resume a pipeline whose restored panes are not activated.
+  const unrealizedSlot = stage.slots.find((slot) => {
+    const pane = panes.value.find(
+      (p) => p.stageId === stage.id && p.slotLabel === slot.label && p.origin === 'pipeline'
+    )
+    return pane && !pane.realized
+  })
+  if (unrealizedSlot) {
+    pipelineLog(
+      `Stage ${stage.id}/${unrealizedSlot.label} ⏸ restored pane not activated — pausing pipeline`
+    )
+    await onPipelineAbort('restore-unavailable')
+    return
+  }
+
   // Reset completion tracker in case it was partially consumed
   stageCompletions.set(index, { expected: stage.slots.length, done: new Set() })
 
@@ -5302,11 +5329,9 @@ async function activateStage(index: number): Promise<void> {
       (p) => p.stageId === stage.id && p.slotLabel === slot.label && p.origin === 'pipeline'
     )
 
-    if (!pane || !pane.realized) {
-      if (pane && !pane.realized) {
-        pipelineLog(`Stage ${stage.id}/${slot.label} ⏸ waiting for restored pane activation`)
-        return
-      }
+    // Unrealized panes were ruled out above, so this is the genuine
+    // never-pre-spawned case.
+    if (!pane) {
       // Fallback: slot was never pre-spawned — spawn it now with kickoff
       pipelineLog(`Stage ${stage.id}/${slot.label} → not pre-spawned, spawning now`)
       const kickoff =
@@ -8126,7 +8151,9 @@ function onSetFocus(paneId: string, ev?: MouseEvent): void {
     else next.add(paneId)
     selectedPaneIds.value = next
     revealPaneTab(paneId)
-    selectPane(paneId, { userInitiated: true })
+    // Adding a pane to a batch selection is not "open this pane" — a modifier
+    // click must never spawn the CLI behind a cold-restore placeholder.
+    selectPane(paneId, { userInitiated: false })
     return
   }
   selectedPaneIds.value = new Set()
@@ -8806,6 +8833,11 @@ function paneSubtitle(p: ActivePane): string {
 }
 
 function panePreparationLabel(p: ActivePane): string {
+  // A cold-restore placeholder carries preparationStatus 'starting' as a seed for
+  // the pane it will become — nothing is starting yet, so report the real state.
+  if (!p.realized) {
+    return i18n.global.t(p.restoring ? 'pane.terminal.resuming' : 'pane.terminal.click-to-resume')
+  }
   if (paneWaitingForSessionId(p)) {
     return i18n.global.t('pane.prep.detecting-session')
   }

--- a/src/renderer/src/components/ControlPane.vue
+++ b/src/renderer/src/components/ControlPane.vue
@@ -2361,6 +2361,12 @@ button.icon-btn.muted:hover {
 .status-dot[data-state='idle'] {
   background: var(--attention-fg);
 }
+/* Cold-restore placeholder: nothing spawned yet — a hollow ring, so it never
+   reads as a live-but-quiet pane. */
+.status-dot[data-state='waiting'] {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--text-secondary);
+}
 .status-dot[data-state='error'] {
   background: var(--danger-fg);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger-fg) 25%, transparent);

--- a/src/renderer/src/components/RestoredPanePlaceholder.vue
+++ b/src/renderer/src/components/RestoredPanePlaceholder.vue
@@ -14,6 +14,10 @@ const emit = defineEmits<{
   'context-menu': [event: MouseEvent]
 }>()
 
+// The container stays a plain div: clicking anywhere in it resumes (mouse
+// convenience), while the keyboard entry point is the real <button> in the
+// body. Declaring the container role="button" instead would nest the minimize
+// button inside it, and a keydown on minimize would bubble up and resume too.
 function activate(): void {
   if (!props.realizing) emit('activate')
 }
@@ -39,10 +43,15 @@ function activate(): void {
       </div>
       <span v-if="subtitle" class="header-sub">{{ subtitle }}</span>
     </header>
-    <div class="resume-prompt">
+    <button
+      class="resume-prompt"
+      type="button"
+      :disabled="realizing"
+      @click.stop="activate"
+    >
       <span class="resume-icon">↩</span>
       <span>{{ $t(realizing ? 'pane.terminal.resuming' : 'pane.terminal.click-to-resume') }}</span>
-    </div>
+    </button>
   </div>
 </template>
 
@@ -62,6 +71,11 @@ function activate(): void {
 .pane.pane-focus {
   border-color: var(--accent-focus);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-focus) 27%, transparent);
+}
+
+.resume-prompt:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
 }
 
 .pane-header {
@@ -133,8 +147,13 @@ function activate(): void {
   align-items: center;
   justify-content: center;
   gap: 8px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
   color: var(--text-secondary);
   cursor: pointer;
+  font-family: inherit;
   font-size: 13px;
 }
 

--- a/src/renderer/src/components/RestoredPanePlaceholder.vue
+++ b/src/renderer/src/components/RestoredPanePlaceholder.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+const props = defineProps<{
+  paneId: string
+  title: string
+  subtitle?: string
+  pipeTag?: string
+  isFocus?: boolean
+  realizing?: boolean
+}>()
+
+const emit = defineEmits<{
+  activate: []
+  minimize: []
+  'context-menu': [event: MouseEvent]
+}>()
+
+function activate(): void {
+  if (!props.realizing) emit('activate')
+}
+</script>
+
+<template>
+  <div
+    :class="['pane', 'restored-pane-placeholder', { 'pane-focus': isFocus, realizing }]"
+    :data-pane-id="paneId"
+    :aria-busy="realizing"
+    @click="activate"
+    @contextmenu.prevent.stop="emit('context-menu', $event)"
+  >
+    <button
+      class="minimize-btn"
+      :title="$t('pane.terminal.minimize-tooltip')"
+      @click.stop="emit('minimize')"
+    >⊟</button>
+    <header class="pane-header">
+      <div class="header-main">
+        <span v-if="pipeTag" class="pipe-tag">{{ pipeTag }}</span>
+        <span class="title">{{ title }}</span>
+      </div>
+      <span v-if="subtitle" class="header-sub">{{ subtitle }}</span>
+    </header>
+    <div class="resume-prompt">
+      <span class="resume-icon">↩</span>
+      <span>{{ $t(realizing ? 'pane.terminal.resuming' : 'pane.terminal.click-to-resume') }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  background: var(--bg-base);
+  border: 1px solid var(--border-muted);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.pane.pane-focus {
+  border-color: var(--accent-focus);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-focus) 27%, transparent);
+}
+
+.pane-header {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1px;
+  padding: 5px 32px 5px 12px;
+  background: var(--bg-subtle);
+  border-bottom: 1px solid var(--border-muted);
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.header-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.header-sub {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pipe-tag {
+  flex-shrink: 0;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--accent-muted);
+  color: var(--accent-bright);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.title {
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.minimize-btn {
+  position: absolute;
+  top: 5px;
+  right: 6px;
+  z-index: 1;
+  padding: 0 3px;
+  border: 0;
+  border-radius: 3px;
+  background: none;
+  color: var(--text-disabled);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.minimize-btn:hover {
+  background: var(--bg-muted);
+  color: var(--text-primary);
+}
+
+.resume-prompt {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.resume-icon {
+  font-size: 18px;
+}
+
+.realizing .resume-prompt {
+  cursor: wait;
+}
+</style>

--- a/src/renderer/src/components/TerminalPane.vue
+++ b/src/renderer/src/components/TerminalPane.vue
@@ -10,6 +10,7 @@ import { PLAN_REF_MIME, isPlanDrag, parsePlanRefPayload, type PlanDragRef } from
 import { formatLoopTime } from '../lib/loopPrompt'
 import RebuildIcon from './RebuildIcon.vue'
 import UsageBadge from './UsageBadge.vue'
+import RestoredPanePlaceholder from './RestoredPanePlaceholder.vue'
 
 interface Props {
   paneId: string
@@ -39,6 +40,8 @@ interface Props {
   rebuilding?: boolean
   isPreparing?: boolean
   preparingLabel?: string
+  /** A cold-restored terminal is mounted but has not rendered its first PTY output yet. */
+  restoring?: boolean
   /** Runtime-only LOOP badge state — lit after the loop prompt was injected. */
   loopActive?: boolean
   /** Epoch ms of the scheduled session-limit auto-resume; set while the loop
@@ -78,6 +81,7 @@ const emit = defineEmits<{
   /** The user typed into a STOPped pane (Enter/printable), taking over — App.vue
    *  clears + un-persists the STOP badge. */
   (e: 'user-resume'): void
+  (e: 'first-output'): void
 }>()
 const containerRef = ref<HTMLElement | null>(null)
 const isDragOver = ref(false)
@@ -117,6 +121,7 @@ const terminal = useTerminal(props.paneId, props.backend, {
   onClear: () => emit('rebuild-clean'),
   onUserResume: () => emit('user-resume'),
   mentionCandidates: () => props.mentionCandidates ?? [],
+  onFirstOutput: () => emit('first-output'),
 })
 const { theme } = useTheme()
 watch(theme, () => terminal.updateXtermTheme())
@@ -398,6 +403,18 @@ onMounted(() => {
       class="respawn-btn"
       @click.stop="emit('rebuild-clean')"
     >↻ {{ $t('pane.terminal.respawn') }}</button>
+    <RestoredPanePlaceholder
+      v-if="restoring && displayStatus !== 'exited' && displayStatus !== 'error'"
+      class="restoring-overlay"
+      :pane-id="paneId"
+      :title="title"
+      :subtitle="subtitle"
+      :pipe-tag="pipeTag"
+      :is-focus="isFocus"
+      realizing
+      @minimize="emit('minimize')"
+      @context-menu="emit('context-menu', $event)"
+    />
   </div>
 </template>
 
@@ -647,6 +664,11 @@ onMounted(() => {
   background: color-mix(in srgb, var(--bg-base) 78%, transparent);
   backdrop-filter: blur(1px);
   pointer-events: auto;
+}
+.restoring-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
 }
 .prep-panel {
   display: inline-flex;

--- a/src/renderer/src/components/__tests__/App.gridLayoutBar.test.ts
+++ b/src/renderer/src/components/__tests__/App.gridLayoutBar.test.ts
@@ -33,9 +33,11 @@ describe('App grid layout preset bar', () => {
   })
 
   it('hides paged-out panes via v-show without unmounting terminals', () => {
-    expect(appSource).toContain(
-      "!(effectiveLayoutMode === 'grid' && !gridPagePaneIds.has(p.id))"
-    )
+    expect(appSource).toContain('v-show="onScreenPaneIds.has(p.id)"')
+    const onScreenAt = appSource.indexOf('const onScreenPaneIds = computed')
+    const onScreenEnd = appSource.indexOf('\nconst dualFocusHandlePos', onScreenAt)
+    const onScreen = appSource.slice(onScreenAt, onScreenEnd)
+    expect(onScreen).toContain('gridPagePaneIds.value')
   })
 
   it('persists the preset under agentTeam.gridPreset', () => {

--- a/src/renderer/src/components/__tests__/App.lazyRestore.test.ts
+++ b/src/renderer/src/components/__tests__/App.lazyRestore.test.ts
@@ -32,11 +32,11 @@ describe('App lazy cold restore', () => {
     expect(select).toContain('options.userInitiated')
     expect(select).toContain('void realizeRestoredPane(paneId)')
     expect(appSource).toContain('@activate="selectPane(p.id, { userInitiated: true })"')
-    expect(appSource).toContain('@focus-pane="selectPane($event, { userInitiated: true')
+    expect(appSource).toContain('@focus-pane="onFocusPane"')
     expect(appSource).toContain('selectPane(visible[0]?.id ?? null, { userInitiated: false })')
   })
 
-  it('a user-selected tab focuses its prior pane and realizes its on-screen panes', () => {
+  it('a user-selected tab focuses its prior pane without realizing it', () => {
     const tabAt = appSource.indexOf('async function onUserSelectTab')
     const tabEnd = appSource.indexOf('// Persist activeTab', tabAt)
     const tabSelect = appSource.slice(tabAt, tabEnd)
@@ -44,11 +44,11 @@ describe('App lazy cold restore', () => {
     expect(tabSelect).toContain('const visible = tabVisiblePanes.value')
     expect(tabSelect).toContain('visible.find((p) => p.id === focusPaneId.value)?.id ?? visible[0]?.id')
     expect(tabSelect).toContain('selectPane(target, { userInitiated: false })')
-    expect(tabSelect).toContain('realizeOnScreenPanes()')
+    expect(tabSelect).not.toContain('realizeRestoredPane(')
     expect(appSource).toContain('@update:model-value="onUserSelectTab"')
   })
 
-  it('uses one on-screen pane set for rendering and user-driven lazy activation', () => {
+  it('uses one on-screen pane set for rendering without automatic activation', () => {
     const helperAt = appSource.indexOf('const onScreenPaneIds = computed')
     const helperEnd = appSource.indexOf('\nconst dualFocusHandlePos', helperAt)
     const helper = appSource.slice(helperAt, helperEnd)
@@ -57,10 +57,9 @@ describe('App lazy cold restore', () => {
     expect(helper).toContain('gridPagePaneIds.value')
     expect(helper).toContain("effectiveLayoutMode.value === 'sidebar'")
     expect(helper).toContain("effectiveLayoutMode.value === 'spotlight'")
-    expect(helper).toContain('function realizeOnScreenPanes()')
-    expect(helper).toContain('void realizeRestoredPane(paneId)')
-    expect(helper).toContain('watch([effectiveLayoutMode, gridPreset, gridPage]')
-    expect(helper).toContain('if (!hydratingColdRestore) realizeOnScreenPanes()')
+    expect(helper).not.toContain('realizeRestoredPane(')
+    expect(appSource).not.toContain('function realizeOnScreenPanes()')
+    expect(appSource).not.toContain('watch([effectiveLayoutMode, gridPreset, gridPage]')
     expect(appSource).not.toContain('watch(onScreenPaneIds')
     expect(appSource).toContain('v-show="onScreenPaneIds.has(p.id)"')
   })
@@ -131,15 +130,15 @@ describe('App lazy cold restore', () => {
     expect(restorePane).toContain('else void realizeRestoredPane(id)')
   })
 
-  it('restores only the initial on-screen panes after the active tab paints', () => {
-    const workspaceAt = appSource.indexOf('hydratingColdRestore = true')
+  it('keeps cold hydration free of session probes and terminal realization', () => {
+    const workspaceAt = appSource.indexOf('async function onWorkspaceCheck')
     const workspaceEnd = appSource.indexOf('\n  }\n}\n\n// Fire the deferred workspace', workspaceAt)
     const workspace = appSource.slice(workspaceAt, workspaceEnd)
 
     expect(workspace).toContain('focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null')
-    expect(workspace).toContain('await nextTick()')
-    expect(workspace).toContain('realizeOnScreenPanes()')
-    expect(workspace).toContain('hydratingColdRestore = false')
+    expect(workspace).not.toContain('canResumeSession(')
+    expect(workspace).not.toContain('realizeRestoredPane(')
+    expect(appSource).not.toContain('hydratingColdRestore')
     expect(appSource).not.toContain('focus_pane_id: id ?? \'\'')
   })
 
@@ -151,6 +150,20 @@ describe('App lazy cold restore', () => {
     expect(realize).toContain('const wasMinimized = minimizedPanes.value.has(paneId)')
     expect(realize).toContain('if (wasMinimized) minimized.add(newId)')
     expect(realize).not.toContain('wasMinimized || saved.is_minimized')
+  })
+
+  it('preserves an unknown saved pointer when Start fresh launches a new CLI', () => {
+    const helperAt = appSource.indexOf('async function spawnRestoredPane')
+    const helperEnd = appSource.indexOf('\ninterface SessionExistsPayload', helperAt)
+    const helper = appSource.slice(helperAt, helperEnd)
+    const realizeAt = appSource.indexOf('async function performRealizeRestoredPane')
+    const realizeEnd = appSource.indexOf('\nasync function onRefreshAnalyzer', realizeAt)
+    const realize = appSource.slice(realizeAt, realizeEnd)
+
+    expect(helper).toContain('preserveSessionPointer?: boolean')
+    expect(helper).toContain('opts.isResume || opts.preserveSessionPointer')
+    expect(helper).toContain('!opts.preserveSessionPointer')
+    expect(realize).toContain('preserveSessionPointer: forceFresh && canResume !== false')
   })
 
   it('locks pane and session identities before the first async decision', () => {

--- a/src/renderer/src/components/__tests__/App.lazyRestore.test.ts
+++ b/src/renderer/src/components/__tests__/App.lazyRestore.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Mounting App starts backend, terminal, settings, and onboarding lifecycles;
+// keep these checks narrow source-text assertions like the other App tests.
+const appSource = readFileSync(
+  resolve(process.cwd(), 'src/renderer/src/App.vue'),
+  'utf8'
+)
+
+describe('App lazy cold restore', () => {
+  it('materializes cold restores without probing or mounting a terminal', () => {
+    const coldStart = appSource.indexOf('if (fullRestore) {')
+    const eagerStart = appSource.indexOf('if (!fullRestore) {', coldStart)
+    const coldSection = appSource.slice(coldStart, eagerStart)
+
+    expect(coldSection).toContain('realized: false')
+    expect(coldSection).toContain('deferredRestore:')
+    expect(coldSection).toContain('autoName: saved.auto_name || undefined')
+    expect(coldSection).not.toContain('await canResumeSession(')
+    expect(appSource).toContain('<TerminalPane\n          v-if="p.realized"')
+    expect(appSource).toContain('<RestoredPanePlaceholder\n          v-else')
+  })
+
+  it('realizes only selections explicitly marked as user initiated', () => {
+    const selectAt = appSource.indexOf('function selectPane(')
+    const selectEnd = appSource.indexOf('\nconst previewLogContent', selectAt)
+    const select = appSource.slice(selectAt, selectEnd)
+
+    expect(select).toContain('options.userInitiated')
+    expect(select).toContain('void realizeRestoredPane(paneId)')
+    expect(appSource).toContain('@activate="selectPane(p.id, { userInitiated: true })"')
+    expect(appSource).toContain('@focus-pane="selectPane($event, { userInitiated: true')
+    expect(appSource).toContain('selectPane(visible[0]?.id ?? null, { userInitiated: false })')
+  })
+
+  it('a user-selected tab focuses its prior pane and realizes its on-screen panes', () => {
+    const tabAt = appSource.indexOf('async function onUserSelectTab')
+    const tabEnd = appSource.indexOf('// Persist activeTab', tabAt)
+    const tabSelect = appSource.slice(tabAt, tabEnd)
+
+    expect(tabSelect).toContain('const visible = tabVisiblePanes.value')
+    expect(tabSelect).toContain('visible.find((p) => p.id === focusPaneId.value)?.id ?? visible[0]?.id')
+    expect(tabSelect).toContain('selectPane(target, { userInitiated: false })')
+    expect(tabSelect).toContain('realizeOnScreenPanes()')
+    expect(appSource).toContain('@update:model-value="onUserSelectTab"')
+  })
+
+  it('uses one on-screen pane set for rendering and user-driven lazy activation', () => {
+    const helperAt = appSource.indexOf('const onScreenPaneIds = computed')
+    const helperEnd = appSource.indexOf('\nconst dualFocusHandlePos', helperAt)
+    const helper = appSource.slice(helperAt, helperEnd)
+
+    expect(helper).toContain("effectiveLayoutMode.value === 'grid'")
+    expect(helper).toContain('gridPagePaneIds.value')
+    expect(helper).toContain("effectiveLayoutMode.value === 'sidebar'")
+    expect(helper).toContain("effectiveLayoutMode.value === 'spotlight'")
+    expect(helper).toContain('function realizeOnScreenPanes()')
+    expect(helper).toContain('void realizeRestoredPane(paneId)')
+    expect(helper).toContain('watch([effectiveLayoutMode, gridPreset, gridPage]')
+    expect(helper).toContain('if (!hydratingColdRestore) realizeOnScreenPanes()')
+    expect(appSource).not.toContain('watch(onScreenPaneIds')
+    expect(appSource).toContain('v-show="onScreenPaneIds.has(p.id)"')
+  })
+
+  it('keeps the realized replacement restoring until its first output', () => {
+    const realizeAt = appSource.indexOf('async function realizeRestoredPane')
+    const realizeEnd = appSource.indexOf('\nasync function onRefreshAnalyzer', realizeAt)
+    const realize = appSource.slice(realizeAt, realizeEnd)
+
+    expect(realize).toContain('placeholder.restoring = true')
+    expect(realize).toContain('restoring: true')
+    expect(appSource).toContain(':restoring="p.restoring"')
+    expect(appSource).toContain('@first-output="onPaneFirstOutput(p.id)"')
+  })
+
+  it('shares an in-flight realization and reports unavailable restored pipeline sessions accurately', () => {
+    const realizeAt = appSource.indexOf('async function realizeRestoredPane')
+    const performAt = appSource.indexOf('async function performRealizeRestoredPane', realizeAt)
+    const realize = appSource.slice(realizeAt, performAt)
+    const resumeAt = appSource.indexOf('async function onPipelineResume')
+    const resumeEnd = appSource.indexOf('// Orders every project.set_ui_state', resumeAt)
+    const resume = appSource.slice(resumeAt, resumeEnd)
+
+    expect(realize).toContain('restoringPanePromises.get(paneId)')
+    expect(realize).toContain('if (pending) return pending')
+    expect(resume).toContain('await Promise.all(pendingPipeline.map((id) => realizeRestoredPane(id)))')
+    expect(resume).toContain('const unresolvedPipeline = panes.value.filter')
+    expect(resume).toContain("await onPipelineAbort('restore-unavailable')")
+    expect(resume.indexOf("await onPipelineAbort('restore-unavailable')")).toBeLessThan(
+      resume.indexOf('await activateStage(info.nextStageIndex)')
+    )
+  })
+
+  it('keeps lazy realization aligned with eager restore session and naming metadata', () => {
+    const helperAt = appSource.indexOf('async function spawnRestoredPane')
+    const helperEnd = appSource.indexOf('\ninterface SessionExistsPayload', helperAt)
+    const helper = appSource.slice(helperAt, helperEnd)
+    const eagerAt = appSource.indexOf('if (!fullRestore) {')
+    const eagerEnd = appSource.indexOf('// Backfill removed manual panes', eagerAt)
+    const eager = appSource.slice(eagerAt, eagerEnd)
+    const realizeAt = appSource.indexOf('async function performRealizeRestoredPane')
+    const realizeEnd = appSource.indexOf('\nasync function onRefreshAnalyzer', realizeAt)
+    const realize = appSource.slice(realizeAt, realizeEnd)
+
+    expect(helper).toContain('await spawnPane({')
+    expect(helper).toContain('autoName: saved.auto_name || undefined')
+    expect(helper).toContain('preferredMessagingName: persistedMessagingName(saved.pane_id)')
+    expect(helper).toContain('sessionKnownOnDisk: opts.sessionKnownOnDisk')
+    expect(helper).toContain('dropPersistedMessagingName(saved.pane_id)')
+    expect(helper).toContain("'pipeline.slot_spawn'")
+    expect(helper).toContain("'manual_pane.spawn'")
+    expect(eager).toContain('await spawnRestoredPane({')
+    expect(realize).toContain('await spawnRestoredPane({')
+    expect(realize).toContain('forceFresh ? { timeoutMs: 2500 } : undefined')
+    expect(realize).toContain('const attemptResume = !forceFresh && shouldAttemptResume(canResume)')
+  })
+
+  it('keeps ungrouped manual panes in the Manual tab and realizes restored grid panes without changing focus', () => {
+    const restoreAt = appSource.indexOf('async function restoreWorkspacePanes')
+    const realizeAt = appSource.indexOf('async function realizeRestoredPane', restoreAt)
+    const restore = appSource.slice(restoreAt, realizeAt)
+    const restorePaneAt = appSource.indexOf('function restorePane(')
+    const restorePaneEnd = appSource.indexOf('/** Drag-reorder', restorePaneAt)
+    const restorePane = appSource.slice(restorePaneAt, restorePaneEnd)
+
+    expect(restore).toContain("saved.origin === 'pipeline' ? ensureRestoreGroup() : ''")
+    expect(restorePane).toContain("if (layoutMode.value !== 'grid') selectPane(id, { userInitiated: true })")
+    expect(restorePane).toContain('else void realizeRestoredPane(id)')
+  })
+
+  it('restores only the initial on-screen panes after the active tab paints', () => {
+    const workspaceAt = appSource.indexOf('hydratingColdRestore = true')
+    const workspaceEnd = appSource.indexOf('\n  }\n}\n\n// Fire the deferred workspace', workspaceAt)
+    const workspace = appSource.slice(workspaceAt, workspaceEnd)
+
+    expect(workspace).toContain('focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null')
+    expect(workspace).toContain('await nextTick()')
+    expect(workspace).toContain('realizeOnScreenPanes()')
+    expect(workspace).toContain('hydratingColdRestore = false')
+    expect(appSource).not.toContain('focus_pane_id: id ?? \'\'')
+  })
+
+  it('transfers the current minimized state instead of stale saved metadata', () => {
+    const realizeAt = appSource.indexOf('async function performRealizeRestoredPane')
+    const realizeEnd = appSource.indexOf('\nasync function onRefreshAnalyzer', realizeAt)
+    const realize = appSource.slice(realizeAt, realizeEnd)
+
+    expect(realize).toContain('const wasMinimized = minimizedPanes.value.has(paneId)')
+    expect(realize).toContain('if (wasMinimized) minimized.add(newId)')
+    expect(realize).not.toContain('wasMinimized || saved.is_minimized')
+  })
+
+  it('locks pane and session identities before the first async decision', () => {
+    const realizeAt = appSource.indexOf('async function realizeRestoredPane')
+    const realizeEnd = appSource.indexOf('\nasync function onRefreshAnalyzer', realizeAt)
+    const realize = appSource.slice(realizeAt, realizeEnd)
+    const lockAt = realize.indexOf('for (const key of lockKeys) rebuildingPanes.add(key)')
+    const firstAwait = realize.indexOf('await coldRestoreDecision(batch)')
+
+    expect(lockAt).toBeGreaterThan(-1)
+    expect(firstAwait).toBeGreaterThan(lockAt)
+    expect(realize).toContain('finally {')
+    expect(realize).toContain('for (const key of lockKeys) rebuildingPanes.delete(key)')
+  })
+
+  it('rejects stale workspace restores before materializing placeholders', () => {
+    const restoreAt = appSource.indexOf('async function restoreWorkspacePanes')
+    const unifiedListAt = appSource.indexOf('// Build unified pane list.', restoreAt)
+    const restoreGuard = appSource.slice(restoreAt, unifiedListAt)
+
+    expect(restoreGuard).toContain('isStale?.()')
+    expect(restoreGuard).toContain('currentWorkspace.value !== workspacePath')
+  })
+
+  it('uses persisted stage identity when closing a pipeline placeholder', () => {
+    const killAt = appSource.indexOf('async function onKill(')
+    const killEnd = appSource.indexOf('/** Recover a render-corrupted pane', killAt)
+    const kill = appSource.slice(killAt, killEnd)
+
+    expect(kill).toContain('pane.deferredRestore?.saved.stage_index')
+    expect(kill).toContain("typeof savedStageIndex === 'number' && savedStageIndex >= 0")
+    expect(kill).toContain("'pipeline.slot_unspawn'")
+    expect(kill).toContain('stage_index: stageIndex')
+  })
+})

--- a/src/renderer/src/components/__tests__/App.lazyRestore.test.ts
+++ b/src/renderer/src/components/__tests__/App.lazyRestore.test.ts
@@ -135,6 +135,11 @@ describe('App lazy cold restore', () => {
     const workspaceEnd = appSource.indexOf('\n  }\n}\n\n// Fire the deferred workspace', workspaceAt)
     const workspace = appSource.slice(workspaceAt, workspaceEnd)
 
+    // onWorkspaceCheck also runs on a pipeline abort and a WS reconnect, so the
+    // cold-load focus seed must never overwrite a focus the user already set.
+    expect(workspace).toContain(
+      'if (!focusPaneId.value || !tabVisiblePanes.value.some((p) => p.id === focusPaneId.value)) {'
+    )
     expect(workspace).toContain('focusPaneId.value = tabVisiblePanes.value[0]?.id ?? null')
     expect(workspace).not.toContain('canResumeSession(')
     expect(workspace).not.toContain('realizeRestoredPane(')
@@ -153,7 +158,9 @@ describe('App lazy cold restore', () => {
   })
 
   it('preserves an unknown saved pointer when Start fresh launches a new CLI', () => {
-    const helperAt = appSource.indexOf('async function spawnRestoredPane')
+    // Slice from the options interface, not the function: preserveSessionPointer
+    // is declared above spawnRestoredPane.
+    const helperAt = appSource.indexOf('interface RestoredPaneSpawnOptions {')
     const helperEnd = appSource.indexOf('\ninterface SessionExistsPayload', helperAt)
     const helper = appSource.slice(helperAt, helperEnd)
     const realizeAt = appSource.indexOf('async function performRealizeRestoredPane')
@@ -186,6 +193,57 @@ describe('App lazy cold restore', () => {
 
     expect(restoreGuard).toContain('isStale?.()')
     expect(restoreGuard).toContain('currentWorkspace.value !== workspacePath')
+  })
+
+  it('never realizes a placeholder added to a batch selection', () => {
+    const focusAt = appSource.indexOf('function onSetFocus(')
+    const focusEnd = appSource.indexOf('// Pane right-click context menu', focusAt)
+    const setFocus = appSource.slice(focusAt, focusEnd)
+    const batchBranch = setFocus.slice(0, setFocus.indexOf('selectedPaneIds.value = new Set()'))
+
+    expect(batchBranch).toContain('selectPane(paneId, { userInitiated: false })')
+    expect(batchBranch).not.toContain('selectPane(paneId, { userInitiated: true })')
+    // The plain (non-modifier) click below it still opens the pane.
+    expect(setFocus).toContain('selectPane(paneId, { userInitiated: true })')
+  })
+
+  it('stops the pipeline before any kickoff when a slot is still a placeholder', () => {
+    const stageAt = appSource.indexOf('async function activateStage(')
+    const stageEnd = appSource.indexOf('\nasync function waitForStagePanesSettled', stageAt)
+    const stage = appSource.slice(stageAt, stageEnd)
+
+    const abortAt = stage.indexOf("await onPipelineAbort('restore-unavailable')")
+    const trackerAt = stage.indexOf('stageCompletions.set(index,')
+    const parallelAt = stage.indexOf('await Promise.all(stage.slots.map(')
+
+    expect(stage).toContain('const unrealizedSlot = stage.slots.find(')
+    expect(abortAt).toBeGreaterThan(-1)
+    // Aborting from inside the parallel slot loop would race the siblings that
+    // are already injecting their kickoff — the check must precede both the
+    // completion tracker and the loop.
+    expect(abortAt).toBeLessThan(trackerAt)
+    expect(abortAt).toBeLessThan(parallelAt)
+    // The loop itself no longer needs an unrealized branch.
+    expect(stage.slice(parallelAt)).not.toContain('!pane.realized')
+  })
+
+  it('reports one reconnect per realization rather than a running total', () => {
+    const realizeAt = appSource.indexOf('async function performRealizeRestoredPane')
+    const realizeEnd = appSource.indexOf('\nasync function onRefreshAnalyzer', realizeAt)
+    const realize = appSource.slice(realizeAt, realizeEnd)
+
+    expect(realize).toContain("i18n.global.t('reconnect.auto-toast', { count: 1 })")
+    expect(realize).not.toContain('auto-toast\', { count: reconnectedCount.value }')
+  })
+
+  it('labels an unrealized pane by its resume state, not a preparation status', () => {
+    const labelAt = appSource.indexOf('function panePreparationLabel(')
+    const labelEnd = appSource.indexOf('function paneWaitingForSessionId(', labelAt)
+    const label = appSource.slice(labelAt, labelEnd)
+
+    expect(label).toContain('if (!p.realized) {')
+    expect(label).toContain("p.restoring ? 'pane.terminal.resuming' : 'pane.terminal.click-to-resume'")
+    expect(label.indexOf('if (!p.realized) {')).toBeLessThan(label.indexOf('paneWaitingForSessionId(p)'))
   })
 
   it('uses persisted stage identity when closing a pipeline placeholder', () => {

--- a/src/renderer/src/components/__tests__/RestoredPanePlaceholder.test.ts
+++ b/src/renderer/src/components/__tests__/RestoredPanePlaceholder.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import RestoredPanePlaceholder from '../RestoredPanePlaceholder.vue'
+
+function mountPlaceholder(realizing = false) {
+  return mount(RestoredPanePlaceholder, {
+    props: {
+      paneId: 'saved-pane-1',
+      title: 'Planning',
+      subtitle: 'Claude · Architect',
+      pipeTag: 'P01',
+      isFocus: true,
+      realizing,
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => ({
+          'pane.terminal.click-to-resume': 'Click to resume',
+          'pane.terminal.resuming': 'Resuming…',
+          'pane.terminal.minimize-tooltip': 'Minimize to sidebar',
+        })[key] ?? key,
+      },
+    },
+  })
+}
+
+describe('RestoredPanePlaceholder', () => {
+  it('shows persisted pane metadata without a terminal host', () => {
+    const wrapper = mountPlaceholder()
+
+    expect(wrapper.attributes('data-pane-id')).toBe('saved-pane-1')
+    expect(wrapper.classes()).toContain('pane-focus')
+    expect(wrapper.text()).toContain('P01')
+    expect(wrapper.text()).toContain('Planning')
+    expect(wrapper.text()).toContain('Claude · Architect')
+    expect(wrapper.text()).toContain('Click to resume')
+    expect(wrapper.find('.terminal').exists()).toBe(false)
+    expect(wrapper.find('.xterm').exists()).toBe(false)
+  })
+
+  it('activates only from a mouse click while idle', async () => {
+    const wrapper = mountPlaceholder()
+
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('activate')).toHaveLength(1)
+
+    await wrapper.trigger('keydown', { key: 'Enter' })
+    await wrapper.trigger('keydown', { key: ' ' })
+    expect(wrapper.emitted('activate')).toHaveLength(1)
+  })
+
+  it('does not activate while realization is already in flight', async () => {
+    const wrapper = mountPlaceholder(true)
+
+    await wrapper.trigger('click')
+    expect(wrapper.emitted('activate')).toBeUndefined()
+    expect(wrapper.text()).toContain('Resuming…')
+    expect(wrapper.attributes('aria-busy')).toBe('true')
+  })
+
+  it('keeps minimize and context-menu actions separate from activation', async () => {
+    const wrapper = mountPlaceholder()
+
+    await wrapper.get('.minimize-btn').trigger('click')
+    expect(wrapper.emitted('minimize')).toHaveLength(1)
+    expect(wrapper.emitted('activate')).toBeUndefined()
+
+    await wrapper.trigger('contextmenu')
+    expect(wrapper.emitted('context-menu')).toHaveLength(1)
+    expect(wrapper.emitted('activate')).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/__tests__/RestoredPanePlaceholder.test.ts
+++ b/src/renderer/src/components/__tests__/RestoredPanePlaceholder.test.ts
@@ -39,22 +39,32 @@ describe('RestoredPanePlaceholder', () => {
     expect(wrapper.find('.xterm').exists()).toBe(false)
   })
 
-  it('activates only from a mouse click while idle', async () => {
+  it('offers a real button so resuming is not mouse-only', async () => {
     const wrapper = mountPlaceholder()
+    const resume = wrapper.get('button.resume-prompt')
 
+    // A native <button> gets Enter/Space from the browser — no keydown handler
+    // on the container, which is what made the minimize button double-fire.
+    expect(resume.attributes('type')).toBe('button')
+    expect(wrapper.attributes('role')).toBeUndefined()
+    expect(wrapper.attributes('tabindex')).toBeUndefined()
+
+    await resume.trigger('click')
+    expect(wrapper.emitted('activate')).toHaveLength(1)
+
+    // Clicking the surrounding pane still resumes, and the button's own click
+    // must not bubble into a second activate.
     await wrapper.trigger('click')
-    expect(wrapper.emitted('activate')).toHaveLength(1)
-
-    await wrapper.trigger('keydown', { key: 'Enter' })
-    await wrapper.trigger('keydown', { key: ' ' })
-    expect(wrapper.emitted('activate')).toHaveLength(1)
+    expect(wrapper.emitted('activate')).toHaveLength(2)
   })
 
   it('does not activate while realization is already in flight', async () => {
     const wrapper = mountPlaceholder(true)
 
     await wrapper.trigger('click')
+    await wrapper.get('button.resume-prompt').trigger('click')
     expect(wrapper.emitted('activate')).toBeUndefined()
+    expect(wrapper.get('button.resume-prompt').attributes('disabled')).toBeDefined()
     expect(wrapper.text()).toContain('Resuming…')
     expect(wrapper.attributes('aria-busy')).toBe('true')
   })
@@ -68,6 +78,21 @@ describe('RestoredPanePlaceholder', () => {
 
     await wrapper.trigger('contextmenu')
     expect(wrapper.emitted('context-menu')).toHaveLength(1)
+    expect(wrapper.emitted('activate')).toBeUndefined()
+  })
+
+  // Keyboard-activating the nested minimize button must not also resume the
+  // pane: a bubbling keydown would fire both actions from one press.
+  it('does not activate when the minimize button is used from the keyboard', async () => {
+    const wrapper = mountPlaceholder()
+    const minimize = wrapper.get('.minimize-btn')
+
+    await minimize.trigger('keydown', { key: 'Enter' })
+    await minimize.trigger('keydown', { key: ' ' })
+    expect(wrapper.emitted('activate')).toBeUndefined()
+
+    await minimize.trigger('click')
+    expect(wrapper.emitted('minimize')).toHaveLength(1)
     expect(wrapper.emitted('activate')).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/__tests__/TerminalPane.restoring.test.ts
+++ b/src/renderer/src/components/__tests__/TerminalPane.restoring.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Ref } from 'vue'
+import TerminalPane from '../TerminalPane.vue'
+
+const mockTerminal = vi.hoisted(() => ({
+  displayStatus: null as unknown as Ref<string>,
+  onFirstOutput: undefined as (() => void) | undefined,
+}))
+
+vi.mock('../../composables/useTerminal', async () => {
+  const { ref } = await import('vue')
+  return {
+    useTerminal: (
+      _paneId: string,
+      _backend: unknown,
+      options?: { onFirstOutput?: () => void },
+    ) => {
+      mockTerminal.displayStatus = ref('starting')
+      mockTerminal.onFirstOutput = options?.onFirstOutput
+      return {
+        mount: vi.fn(),
+        updateXtermTheme: vi.fn(),
+        setDisableStdin: vi.fn(),
+        displayStatus: mockTerminal.displayStatus,
+        sessionId: ref(''),
+        isAltBuffer: ref(false),
+      }
+    },
+  }
+})
+
+function mountPane(): VueWrapper {
+  return mount(TerminalPane, {
+    props: {
+      paneId: 'restored-pane',
+      title: 'Claude',
+      subtitle: 'Architect',
+      backend: {} as never,
+      cliProfiles: {} as never,
+      restoring: true,
+    },
+    global: {
+      mocks: {
+        $t: (key: string) => ({
+          'pane.terminal.resuming': 'Resuming…',
+          'pane.terminal.minimize-tooltip': 'Minimize',
+        })[key] ?? key,
+      },
+    },
+  })
+}
+
+describe('TerminalPane restored-session startup', () => {
+  let wrapper: VueWrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+    mockTerminal.onFirstOutput = undefined
+  })
+
+  it('keeps the placeholder overlay until first output is reported', async () => {
+    wrapper = mountPane()
+
+    expect(wrapper.find('.restoring-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Resuming…')
+
+    mockTerminal.onFirstOutput?.()
+    expect(wrapper.emitted('first-output')).toHaveLength(1)
+
+    await wrapper.setProps({ restoring: false })
+    expect(wrapper.find('.restoring-overlay').exists()).toBe(false)
+  })
+
+  it('does not cover terminal errors while waiting for output', async () => {
+    wrapper = mountPane()
+
+    mockTerminal.displayStatus.value = 'error'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.restoring-overlay').exists()).toBe(false)
+    expect(wrapper.find('.respawn-btn').exists()).toBe(true)
+  })
+})

--- a/src/renderer/src/composables/__tests__/useTerminal.outputFlush.test.ts
+++ b/src/renderer/src/composables/__tests__/useTerminal.outputFlush.test.ts
@@ -25,6 +25,7 @@ vi.mock('../useTerminalResize', () => ({
 
 const captured = vi.hoisted(() => ({
   writes: [] as string[],
+  writeCallbacks: [] as Array<() => void>,
   textarea: undefined as HTMLTextAreaElement | undefined,
 }))
 
@@ -54,8 +55,9 @@ vi.mock('@xterm/xterm', () => {
     onData(): { dispose(): void } {
       return { dispose(): void {} }
     }
-    write(data: string): void {
+    write(data: string, callback?: () => void): void {
       captured.writes.push(data)
+      if (callback) captured.writeCallbacks.push(callback)
     }
     writeln(): void {}
     resize(): void {}
@@ -84,14 +86,15 @@ describe('useTerminal — output flush policy', () => {
   afterEach(() => {
     vi.clearAllMocks()
     captured.writes = []
+    captured.writeCallbacks = []
     captured.textarea = undefined
     localStorage.clear() // drop the persisted PTY id so the next spawn is fresh
   })
 
-  async function spawnedTerminal() {
+  async function spawnedTerminal(onFirstOutput?: () => void) {
     const mock = createMockBackend()
     mock.setResponse('terminal.create', { terminal_session_id: 'sess-1', pid: 42 })
-    const { result, scope } = withScope(() => useTerminal('pane-1', mock.backend))
+    const { result, scope } = withScope(() => useTerminal('pane-1', mock.backend, { onFirstOutput }))
     result.mount(document.createElement('div'))
     await result.spawn({ command: 'bash', cwd: '/tmp' })
     captured.writes = [] // discard anything written during spawn
@@ -110,6 +113,23 @@ describe('useTerminal — output flush policy', () => {
     expect(captured.writes).toEqual(['a'])
     emitOutput(mock, '中')
     expect(captured.writes).toEqual(['a', '中'])
+    scope.stop()
+  })
+
+  it('reports the first rendered PTY output exactly once', async () => {
+    const onFirstOutput = vi.fn()
+    const { mock, scope } = await spawnedTerminal(onFirstOutput)
+    captured.textarea!.dispatchEvent(new Event('focus'))
+
+    expect(onFirstOutput).not.toHaveBeenCalled()
+    emitOutput(mock, 'first')
+    emitOutput(mock, 'second')
+
+    expect(captured.writes).toEqual(['first', 'second'])
+    expect(onFirstOutput).not.toHaveBeenCalled()
+    expect(captured.writeCallbacks).toHaveLength(1)
+    captured.writeCallbacks[0]()
+    expect(onFirstOutput).toHaveBeenCalledTimes(1)
     scope.stop()
   })
 

--- a/src/renderer/src/composables/useTerminal.ts
+++ b/src/renderer/src/composables/useTerminal.ts
@@ -766,6 +766,7 @@ interface UseTerminalOptions {
    *  Feeds the @-mention autocomplete menu. Read lazily at trigger time so the
    *  list stays current as panes come and go. */
   mentionCandidates?: () => string[]
+  onFirstOutput?: () => void
 }
 
 // Throttle for RESUME spawns' terminal.create across all panes. A session
@@ -1127,6 +1128,7 @@ export function useTerminal(paneId: string, backend: ReturnType<typeof useBacken
   let inputDisposer: { dispose(): void } | null = null
   let outputUnsub: (() => void) | null = null
   let exitUnsub: (() => void) | null = null
+  let firstOutputSeen = false
   // Pending terminal output coalescing. The focused pane flushes immediately
   // on arrival — keystroke echo must not wait for a frame (worst for IME
   // input, where the whole commit waits on it). Unfocused panes coalesce
@@ -1143,7 +1145,9 @@ export function useTerminal(paneId: string, backend: ReturnType<typeof useBacken
     const chunk = _pendingOutput
     _pendingOutput = ''
     if (!chunk) return
-    term.write(chunk)
+    const onFirstOutput = !firstOutputSeen ? opts?.onFirstOutput : undefined
+    firstOutputSeen = true
+    term.write(chunk, onFirstOutput)
     appendClean(chunk)
     appendToScrollBuffer(chunk)
   }

--- a/src/renderer/src/i18n/locales/en-US.json
+++ b/src/renderer/src/i18n/locales/en-US.json
@@ -201,6 +201,8 @@
       "sort-progress": "Progress"
     },
     "terminal": {
+      "click-to-resume": "Click to resume",
+      "resuming": "Resuming…",
       "rebuild-tooltip": "Rebuild (resume) ⌘⇧B — kill and re-spawn via --resume at the current size to clear ghosting/overlap that can't be repainted. Interrupts the in-progress turn and reprints the conversation.",
       "rebuild-tooltip-disabled": "Rebuild needs an existing session to resume. Send a message first — the conversation transcript is created after the first turn.",
       "rebuild-busy-skipped": "CLI is busy — kept the running work, skipped rebuild",

--- a/src/renderer/src/i18n/locales/zh-TW.json
+++ b/src/renderer/src/i18n/locales/zh-TW.json
@@ -201,6 +201,8 @@
       "sort-progress": "進度"
     },
     "terminal": {
+      "click-to-resume": "點擊以續接",
+      "resuming": "續接中…",
       "rebuild-tooltip": "重建 (resume) ⌘⇧B — 殺掉並用 --resume 在當前尺寸重新開,清除無法重畫的疊影/跑版。會中斷進行中的回合、重印對話。",
       "rebuild-tooltip-disabled": "重建需要一段可 resume 的對話。請先送出一則訊息，逐字稿會在第一次對話後建立。",
       "rebuild-busy-skipped": "CLI 正在執行中,已保留現有工作,略過重建",


### PR DESCRIPTION
## Summary

Add lazy boot restore for persisted CLI panes. Cold-restored panes remain lightweight placeholders; an explicit user selection realizes exactly that pane through the existing resume/fresh flow.

## Reviewer alignment

- Cold boot does not probe sessions or create PTYs.
- Switching tabs, changing layout, or paging a grid only changes what is rendered; none starts a CLI.
- The Active Agents focus action reveals the pane's tab before explicitly selecting it.
- Start fresh launches a fresh CLI while retaining a saved session pointer when the availability probe is unknown; only a confirmed missing session can replace it.
- The branch is rebased onto current upstream `main`.

## Testing

- [x] `pnpm exec vitest run src/renderer/src/components/__tests__/App.lazyRestore.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm test:run`
- [ ] Manual Electron verification (local Electron runtime required)

## Related Issue

Related to #7.