### PR TITLE
docs(agents): route CLAUDE.md and AGENTS.md at files that exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,20 @@ This file is a router — read the referenced file BEFORE doing the matching wor
 
 | Situation | Read first |
 |---|---|
-| Running tests / typecheck / build / dev app; git & commit rules; worktrees | `.Codex/playbook/10-ops.md` |
-| Touching terminal, xterm, PTY, WebSocket, or panes | `.Codex/playbook/20-pitfalls.md` |
-| Why this repo leaks tokens + the giant-file protocol | `.Codex/playbook/00-diagnosis.md` |
-| Delegation, model choice, judgment calls (Codex only) | `~/.Codex/playbook/` (see route table in global AGENTS.md) |
+| Dev setup, tests, typecheck, PR and commit rules | `CONTRIBUTING.md` |
+| Process boundaries, ownership, persistence and trust boundaries | `docs/en-US/architecture.md` |
+| Adding or changing an agent CLI integration | `docs/en-US/cli-extension-guide.md` |
+| Building or changing a plugin | `docs/en-US/plugin-development.md` |
+| Editor, diff, or plan surfaces | `docs/en-US/editor-design.md` |
+| Keyboard shortcuts and the key resolver | `docs/en-US/keybindings.md` |
 
 Read routed files on demand, not all up front.
+
+An optional machine-local overlay may exist at `.Codex/playbook/` and
+`~/.Codex/playbook/` for delegation and model-choice guidance. Neither is
+checked in, so a fresh clone will not have them. Read them when present; never
+block on them — every rule required to work in this repo is in this file or the
+routed in-repo docs above.
 
 ## Always-on rules (the expensive-to-violate subset)
 
@@ -26,19 +34,37 @@ Read routed files on demand, not all up front.
    they explicitly authorized committing for the task.
 4. **No UI automation** (cliclick/screencapture/AppleScript) — the user tests
    UI manually.
-5. **Giant files** (App.vue ~7K lines, GitPane.vue ~3K,
-   EditorWindowApp.vue ~2.6K, backend/agent_team_backend/app.py ~2.7K):
-   Grep tool to locate → Read with offset/limit → batch edits through one
-   subagent. Never whole-file Read, never bash/python inline search.
+5. **Giant files** — any file over ~2K lines: Grep tool to locate → Read with
+   offset/limit → batch edits through one subagent. Never whole-file Read,
+   never bash/python inline search. The largest, as of v0.1.75, are
+   `src/renderer/src/App.vue` (~11.8K lines),
+   `backend/agent_team_backend/ws_handlers.py` (~5.0K),
+   `src/renderer/src/components/GitPane.vue` (~3.5K),
+   `src/renderer/src/components/SettingsModal.vue` (~3.0K),
+   `backend/agent_team_backend/usage_service.py` (~2.9K),
+   `src/renderer/src/components/ControlPane.vue` (~2.8K),
+   `backend/agent_team_backend/git_service.py` (~2.7K),
+   `src/renderer/src/EditorWindowApp.vue` (~2.7K), and
+   `src/renderer/src/composables/useTerminal.ts` (~2.6K). Check with `wc -l`
+   rather than trusting this list — it drifts.
 
-## Workflow (Cursor Plan Mode)
+## Workflow (Plan Documents)
 
-Plan-driven development:
+Plan mode is **opt-in only** — enter it solely when the user explicitly asks
+(e.g. "建立計畫", "plan 模式"). Never create a plan file proactively, even for
+complex tasks; without a plan, state assumptions and implement directly.
 
-1. Before implementation, read the latest `.plan.md` under `.cursor/plans/`.
-2. Implement by the plan's `todos` phases; update each todo's `status` in the
-   plan file as phases complete.
-3. No plan + complex task → Discovery → Clarify → Plan Artifact first.
+When a plan exists or was explicitly requested:
+
+1. Plans are agent-authored HTML in `.agent-team/plans/` per
+   `.agent-team/plans/_spec.md` (copy `_template.html` to start). The user
+   views them in the app.
+2. Updates (todo status, stage, review notes): edit only the `plan-meta`
+   JSON block plus its matching visible markup — never rewrite the file.
+3. Approval gate: write code only when the plan's `stage` is `approved` or
+   later. The user saying "開始" means: set `stage: approved` + `approvedAt`,
+   then start.
+4. Legacy `.cursor/plans/*.plan.md` stay readable; never create new ones.
 
 ## Language
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,12 +7,20 @@ This file is a router — read the referenced file BEFORE doing the matching wor
 
 | Situation | Read first |
 |---|---|
-| Running tests / typecheck / build / dev app; git & commit rules; worktrees | `.claude/playbook/10-ops.md` |
-| Touching terminal, xterm, PTY, WebSocket, or panes | `.claude/playbook/20-pitfalls.md` |
-| Why this repo leaks tokens + the giant-file protocol | `.claude/playbook/00-diagnosis.md` |
-| Delegation, model choice, judgment calls (Claude Code only) | `~/.claude/playbook/` (see route table in global CLAUDE.md) |
+| Dev setup, tests, typecheck, PR and commit rules | `CONTRIBUTING.md` |
+| Process boundaries, ownership, persistence and trust boundaries | `docs/en-US/architecture.md` |
+| Adding or changing an agent CLI integration | `docs/en-US/cli-extension-guide.md` |
+| Building or changing a plugin | `docs/en-US/plugin-development.md` |
+| Editor, diff, or plan surfaces | `docs/en-US/editor-design.md` |
+| Keyboard shortcuts and the key resolver | `docs/en-US/keybindings.md` |
 
 Read routed files on demand, not all up front.
+
+An optional machine-local overlay may exist at `.claude/playbook/` (ignored by
+Git, so a fresh clone will not have it) and at `~/.claude/playbook/` for
+delegation and model-choice guidance. Read them when present; never block on
+them — every rule required to work in this repo is in this file or the routed
+in-repo docs above.
 
 ## Always-on rules (the expensive-to-violate subset)
 
@@ -26,10 +34,19 @@ Read routed files on demand, not all up front.
    they explicitly authorized committing for the task.
 4. **No UI automation** (cliclick/screencapture/AppleScript) — the user tests
    UI manually.
-5. **Giant files** (App.vue ~7K lines, GitPane.vue ~3K,
-   EditorWindowApp.vue ~2.6K, backend/agent_team_backend/app.py ~2.7K):
-   Grep tool to locate → Read with offset/limit → batch edits through one
-   subagent. Never whole-file Read, never bash/python inline search.
+5. **Giant files** — any file over ~2K lines: Grep tool to locate → Read with
+   offset/limit → batch edits through one subagent. Never whole-file Read,
+   never bash/python inline search. The largest, as of v0.1.75, are
+   `src/renderer/src/App.vue` (~11.8K lines),
+   `backend/agent_team_backend/ws_handlers.py` (~5.0K),
+   `src/renderer/src/components/GitPane.vue` (~3.5K),
+   `src/renderer/src/components/SettingsModal.vue` (~3.0K),
+   `backend/agent_team_backend/usage_service.py` (~2.9K),
+   `src/renderer/src/components/ControlPane.vue` (~2.8K),
+   `backend/agent_team_backend/git_service.py` (~2.7K),
+   `src/renderer/src/EditorWindowApp.vue` (~2.7K), and
+   `src/renderer/src/composables/useTerminal.ts` (~2.6K). Check with `wc -l`
+   rather than trusting this list — it drifts.
 
 ## Workflow (Plan Documents)
 


### PR DESCRIPTION
## Summary / 摘要

`CLAUDE.md` and `AGENTS.md` both open by declaring themselves routers — "read the referenced file BEFORE doing the matching work" — but every row in both route tables points at a file that is not in the repository. `.claude/` is gitignored (`.gitignore:56`) and `.Codex/` was never created, so on a fresh clone all four routes in each file dead-end. An agent following the instructions correctly reads nothing.

This PR makes the routers resolve, and fixes two other pieces of drift found while verifying them.

> 兩份 router 檔的 route table 全部指向不存在的檔案（`.claude/` 已被 gitignore，`.Codex/` 從未建立），fresh clone 下來四條路由一條都讀不到。這個 PR 讓路由指向真的存在的 in-repo 文件，並修掉另外兩處文件漂移。

## Changes / 變更內容

- **Route tables** — replace the four dead `*/playbook/*.md` rows with six in-repo documents that already cover the same ground: `CONTRIBUTING.md` (setup, tests, typecheck, commit format), `docs/en-US/architecture.md`, `cli-extension-guide.md`, `plugin-development.md`, `editor-design.md`, `keybindings.md`. The machine-local playbooks are demoted to an explicitly optional overlay: read when present, never block on.
- **Giant-file rule** — the list had drifted in both directions. `App.vue` was listed at ~7K but is 11,829 lines; `backend/agent_team_backend/app.py` was listed at ~2.7K but is 1,858; the two largest files in the repo (`ws_handlers.py` 4,969 and `SettingsModal.vue` 2,999) were not listed at all. Refreshed against `wc -l`, stamped with the version, and restated around a ~2K-line threshold so the rule keeps working after the next drift.
- **`AGENTS.md` plan workflow** — still described Cursor plan mode over `.cursor/plans/*.plan.md` (that directory does not exist) and instructed agents to author a plan artifact for any complex task. Both contradict `CLAUDE.md`, which marks that path legacy ("never create new ones") and makes plan mode strictly opt-in. Synced to the `.agent-team/plans/` HTML workflow.

No behavior, no code, no dependency changes — instruction files only.

## Testing / 測試

- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` passes — 181 test files, 2675 tests, all green
- [ ] `cd backend && uv run pytest` — not run locally (`uv` is not installed on this machine); the change touches zero Python files and CI runs the backend suite on this PR
- [ ] Manually tested in Electron app — N/A, no runtime surface is affected

## Notes / 補充

- No `CHANGELOG.md` entry: `CONTRIBUTING.md` scopes that requirement to user-facing behavior changes, and these are agent instruction files.
- `.gitignore:51-53` still whitelists `.cursor/plans/*.plan.md`. Left alone deliberately — `CLAUDE.md` says legacy plans stay readable, so anyone holding them keeps them tracked.
- One route has no in-repo replacement and was dropped rather than pointed somewhere wrong: terminal / xterm / PTY / WebSocket / pane pitfalls. Its load-bearing rule (never clear scrollback) is already always-on rule 2. A `docs/en-US/terminal-internals.md` would be the real fix — happy to write one as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)