### PR TITLE
Windows follow-ups: resource probe, secret ACLs, frozen askpass, per-shell script text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,8 +346,12 @@ jobs:
       - name: Report the backend test log
         # The job's log blob is uploaded when the job ends, so a hang in any
         # step loses every step's output. This step must not hang either:
-        # pwsh, no children.
+        # pwsh, no children. Diagnostics only, and never the job's verdict:
+        # after a run that spawns thousands of processes the runner has
+        # failed to start pwsh at all (0xC0000142, DLL init), which must not
+        # turn a suite that passed into a red job.
         if: always()
+        continue-on-error: true
         shell: pwsh
         run: |
           Write-Host "--- processes still around:"

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -16,7 +16,7 @@ Navide は、一人の人間が複数の Coding Agent を指揮するための�
 [![Electron](https://img.shields.io/badge/Electron-33-47848F?logo=electron)](https://www.electronjs.org/)
 [![Vue 3](https://img.shields.io/badge/Vue-3-4FC08D?logo=vue.js)](https://vuejs.org/)
 [![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python)](https://python.org/)
-[![Platform](https://img.shields.io/badge/platform-macOS-lightgrey?logo=apple)](https://www.apple.com/macos/)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)](docs/ja-JP/getting-started.md)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 ## AI は実行能力を変えた。次のボトルネックは協調である
@@ -121,6 +121,8 @@ Navide は Apple silicon 上の macOS 13 以降をサポートします。v0.2.1
 - [ZIP をダウンロード](https://github.com/nt-nerdtechnic/Navide/releases/download/v0.2.1/Navide-0.2.1-arm64.zip)
 
 Navide を Applications にコピーすればそのまま開けます。Gatekeeper の回避は不要です。このリリース以降、アプリ内自動アップデートが利用できます。
+
+Linux と Windows もサポートされ、macOS と同じ CI Gate を通過します。Release CI は Linux x64 向けに AppImage と `.deb` を、Windows x64 向けに NSIS Installer をビルドしますが、これらの Installer が配布されるのは次のリリースからです。v0.2.1 には macOS の Asset のみが含まれるため、それまでこの 2 つの Platform では Source からインストールしてください。Windows Build はまだ Code Signing されていないため初回起動時に SmartScreen が警告し、Executions ウィンドウはこの Platform で Scheduled Job を一覧・管理できず（Windows Task Scheduler は未統合）、Pane ごとの CLI Home と管理対象の Skills は Symbolic Link で構成されるため Windows の開発者モードまたは管理者権限での実行が必要で、CLI は停止を通知されずに終了されるため Pane が閉じる前に Transcript を書き出せない場合があります。
 
 開発用 Checkout では、代わりに Source からインストールしてください。
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ English | [繁體中文](README.zh-TW.md) | [日本語](README.ja-JP.md)
 [![Electron](https://img.shields.io/badge/Electron-33-47848F?logo=electron)](https://www.electronjs.org/)
 [![Vue 3](https://img.shields.io/badge/Vue-3-4FC08D?logo=vue.js)](https://vuejs.org/)
 [![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python)](https://python.org/)
-[![Platform](https://img.shields.io/badge/platform-macOS-lightgrey?logo=apple)](https://www.apple.com/macos/)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)](docs/en-US/getting-started.md)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 ## AI changed execution. Coordination is the new bottleneck.
@@ -121,6 +121,8 @@ Navide supports macOS 13+ on Apple silicon. The v0.2.1 release is signed with a 
 - [Download ZIP](https://github.com/nt-nerdtechnic/Navide/releases/download/v0.2.1/Navide-0.2.1-arm64.zip)
 
 Copy Navide to Applications and open it normally — no Gatekeeper workaround is needed. In-app auto-update is available from this release onward.
+
+Linux and Windows are supported and run the same CI gates as macOS; release CI builds an AppImage and a `.deb` for Linux x64 and an NSIS installer for Windows x64, and those installers ship from the next release — v0.2.1 carries macOS assets only, so install from source on those platforms until then. The Windows build is not code-signed yet, so SmartScreen warns on first run, the Executions window cannot list or manage scheduled jobs there (Windows Task Scheduler is not integrated), per-pane CLI homes and managed skills need Windows Developer Mode or an elevated Navide because they are built from symbolic links, and a CLI is terminated rather than asked to stop, so it may not flush its transcript before a pane closes.
 
 For a development checkout, install from source instead.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -16,7 +16,7 @@ Navide 是一套開源、AI-native 的軟體工程環境，專為一個人調度
 [![Electron](https://img.shields.io/badge/Electron-33-47848F?logo=electron)](https://www.electronjs.org/)
 [![Vue 3](https://img.shields.io/badge/Vue-3-4FC08D?logo=vue.js)](https://vuejs.org/)
 [![Python](https://img.shields.io/badge/Python-3.12-3776AB?logo=python)](https://python.org/)
-[![Platform](https://img.shields.io/badge/platform-macOS-lightgrey?logo=apple)](https://www.apple.com/macos/)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)](docs/zh-TW/getting-started.md)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 ## AI 改變了執行能力，協調成為新的瓶頸
@@ -121,6 +121,8 @@ Navide 支援配備 Apple 晶片且執行 macOS 13 以上版本的 Mac。v0.2.1 
 - [下載 ZIP](https://github.com/nt-nerdtechnic/Navide/releases/download/v0.2.1/Navide-0.2.1-arm64.zip)
 
 將 Navide 複製到「應用程式」後即可正常開啟，無需繞過 Gatekeeper。自此版本起支援 App 內自動更新。
+
+Linux 與 Windows 同樣受支援，並通過與 macOS 相同的 CI 關卡；Release CI 會為 Linux x64 建置 AppImage 與 `.deb`、為 Windows x64 建置 NSIS 安裝程式，這些安裝檔將自下一個版本起隨發行提供——v0.2.1 只附帶 macOS 資產，在此之前請在這兩個平台上從原始碼安裝。Windows 版本尚未經過程式碼簽章，因此首次執行時 SmartScreen 會出現警告；「執行管理」視窗在該平台無法列出或管理排程工作（尚未整合 Windows Task Scheduler）；每個 Pane 的 CLI Home 與受管理的 Skills 以符號連結建立，因此需要 Windows 開發人員模式或以系統管理員身分執行 Navide；CLI 只能被直接終止而無法收到停止通知，Pane 關閉前可能來不及寫出 Transcript。
 
 若要建立開發環境，仍可從原始碼安裝。
 

--- a/backend/agent_team_backend/__main__.py
+++ b/backend/agent_team_backend/__main__.py
@@ -4,16 +4,32 @@ import argparse
 import logging
 import sys
 
-import socket
+from .git_askpass_helper import ASKPASS_FLAG, main as askpass_main
 
-import threading
+# This process was started by git as GIT_ASKPASS (through the launcher
+# `osplat.paths.askpass_launcher` wrote), not to serve: answer the one prompt
+# on argv and exit, which the helper does itself.
+#
+# Before the imports below, not inside `main()`, and this is why: git takes the
+# FIRST LINE OF STDOUT as the credential, and importing the backend prints to
+# stdout on the way up. It also keeps a credential prompt instant instead of
+# paying for a whole backend import.
+#
+# Deliberately not an argparse subcommand: git's prompt is free text ("Password
+# for 'https://x':") that must never be parsed as options.
+if len(sys.argv) > 1 and sys.argv[1] == ASKPASS_FLAG:
+    askpass_main(sys.argv[2] if len(sys.argv) > 2 else "")
 
-import uvicorn
+import socket  # noqa: E402
 
-from . import __version__
-from .app import app as _fastapi_app
-from . import confirm_token, ws_auth
-from .applog import backend_port_file, setup_file_logging
+import threading  # noqa: E402
+
+import uvicorn  # noqa: E402
+
+from . import __version__  # noqa: E402
+from .app import app as _fastapi_app  # noqa: E402
+from . import confirm_token, ws_auth  # noqa: E402
+from .applog import backend_port_file, setup_file_logging  # noqa: E402
 
 
 def _read_confirm_key() -> str:

--- a/backend/agent_team_backend/claude_hooks.py
+++ b/backend/agent_team_backend/claude_hooks.py
@@ -27,10 +27,11 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shlex
 import shutil
 from pathlib import Path
 from typing import Any
+
+from . import osplat
 
 log = logging.getLogger("agent_team_backend.claude_hooks")
 
@@ -108,25 +109,19 @@ def _build_curl_command(port_file: str, event_kind: str, endpoint: str = "claude
     """
     from . import hook_auth
 
-    safe_port_file = shlex.quote(port_file)
-    # The secret is read out of a 0600 file when the hook fires (`-H @file`),
-    # never written into this command: settings.json is world readable and
-    # `ps` would show an argument. See hook_auth.
-    safe_auth_file = shlex.quote(str(hook_auth.header_file()))
     # Claude's Stop hook only: qwen borrows this builder, and nothing has
     # established that its CLI reads a hook's stdout the same way.
     keeps_body = event_kind == "stop" and endpoint == "claude"
-    sink = "" if keeps_body else "-o /dev/null "
-    timeout = _STOP_TIMEOUT_S if keeps_body else 2
-    return (
-        f"{_AGENT_TEAM_MARKER} kind={event_kind}\n"
-        f"PORT=$(cat {safe_port_file} 2>/dev/null); "
-        f"[ -n \"$PORT\" ] && curl -fsS -m {timeout} {sink}-X POST "
-        f"-H 'Content-Type: application/json' "
-        f"-H 'X-Agent-Team-Event: {event_kind}' "
-        f"-H @{safe_auth_file} "
-        f"--data-binary @- "
-        f"\"http://127.0.0.1:$PORT/hooks/{endpoint}\" || true"
+    # The secret is read out of a 0600 file when the hook fires (`-H @file`),
+    # never written into this command: settings.json is world readable and
+    # `ps` would show an argument. See hook_auth.
+    return f"{_AGENT_TEAM_MARKER} kind={event_kind}\n" + osplat.scripts.hook_post_json(
+        port_file=port_file,
+        header_file=str(hook_auth.header_file()),
+        url_path=f"/hooks/{endpoint}",
+        event=event_kind,
+        timeout_s=_STOP_TIMEOUT_S if keeps_body else 2,
+        keep_body=keeps_body,
     )
 
 
@@ -152,21 +147,11 @@ def _build_rewake_command(port_file: str) -> str:
     """
     from . import hook_auth
 
-    safe_port_file = shlex.quote(port_file)
-    safe_auth_file = shlex.quote(str(hook_auth.header_file()))
-    return (
-        f"{_AGENT_TEAM_MARKER} kind=rewake\n"
-        f"PORT=$(cat {safe_port_file} 2>/dev/null); "
-        f"[ -n \"$PORT\" ] || exit 0\n"
-        f"BODY=$(curl -fsS -m {_REWAKE_CURL_TIMEOUT_S} -X POST "
-        f"-H 'Content-Type: application/json' "
-        f"-H 'X-Agent-Team-Event: rewake' "
-        f"-H @{safe_auth_file} "
-        f"--data-binary @- "
-        f"\"http://127.0.0.1:$PORT/hooks/claude/rewake\" || true)\n"
-        f"[ -n \"$BODY\" ] || exit 0\n"
-        f"printf '%s\\n' \"$BODY\" >&2\n"
-        f"exit 2"
+    return f"{_AGENT_TEAM_MARKER} kind=rewake\n" + osplat.scripts.hook_rewake(
+        port_file=port_file,
+        header_file=str(hook_auth.header_file()),
+        url_path="/hooks/claude/rewake",
+        timeout_s=_REWAKE_CURL_TIMEOUT_S,
     )
 
 
@@ -293,14 +278,10 @@ def install_hooks(port_file: str, settings_file: Path | None = None) -> dict[str
         # (Stop) wants both.
         ours: list[dict[str, Any]] = []
         if event_kind:
-            ours.append({
-                "type": "command",
-                "command": _build_curl_command(port_file, event_kind),
-            })
+            ours.append(osplat.scripts.hook_entry(_build_curl_command(port_file, event_kind)))
         if event_name in _REWAKE_EVENTS and rewake_wanted:
             ours.append({
-                "type": "command",
-                "command": _build_rewake_command(port_file),
+                **osplat.scripts.hook_entry(_build_rewake_command(port_file)),
                 "asyncRewake": True,
                 "timeout": _REWAKE_TIMEOUT_S,
             })

--- a/backend/agent_team_backend/copilot_hooks.py
+++ b/backend/agent_team_backend/copilot_hooks.py
@@ -23,9 +23,10 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shlex
 from pathlib import Path
 from typing import Any
+
+from . import osplat
 
 log = logging.getLogger("agent_team_backend.copilot_hooks")
 
@@ -41,8 +42,8 @@ def hooks_dir() -> Path:
     return root / "hooks"
 
 
-def _build_command(port_file: str) -> str:
-    """Shell one-liner forwarding the hook's stdin JSON to this backend.
+def _build_command(port_file: str, shell: str) -> str:
+    """One `shell` one-liner forwarding the hook's stdin JSON to this backend.
 
     Reads the port at fire time so it survives backend restarts. Ends in
     `exit 0` unconditionally: a non-zero exit is how a Copilot hook reports
@@ -51,17 +52,14 @@ def _build_command(port_file: str) -> str:
     """
     from . import hook_auth
 
-    safe_port_file = shlex.quote(port_file)
     # The secret comes out of a 0600 file at fire time (`-H @file`); see hook_auth.
-    safe_auth_file = shlex.quote(str(hook_auth.header_file()))
-    return (
-        f"PORT=$(cat {safe_port_file} 2>/dev/null); "
-        f"[ -n \"$PORT\" ] && curl -fsS -m 2 -o /dev/null -X POST "
-        f"-H 'Content-Type: application/json' "
-        f"-H 'X-Agent-Team-Event: notification' "
-        f"-H @{safe_auth_file} "
-        f"--data-binary @- "
-        f"\"http://127.0.0.1:$PORT/hooks/copilot\" >/dev/null 2>&1; exit 0"
+    return osplat.scripts_by_shell[shell].hook_post_json(
+        port_file=port_file,
+        header_file=str(hook_auth.header_file()),
+        url_path="/hooks/copilot",
+        event="notification",
+        timeout_s=2,
+        exit_zero=True,
     )
 
 
@@ -82,7 +80,14 @@ def install_hooks(port_file: str, hooks_directory: Path | None = None) -> dict[s
         "hooks": {
             "notification": [
                 {
-                    "command": _build_command(port_file),
+                    # `command` is the cross-platform fallback Copilot copies
+                    # into whichever shell it runs; `bash` and `powershell`
+                    # take precedence over it per platform. All three are
+                    # written on every platform because this one file is read
+                    # wherever Copilot runs, not only where it was installed.
+                    "command": _build_command(port_file, "bash"),
+                    "bash": _build_command(port_file, "bash"),
+                    "powershell": _build_command(port_file, "powershell"),
                     "timeoutSec": 5,
                 }
             ]

--- a/backend/agent_team_backend/git_askpass_helper.py
+++ b/backend/agent_team_backend/git_askpass_helper.py
@@ -3,8 +3,12 @@
 prompts to the Agent-Team backend over a one-shot loopback TCP connection.
 
 git execs the path pointed to by GIT_ASKPASS with the prompt string as the
-sole argv[1] -- it does not go through a shell -- so this file must be
-directly executable (shebang + chmod +x) rather than a multi-word command.
+sole argv[1] -- it does not go through a shell -- so what GIT_ASKPASS names
+is either this file run through its shebang (a source checkout) or a small
+launcher the platform can exec, which re-enters the backend executable in the
+`--askpass-helper` entry mode and lands back in `main()` below. Nothing here
+may depend on an interpreter being on PATH: a frozen build ships none, and
+`python` on a stock Windows is the Store's alias stub.
 
 Any failure (missing env, connection refused, timeout, bad response) must
 fall back to printing an empty string and exiting 0 so git proceeds with its
@@ -18,8 +22,17 @@ import socket
 import sys
 
 
-def main() -> None:
-    prompt = sys.argv[1] if len(sys.argv) > 1 else ""
+#: The argv[1] that puts `__main__` into this entry mode. Defined here, where
+#: nothing heavy is imported, so both the dispatcher and git_service (which
+#: writes it into the launcher) can name it without importing the other.
+ASKPASS_FLAG = "--askpass-helper"
+
+
+def main(prompt: str | None = None) -> None:
+    """Answer one credential prompt. `prompt` defaults to argv[1], which is
+    where git puts it when it execs this file directly."""
+    if prompt is None:
+        prompt = sys.argv[1] if len(sys.argv) > 1 else ""
     value = ""
     try:
         port = int(os.environ["NAVIDE_ASKPASS_PORT"])

--- a/backend/agent_team_backend/git_service.py
+++ b/backend/agent_team_backend/git_service.py
@@ -32,6 +32,7 @@ from agent_team_backend.applog import app_data_dir
 from agent_team_backend.osplat import paths
 from agent_team_backend import commit_message_prompt
 from agent_team_backend.git_security import is_remote_helper_form
+from agent_team_backend.git_askpass_helper import ASKPASS_FLAG
 from agent_team_backend.host_shell import (
     run_allowlisted,
     run_allowlisted_capped,
@@ -3053,12 +3054,20 @@ def _resolve_askpass_helper_path() -> str:
             log.warning("git askpass: stable helper copy failed: %s", err)
             helper = source
 
-    # git execs this path directly (no shell). POSIX runs the script through
-    # its shebang; Windows needs a launcher around an interpreter, and a frozen
-    # build carries none of its own (None → the one on PATH, which is what the
-    # shebang's `/usr/bin/env python3` already relies on).
-    interpreter = None if getattr(sys, "frozen", False) else sys.executable
-    return str(paths.askpass_launcher(helper, interpreter))
+    # git execs this path directly (no shell), so the seam writes whatever
+    # launcher this platform can exec around the argv below. That argv is
+    # always this process's own executable and never the name `python`: a
+    # frozen build ships no interpreter for that name to find, and on Windows
+    # it usually resolves to the Store's alias stub, which prints its install
+    # page and answers git with an empty credential. A frozen build re-enters
+    # itself through the askpass entry mode; from a checkout the same mode is
+    # reached with `-m`.
+    launch_argv = (
+        [sys.executable, ASKPASS_FLAG]
+        if getattr(sys, "frozen", False)
+        else [sys.executable, "-m", "agent_team_backend", ASKPASS_FLAG]
+    )
+    return str(paths.askpass_launcher(helper, launch_argv))
 
 
 _ASKPASS_HELPER_PATH = _resolve_askpass_helper_path()

--- a/backend/agent_team_backend/onboarding_deps.py
+++ b/backend/agent_team_backend/onboarding_deps.py
@@ -19,7 +19,6 @@ import hashlib
 import logging
 import os
 import re
-import shlex
 import shutil
 import signal
 import sqlite3
@@ -510,13 +509,12 @@ def _candidate_removal(candidate: dict[str, Any], dep: Dep, version: str) -> dic
     if not package_marker or package_marker not in resolved or npm is None:
         return {"manager": "", "command": ""}
 
-    uninstall = f"{shlex.quote(str(npm))} uninstall -g {shlex.quote(package)}"
+    quote = osplat.paths.quote_arg
+    uninstall = f"{quote(str(npm))} uninstall -g {quote(package)}"
     description = f"Remove {dep.label} {version or ''} from {path}".replace("  ", " ")
-    confirmed = (
-        f"printf '%s\\n' {shlex.quote(description)}; "
-        "printf 'Continue? [y/N] '; read -r answer; "
-        f"case \"$answer\" in [Yy]*) {uninstall} ;; *) echo 'Cancelled.' ;; esac"
-    )
+    # The user's terminal runs this, so it has to be that terminal's language:
+    # `external-terminal.ts` opens sh on POSIX and PowerShell on Windows.
+    confirmed = osplat.scripts.confirm_then_run(description, uninstall)
     return {"manager": "npm", "command": confirmed}
 
 

--- a/backend/agent_team_backend/osplat/__init__.py
+++ b/backend/agent_team_backend/osplat/__init__.py
@@ -73,3 +73,21 @@ __all__ += ["secret_files"]
 scheduler: spec.Scheduler = _impl.scheduler
 
 __all__ += ["scheduler"]
+
+scripts: spec.Scripts = _impl.scripts
+
+#: Both shells' renderers, keyed by the name the consumer uses for them.
+#:
+#: For the one caller that has to write text for a shell this machine is not
+#: running: Copilot's hook file declares a `bash` and a `powershell` spelling
+#: side by side and chooses at fire time, so the file is correct wherever it
+#: is read rather than only where it was written. Everything else wants
+#: `scripts`, which is this machine's.
+from . import _posix_paths, _windows  # noqa: E402
+
+scripts_by_shell: dict[str, spec.Scripts] = {
+    "bash": _posix_paths.scripts,
+    "powershell": _windows.scripts,
+}
+
+__all__ += ["scripts", "scripts_by_shell"]

--- a/backend/agent_team_backend/osplat/_darwin.py
+++ b/backend/agent_team_backend/osplat/_darwin.py
@@ -74,8 +74,8 @@ class DarwinLayout(DarwinPaths):
     def isolated_home_env(self, home_dir: Path) -> dict[str, str]:
         return _posix_paths.isolated_home_env(home_dir)
 
-    def askpass_launcher(self, helper_py: Path, python_exe: str | None) -> Path:
-        return _posix_paths.askpass_launcher(helper_py, python_exe)
+    def askpass_launcher(self, helper_py: Path, launch_argv: list[str]) -> Path:
+        return _posix_paths.askpass_launcher(helper_py, launch_argv)
 
     def executable_candidates(self, name: str) -> list[str]:
         return _posix_paths.executable_candidates(name)
@@ -104,6 +104,7 @@ class DarwinLayout(DarwinPaths):
 
 paths = DarwinLayout()
 secret_files = _posix_secrets.secret_files
+scripts = _posix_paths.scripts
 
 from . import _posix_scheduler  # noqa: E402
 

--- a/backend/agent_team_backend/osplat/_linux.py
+++ b/backend/agent_team_backend/osplat/_linux.py
@@ -208,8 +208,8 @@ class LinuxLayout(LinuxPaths):
     def isolated_home_env(self, home_dir: Path) -> dict[str, str]:
         return _posix_paths.isolated_home_env(home_dir)
 
-    def askpass_launcher(self, helper_py: Path, python_exe: str | None) -> Path:
-        return _posix_paths.askpass_launcher(helper_py, python_exe)
+    def askpass_launcher(self, helper_py: Path, launch_argv: list[str]) -> Path:
+        return _posix_paths.askpass_launcher(helper_py, launch_argv)
 
     def executable_candidates(self, name: str) -> list[str]:
         return _posix_paths.executable_candidates(name)
@@ -238,6 +238,7 @@ class LinuxLayout(LinuxPaths):
 
 paths = LinuxLayout()
 secret_files = _posix_secrets.secret_files
+scripts = _posix_paths.scripts
 
 from . import _posix_scheduler  # noqa: E402
 

--- a/backend/agent_team_backend/osplat/_posix_paths.py
+++ b/backend/agent_team_backend/osplat/_posix_paths.py
@@ -8,8 +8,13 @@ share (the config and state roots) stays in each module.
 
 from __future__ import annotations
 
+import logging
+import shlex
 import stat
+import sys
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 
 def home_env_var() -> str:
@@ -25,15 +30,36 @@ def isolated_home_env(home_dir: Path) -> dict[str, str]:
     return {"HOME": home, "TMPDIR": home}
 
 
-def askpass_launcher(helper_py: Path, python_exe: str | None) -> Path:
-    """The `.py` itself: git execs it and the kernel runs the shebang.
+def askpass_launcher(helper_py: Path, launch_argv: list[str]) -> Path:
+    """The `.py` itself, or a `.sh` around `launch_argv` in a frozen build.
 
-    `python_exe` is unused on purpose — the shebang's `/usr/bin/env python3`
-    decides the interpreter, which is also why a frozen build works here
-    without carrying one. Best effort on the chmod: a helper on a read-only
-    volume is still worth pointing git at, and git reports the exec failure
-    itself.
+    From a source checkout the answer stays what it has always been: git execs
+    the script and the kernel runs its `/usr/bin/env python3` shebang. A
+    frozen build has no `python3` to promise — it ships one inside itself —
+    so it gets a sibling `.sh` that runs its own askpass entry mode and passes
+    git's prompt through.
+
+    Best effort on both writes: a helper on a read-only volume is still worth
+    pointing git at, and git reports the exec failure itself.
     """
+    if getattr(sys, "frozen", False):
+        launcher = helper_py.with_suffix(".sh")
+        argv = " ".join(shlex.quote(part) for part in launch_argv)
+        content = f'#!/bin/sh\nexec {argv} "$@"\n'.encode("utf-8")
+        try:
+            existing = launcher.read_bytes()
+        except OSError:
+            existing = b""
+        try:
+            # Rewritten only when its content differs, so a launcher that is
+            # already right keeps its mtime and no other process sees it flicker.
+            if existing != content:
+                launcher.write_bytes(content)
+            launcher.chmod(0o755)
+        except OSError as err:
+            log.warning("cannot write git askpass launcher %s: %s", launcher, err)
+        return launcher
+
     try:
         helper_py.chmod(helper_py.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     except OSError:
@@ -45,7 +71,6 @@ def askpass_launcher(helper_py: Path, python_exe: str | None) -> Path:
 # ---- appended: the members added for the Windows port ------------------------
 
 import os  # noqa: E402
-import shlex  # noqa: E402
 
 
 def executable_candidates(name: str) -> list[str]:
@@ -89,3 +114,70 @@ def shell_command(command: str) -> list[str]:
 
 def quote_arg(arg: str) -> str:
     return shlex.quote(arg)
+
+
+# ---- appended: the sh renderings of the scripts the backend writes -----------
+
+
+class PosixScripts:
+    """sh, for every shell a POSIX box opens and for Claude Code's default.
+
+    Also the `bash` half of Copilot's hook file on *every* platform: that file
+    declares both spellings and picks at fire time, so it is written once and
+    read wherever Copilot runs.
+    """
+
+    def hook_entry(self, command: str) -> dict:
+        # No `shell` key: sh is what Claude Code runs a hook with here, and
+        # adding one would rewrite every existing settings.json for nothing.
+        return {"type": "command", "command": command}
+
+    def hook_post_json(
+        self,
+        *,
+        port_file: str,
+        header_file: str,
+        url_path: str,
+        event: str,
+        timeout_s: int,
+        keep_body: bool = False,
+        exit_zero: bool = False,
+    ) -> str:
+        sink = "" if keep_body else "-o /dev/null "
+        tail = ' >/dev/null 2>&1; exit 0' if exit_zero else " || true"
+        return (
+            f"PORT=$(cat {shlex.quote(port_file)} 2>/dev/null); "
+            f'[ -n "$PORT" ] && curl -fsS -m {timeout_s} {sink}-X POST '
+            f"-H 'Content-Type: application/json' "
+            f"-H 'X-Agent-Team-Event: {event}' "
+            f"-H @{shlex.quote(header_file)} "
+            f"--data-binary @- "
+            f'"http://127.0.0.1:$PORT{url_path}"{tail}'
+        )
+
+    def hook_rewake(
+        self, *, port_file: str, header_file: str, url_path: str, timeout_s: int
+    ) -> str:
+        return (
+            f"PORT=$(cat {shlex.quote(port_file)} 2>/dev/null); "
+            f'[ -n "$PORT" ] || exit 0\n'
+            f"BODY=$(curl -fsS -m {timeout_s} -X POST "
+            f"-H 'Content-Type: application/json' "
+            f"-H 'X-Agent-Team-Event: rewake' "
+            f"-H @{shlex.quote(header_file)} "
+            f"--data-binary @- "
+            f'"http://127.0.0.1:$PORT{url_path}" || true)\n'
+            f'[ -n "$BODY" ] || exit 0\n'
+            f"printf '%s\\n' \"$BODY\" >&2\n"
+            f"exit 2"
+        )
+
+    def confirm_then_run(self, description: str, command: str) -> str:
+        return (
+            f"printf '%s\\n' {shlex.quote(description)}; "
+            "printf 'Continue? [y/N] '; read -r answer; "
+            f"case \"$answer\" in [Yy]*) {command} ;; *) echo 'Cancelled.' ;; esac"
+        )
+
+
+scripts = PosixScripts()

--- a/backend/agent_team_backend/osplat/_windows.py
+++ b/backend/agent_team_backend/osplat/_windows.py
@@ -75,16 +75,50 @@ class WindowsPaths:
 
 
 class WindowsResourceProbe:
-    """Per-pid sampling is not ported yet; only the self peak is available."""
+    """Memory and CPU from psutil, one process handle per pid.
+
+    `psutil` reads both out of the same `NtQueryInformationProcess` family of
+    calls that Task Manager uses, so this is the cheap in-process path the
+    other platforms get from `proc_pid_rusage` and `/proc` — there is no `ps`
+    here to shell out to anyway.
+
+    Memory is the private working set (`private`, what Task Manager calls
+    "Commit size"), not `rss`: RSS on Windows is the working set, which
+    charges every page of a shared DLL to each of the processes mapping it and
+    so over-reports a fleet of same-binary CLIs exactly the way it does on
+    POSIX. `private` is not interchangeable with `phys_footprint` or PSS — it
+    excludes shared pages outright where those charge them once — which is why
+    `memory_kind` names it for the panel to label.
+    """
 
     def available(self) -> bool:
-        return False
+        return True
 
     def sample(self, pids: list[int]) -> dict[int, tuple[int, float]]:
-        return {}
+        out: dict[int, tuple[int, float]] = {}
+        for pid in pids:
+            if pid <= 0:
+                continue
+            try:
+                proc = psutil.Process(pid)
+                memory = proc.memory_info()
+                cpu = proc.cpu_times()
+            except (psutil.Error, OSError):
+                # Died mid-sweep, or belongs to another user. Same contract as
+                # the Darwin and Linux probes: absent rather than zero, so the
+                # caller can tell "not measured" from "measured as nothing".
+                continue
+            # `private` is Windows-only on the psutil namedtuple; a build that
+            # does not carry it still answers with the working set.
+            private = getattr(memory, "private", None)
+            out[pid] = (
+                int(private if private is not None else memory.rss),
+                float(cpu.user) + float(cpu.system),
+            )
+        return out
 
     def memory_kind(self) -> str:
-        return "unavailable"
+        return "private_bytes"
 
     def peak_rss_bytes(self) -> int | None:
         try:
@@ -815,20 +849,23 @@ class WindowsLayout(WindowsPaths):
         home = str(home_dir)
         return {"USERPROFILE": home, "HOME": home, "TEMP": home, "TMP": home}
 
-    def askpass_launcher(self, helper_py: Path, python_exe: str | None) -> Path:
-        """A sibling `.cmd` that runs the helper through an interpreter.
+    def askpass_launcher(self, helper_py: Path, launch_argv: list[str]) -> Path:
+        """A sibling `.cmd` that runs this backend's own askpass entry mode.
 
         git execs `GIT_ASKPASS` with no shell and Windows cannot exec a
-        `.py`. `python_exe` None (a frozen build) falls back to `python` on
-        PATH. Rewritten only when its content differs, so a launcher that is
+        `.py`, so the launcher has to name something runnable. `launch_argv`
+        is this process's executable plus the flag, never the bare name
+        `python`: that name resolves on a stock Windows to the Store's alias
+        stub, which prints its install page and hands git an empty credential.
+
+        Rewritten only when its content differs, so a launcher that is
         already right keeps its mtime and no other process sees it flicker.
         Best effort on the write, like the POSIX chmod: git_service resolves
         this at import, so an unwritable directory must not stop the backend
         — git reports the missing launcher itself when a credential is asked.
         """
         launcher = helper_py.with_suffix(".cmd")
-        interpreter = python_exe or "python"
-        content = f'@"{interpreter}" "{helper_py}" %*\r\n'.encode("utf-8")
+        content = f"@{subprocess.list2cmdline(launch_argv)} %*\r\n".encode("utf-8")
         try:
             if launcher.read_bytes() == content:
                 return launcher
@@ -846,8 +883,9 @@ class WindowsLayout(WindowsPaths):
 # `os.chmod(0o600)` is a no-op on NTFS, so mode bits cannot protect a secret
 # here. `write_private` wraps the content with `CryptProtectData` instead:
 # only the same Windows account can unwrap it, whichever ACL the file ends up
-# with. `write_private_plain` stays in the clear because another program has
-# to read it; an owner-only ACL for that case is the missing piece.
+# with. `write_private_plain` has to stay in the clear because another program
+# reads it, so that one is protected the only way NTFS expresses it — an
+# owner-only ACL, written with `icacls` (see `_restrict_to_owner`).
 
 #: Header that marks a DPAPI-wrapped file; anything without it is read as-is.
 DPAPI_MAGIC = b"NAVIDE-DPAPI-1\n"
@@ -921,8 +959,62 @@ def _write_atomic(path: Path, data: bytes) -> None:
         raise
 
 
+#: `icacls` is a local, non-networked call; a timeout this generous only
+#: matters when the machine is thrashing.
+_ICACLS_TIMEOUT_S = 10.0
+
+
+def _current_user() -> str | None:
+    """The account to grant, or None when the name cannot be established."""
+    try:
+        name = os.getlogin()
+    except OSError:
+        # No console attached (a service-started backend): the environment is
+        # the other place the session's user name is written down.
+        name = ""
+    return name or os.environ.get("USERNAME") or None
+
+
+def _restrict_to_owner(path: Path, *, container: bool) -> None:
+    """Take `path` down to one full-control ACE for this account, via `icacls`.
+
+    `/inheritance:r` drops what the parent handed down — on a default profile
+    that is SYSTEM and Administrators, and on a tree someone has widened it can
+    be Users — and `/grant:r` then replaces any remaining grant for this
+    account rather than adding a second ACE, so calling this twice is the same
+    as calling it once. A directory also takes `(OI)(CI)` so the files created
+    inside it start owner-only too.
+
+    Never raises. The secret is already written and correct at this point; a
+    box where `icacls` is missing or refuses must still start, with the failure
+    in the log rather than in the caller.
+    """
+    user = _current_user()
+    if not user:
+        log.warning("cannot restrict %s: no account name to grant to", path)
+        return
+    rights = "(OI)(CI)F" if container else "F"
+    argv = ["icacls", str(path), "/inheritance:r", "/grant:r", f"{user}:{rights}"]
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_ICACLS_TIMEOUT_S,
+            # No console flash on a GUI-launched backend; absent off Windows,
+            # where this module still imports for the tests.
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except (OSError, subprocess.SubprocessError) as err:
+        log.warning("icacls failed for %s: %s", path, err)
+        return
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        log.warning("icacls refused %s (exit %s): %s", path, proc.returncode, detail)
+
+
 class WindowsSecretFiles:
-    """`SecretFiles` through DPAPI; directory ACLs are out of scope for now."""
+    """`SecretFiles` through DPAPI for our own content, ACLs for the rest."""
 
     def write_private(self, path: Path, data: bytes) -> None:
         # Wrap first: a DPAPI failure must leave no file behind at all.
@@ -931,6 +1023,9 @@ class WindowsSecretFiles:
 
     def write_private_plain(self, path: Path, data: bytes) -> None:
         _write_atomic(path, data)
+        # After the replace, not before: the ACL has to land on the file that
+        # survives, and the temp file is the one that gets thrown away.
+        _restrict_to_owner(path, container=False)
 
     def read_private(self, path: Path) -> bytes:
         raw = path.read_bytes()
@@ -939,11 +1034,14 @@ class WindowsSecretFiles:
         return _dpapi("CryptUnprotectData", raw[len(DPAPI_MAGIC):])
 
     def harden_file(self, path: Path) -> None:
-        # No ACL rewrite yet; still reports a missing file like the POSIX one.
+        # `stat` first, so a missing file reports like the POSIX one does
+        # rather than as an `icacls` exit code in the log.
         path.stat()
+        _restrict_to_owner(path, container=False)
 
     def make_private_dir(self, path: Path) -> None:
         path.mkdir(parents=True, exist_ok=True)
+        _restrict_to_owner(path, container=True)
 
 
 
@@ -1054,3 +1152,85 @@ class WindowsScheduler:
 paths = WindowsDiscoveryLayout()
 secret_files = WindowsSecretFiles()
 scheduler = WindowsScheduler()
+
+
+# ---- appended: the PowerShell renderings of the scripts the backend writes ---
+#
+# PowerShell rather than cmd because that is what reads these texts here:
+# Claude Code runs a hook under Git Bash when it is installed and PowerShell
+# otherwise (so the entry declares which it wrote), Copilot's hook file has a
+# `powershell` key next to its `bash` one, and `external-terminal.ts` opens a
+# terminal with `powershell -NoExit -Command`.
+
+
+def _ps_quote(value: str) -> str:
+    """`value` as a PowerShell single-quoted string: only `'` needs escaping.
+
+    Single quotes and not double: inside double quotes PowerShell expands
+    `$name` and backticks, and these strings carry Windows paths a user chose
+    the characters of.
+    """
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+class WindowsScripts:
+    def hook_entry(self, command: str) -> dict:
+        # Without `shell`, Claude Code looks for Git Bash and only falls back
+        # to PowerShell when it finds none -- so a box that has Git installed
+        # would run this text under the wrong shell.
+        return {"type": "command", "shell": "powershell", "command": command}
+
+    def hook_post_json(
+        self,
+        *,
+        port_file: str,
+        header_file: str,
+        url_path: str,
+        event: str,
+        timeout_s: int,
+        keep_body: bool = False,
+        exit_zero: bool = False,
+    ) -> str:
+        # `curl.exe`, never `curl`: the bare name is a PowerShell alias for
+        # Invoke-WebRequest, which takes none of these arguments. `'@-'` and
+        # `'@file'` are quoted because `@` starts a splat or an array here.
+        # `exit_zero` costs nothing to honour -- the line already ends that
+        # way, because a PowerShell failure otherwise surfaces as a hook error.
+        sink = "" if keep_body else "-o NUL "
+        return (
+            f"$PORT = Get-Content -ErrorAction SilentlyContinue {_ps_quote(port_file)}; "
+            f"if ($PORT) {{ curl.exe -fsS -m {timeout_s} {sink}-X POST "
+            f"-H 'Content-Type: application/json' "
+            f"-H 'X-Agent-Team-Event: {event}' "
+            f"-H {_ps_quote('@' + header_file)} "
+            f"--data-binary '@-' "
+            f'"http://127.0.0.1:$PORT{url_path}" }}; exit 0'
+        )
+
+    def hook_rewake(
+        self, *, port_file: str, header_file: str, url_path: str, timeout_s: int
+    ) -> str:
+        return (
+            f"$PORT = Get-Content -ErrorAction SilentlyContinue {_ps_quote(port_file)}; "
+            f"if (-not $PORT) {{ exit 0 }}; "
+            f"$BODY = curl.exe -fsS -m {timeout_s} -X POST "
+            f"-H 'Content-Type: application/json' "
+            f"-H 'X-Agent-Team-Event: rewake' "
+            f"-H {_ps_quote('@' + header_file)} "
+            f"--data-binary '@-' "
+            f'"http://127.0.0.1:$PORT{url_path}" 2>$null; '
+            f"if ($BODY) {{ [Console]::Error.WriteLine($BODY); exit 2 }}; exit 0"
+        )
+
+    def confirm_then_run(self, description: str, command: str) -> str:
+        # `&` is the call operator: `command` starts with a quoted path, which
+        # PowerShell would otherwise treat as a string to print.
+        return (
+            f"Write-Host {_ps_quote(description)}; "
+            f"$a = Read-Host 'Continue? [y/N]'; "
+            f"if ($a -match '^[Yy]') {{ & {command} }} else {{ Write-Host 'Cancelled.' }}"
+        )
+
+
+scripts = WindowsScripts()

--- a/backend/agent_team_backend/osplat/_windows.py
+++ b/backend/agent_team_backend/osplat/_windows.py
@@ -652,7 +652,18 @@ class WindowsTerminalHandle:
             ):
                 return
             self._scheduled = True
-        loop.call_soon_threadsafe(self._deliver)
+        try:
+            loop.call_soon_threadsafe(self._deliver)
+        except RuntimeError:
+            # The pane's loop went away before its pump did — a window closing,
+            # or shutdown. POSIX reaches this moment with an `add_reader`
+            # callback the loop simply stops calling; here it is a cross-thread
+            # call into a closed loop, which raises on the pump thread. Nothing
+            # can be delivered any more, so end the pump the way `close()`
+            # would rather than let it surface as a thread exception.
+            with self._lock:
+                self._scheduled = False
+                self._closed = True
 
     def _deliver(self) -> None:
         with self._lock:
@@ -984,6 +995,16 @@ def _restrict_to_owner(path: Path, *, container: bool) -> None:
     account rather than adding a second ACE, so calling this twice is the same
     as calling it once. A directory also takes `(OI)(CI)` so the files created
     inside it start owner-only too.
+
+    What is left behind is the machine itself: SYSTEM, and on an administrator
+    account the local Administrators group, arrive on a new file as *explicit*
+    ACEs off the creating token's default DACL, so `/inheritance:r` has nothing
+    to remove and `/grant:r` only rewrites the entry it names. That is the
+    boundary this draws, and it is the one `0600` draws on POSIX: no other
+    person, rather than nobody at all — an administrator holds
+    SeTakeOwnershipPrivilege and can put any DACL back whatever is written
+    here, so spending a `/remove` on them would cost backup and system access
+    and buy no confidentiality.
 
     Never raises. The secret is already written and correct at this point; a
     box where `icacls` is missing or refuses must still start, with the failure

--- a/backend/agent_team_backend/osplat/spec.py
+++ b/backend/agent_team_backend/osplat/spec.py
@@ -96,16 +96,24 @@ class Paths(Protocol):
         """
         ...
 
-    def askpass_launcher(self, helper_py: Path, python_exe: str | None) -> Path:
-        """The path git can exec as `GIT_ASKPASS` to run `helper_py`.
+    def askpass_launcher(self, helper_py: Path, launch_argv: list[str]) -> Path:
+        """The path git can exec as `GIT_ASKPASS` to run the helper.
 
-        git execs `GIT_ASKPASS` directly, with no shell. POSIX can run the
-        script itself through its shebang, so the answer is `helper_py` made
-        executable. Windows cannot exec a `.py`, so a sibling `.cmd` that
-        invokes `python_exe` on it is written and returned instead; a
-        `python_exe` of None means this process carries no interpreter of its
-        own (a frozen build) and the one on `PATH` is used, which is what the
-        shebang's `/usr/bin/env python3` already relies on elsewhere.
+        git execs `GIT_ASKPASS` directly, with no shell, so the answer is
+        always a file the kernel (or cmd.exe) can start on its own.
+
+        `launch_argv` runs this backend's own askpass entry mode -- this
+        process's executable plus the flag -- and git's prompt is appended to
+        it. A launcher written around it depends on nothing but the running
+        build: a frozen backend has no `python` to promise, and the name
+        usually resolves on Windows to the Store's alias stub, which answers
+        git with an empty credential.
+
+        Windows always writes a sibling `.cmd`, because it cannot exec a
+        `.py`. POSIX writes a sibling `.sh` only when frozen and otherwise
+        returns `helper_py` itself, made executable: a source checkout's
+        `/usr/bin/env python3` shebang is the same interpreter `launch_argv`
+        names.
         """
         ...
 
@@ -430,8 +438,9 @@ class SecretFiles(Protocol):
       *program* too, which is why it must not be used for the second kind.
     - `write_private_plain` is for a secret another process consumes as-is:
       the ws token Electron reads, the header file curl loads, the MCP config
-      a CLI parses. POSIX gives it the same 0600; Windows can only write it
-      in the clear (an owner-only ACL is the missing piece — see `_windows`).
+      a CLI parses. POSIX gives it the same 0600; Windows has to write it in
+      the clear and protects it with an owner-only ACL instead (`icacls`,
+      see `_windows`).
     """
 
     def write_private(self, path: Path, data: bytes) -> None:
@@ -493,4 +502,80 @@ class Scheduler(Protocol):
 
     async def remove(self, kind: str, target: str) -> None:
         """Delete one job; `SchedulerError` on failure."""
+        ...
+
+
+class Scripts(Protocol):
+    """Text the platform's own shell runs: hook commands, and terminal prompts.
+
+    Three of the things the backend writes are *programs for a shell* rather
+    than argv, and each is read back by something that picked the shell for
+    us. Claude Code runs a hook's `command` under Git Bash on Windows, or
+    PowerShell when Git Bash is absent, and the hook entry says which with a
+    `shell` field; Copilot's hook file carries a `bash` and a `powershell`
+    spelling side by side and picks at fire time; and the "confirm, then run"
+    line goes to whichever terminal the app opens, `cmd`/PowerShell on
+    Windows.
+
+    So the renderer is the seam, not the caller: `osplat.scripts` is this
+    machine's, and `osplat.scripts_by_shell` names both for the one file that
+    has to carry a shell this machine is not running.
+    """
+
+    def hook_entry(self, command: str) -> dict:
+        """`command` as a Claude Code hook entry, declaring its shell.
+
+        POSIX: `{"type": "command", "command": ...}`, unchanged from what the
+        installer has always written. Windows adds `"shell": "powershell"`,
+        without which Claude Code falls back to Git Bash and finds nothing to
+        run this text with when it is not installed.
+        """
+        ...
+
+    def hook_post_json(
+        self,
+        *,
+        port_file: str,
+        header_file: str,
+        url_path: str,
+        event: str,
+        timeout_s: int,
+        keep_body: bool = False,
+        exit_zero: bool = False,
+    ) -> str:
+        """A one-liner that POSTs the hook's stdin JSON to the running backend.
+
+        `port_file` is read when the hook fires, not now, so the command
+        survives a backend restart on a different port, and its absence (no
+        backend) makes the whole thing a no-op. `header_file` is the
+        owner-only file curl loads the auth header out of -- the secret is
+        never written into the command, which lands in a world-readable
+        settings file.
+
+        `keep_body` keeps curl's stdout, which is where the CLI reads a hook's
+        decision from; everything else discards it. `exit_zero` ends the line
+        with an unconditional success, for a CLI that reads a non-zero exit as
+        a hook failure (Copilot) rather than as "nothing to report".
+        """
+        ...
+
+    def hook_rewake(
+        self, *, port_file: str, header_file: str, url_path: str, timeout_s: int
+    ) -> str:
+        """The parked-waiter variant: the body goes to stderr and exit 2 wakes the agent.
+
+        Backgrounded by the CLI, which reads only the exit code, so the
+        response body has to travel on stderr. An empty body, a missing port
+        file, or a refused connection all exit 0, which is "nothing to
+        report".
+        """
+        ...
+
+    def confirm_then_run(self, description: str, command: str) -> str:
+        """A script that prints `description`, asks for y/N, and runs `command` on yes.
+
+        Handed to a terminal the app opens, so it has to be that terminal's
+        language: sh on POSIX, PowerShell on Windows (`external-terminal.ts`
+        runs it through `powershell -NoExit -Command` there).
+        """
         ...

--- a/backend/agent_team_backend/process_cpu.py
+++ b/backend/agent_team_backend/process_cpu.py
@@ -13,10 +13,12 @@ actually wants to show. This module only takes the readings; the differencing
 lives in the caller, so that two windows sampling at different rates each get
 their own interval instead of fighting over one shared previous sample.
 
-On macOS the counter is read straight from the kernel through `proc_pid_rusage`
-(see `proc_rusage`) — a syscall per pid, no subprocess to spawn or time out,
-and the same figure `ps -o time=` prints once converted out of mach time units.
-Everywhere else `ps` takes the whole pid list in one call.
+The counter is read straight from the kernel through the platform probe (see
+`osplat.resource_probe`) — `proc_pid_rusage` on macOS, `/proc` on Linux,
+psutil on Windows — costing no subprocess to spawn or time out, and giving
+the same figure `ps -o time=` prints. `ps` stays as the fallback for a machine
+where the probe cannot be resolved at all, taking the whole pid list in one
+call.
 """
 
 from __future__ import annotations
@@ -24,8 +26,8 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shutil
 import subprocess
-import sys
 import time
 
 from . import osplat
@@ -39,6 +41,10 @@ _ROW_RE = re.compile(r"^\s*(\d+)\s+(\S+)\s*$")
 #: short still leaves room for a machine deep in swap.
 _SWEEP_TIMEOUT_S = 5.0
 
+#: Whether this machine has a `ps` for the fallback path, resolved on first
+#: use. None until then.
+_HAS_PS: bool | None = None
+
 #: Same cap as the footprint sweep — beyond this the panel is an audit, not a
 #: summary, and the `ps` fallback's argv gets unwieldy.
 _MAX_PIDS = 4000
@@ -47,11 +53,20 @@ _MAX_PIDS = 4000
 def available() -> bool:
     """Whether the CPU sweep can be expected to work.
 
-    `ps -o time=` is POSIX, but the panel it feeds is gated on the macOS-only
-    footprint sweep anyway, so anything that is not Windows is fair game and
-    the panel decides on its own whether to show the column.
+    The platform probe answers first; only when there is none does it matter
+    whether this machine has a `ps` to fall back on. Asking `shutil.which` is
+    what replaced the platform branch that used to live here: Windows has no
+    `ps`, and neither does a stripped container, so the question the sweep
+    actually has is whether the command exists — not which OS this is.
     """
-    return sys.platform != "win32"
+    if osplat.resource_probe.available():
+        return True
+    global _HAS_PS
+    if _HAS_PS is None:
+        # Cached: `available()` runs once per sweep and the sweep is on a
+        # timer, while a PATH scan is filesystem work.
+        _HAS_PS = shutil.which("ps") is not None
+    return _HAS_PS
 
 
 def parse_cpu_time(raw: str) -> float | None:

--- a/backend/tests/hook_shell.py
+++ b/backend/tests/hook_shell.py
@@ -1,0 +1,48 @@
+"""Run an installed hook command the way the CLI that reads it would.
+
+A hook's `command` is a program for a shell, and which shell is not the test's
+choice: the installer writes the text and declares the shell in the same entry
+(`osplat.scripts.hook_entry`) — POSIX sh on a POSIX box, PowerShell on Windows.
+Both read the event JSON on stdin and answer on stdout, stderr and the exit
+code, so one argv builder serves both and the tests stay about the guarantee
+rather than about the spelling.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def _bash() -> str | None:
+    """Git for Windows' bash first: a bare `which("bash")` can land on the WSL
+    stub in System32, which has no distribution to run anything with."""
+    git = shutil.which("git")
+    if git is not None:
+        candidate = Path(git).resolve().parent.parent / "bin" / "bash.exe"
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which("bash")
+
+
+def shell_argv(entry: dict) -> list[str]:
+    """The interpreter for one hook entry, skipping when it is not installed.
+
+    `-Command` and not `-File`, because that is the shape Claude Code runs a
+    PowerShell hook with: the text, not a script on disk. `-NoProfile` keeps a
+    developer's profile out of the run and `-NonInteractive` makes a prompt an
+    error rather than a hang.
+    """
+    command = entry["command"]
+    if entry.get("shell") == "powershell":
+        exe = shutil.which("powershell.exe") or shutil.which("pwsh")
+        if exe is None:
+            pytest.skip("the hook command is PowerShell and no PowerShell is on PATH")
+        return [exe, "-NoProfile", "-NonInteractive", "-Command", command]
+    bash = _bash()
+    if bash is None:
+        pytest.skip("the hook command is a POSIX sh script and no bash is on PATH")
+    return [bash, "-c", command]
+

--- a/backend/tests/test_claude_hooks.py
+++ b/backend/tests/test_claude_hooks.py
@@ -1,24 +1,12 @@
 import json
-import shutil
+import re
 import subprocess
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from pathlib import Path
 
-import pytest
-
+from agent_team_backend import osplat
 from agent_team_backend.claude_hooks import _build_curl_command
-
-
-def _bash() -> str | None:
-    """Git for Windows' bash first: a bare `which("bash")` can land on the WSL
-    stub in System32, which has no distribution to run anything with."""
-    git = shutil.which("git")
-    if git is not None:
-        candidate = Path(git).resolve().parent.parent / "bin" / "bash.exe"
-        if candidate.is_file():
-            return str(candidate)
-    return shutil.which("bash")
+from tests import hook_shell
 
 
 def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
@@ -28,12 +16,16 @@ def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
     the interesting half, because that is the only channel a CLI reads a hook's
     decision from.
     """
-    # The hook command is a POSIX sh script: `shell=True` would hand it to
-    # cmd.exe on Windows, so run it under an explicit bash (Git for Windows
-    # ships one) — checked before the server thread starts.
-    bash = _bash()
-    if bash is None:
-        pytest.skip("hook commands are POSIX sh scripts and no bash is on PATH")
+    # Which shell this text is for is the installer's declaration, not a guess:
+    # `shell=True` would hand it to cmd.exe on Windows, and bash would get
+    # PowerShell there. Resolved before the server thread starts, so a box with
+    # neither shell skips rather than leaving one hanging.
+    port_file = tmp_path / "backend.port"
+    argv = hook_shell.shell_argv(
+        osplat.scripts.hook_entry(
+            _build_curl_command(str(port_file), event_kind, endpoint=endpoint)
+        )
+    )
     received: list[bytes] = []
 
     class Handler(BaseHTTPRequestHandler):
@@ -53,25 +45,23 @@ def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
     server.timeout = 5
     thread = threading.Thread(target=server.handle_request)
     thread.start()
-    port_file = tmp_path / "backend.port"
     port_file.write_text(str(server.server_port), encoding="utf-8")
     payload = '{"hook_event_name":"Stop","session_id":"session-1"}'
 
     try:
         result = subprocess.run(
-            [bash, "-c", _build_curl_command(str(port_file), event_kind, endpoint=endpoint)],
-            input=payload,
-            text=True,
-            capture_output=True,
-            timeout=10,
-            check=False,
+            argv, input=payload, text=True, capture_output=True, timeout=10, check=False
         )
     finally:
         thread.join(timeout=6)
         server.server_close()
 
     assert received == [payload.encode()]
-    return received, result.stdout
+    # One trailing line ending is the shell's, not the hook's: PowerShell ends
+    # a native command's output with a newline where sh passes curl's bytes
+    # through untouched, and a CLI parsing the JSON object cannot tell. Every
+    # other byte is compared exactly.
+    return received, result.stdout.removesuffix("\n").removesuffix("\r")
 
 
 def test_stop_hook_puts_the_response_on_stdout_where_the_cli_reads_decisions(tmp_path) -> None:
@@ -157,7 +147,21 @@ def test_subagent_stop_hook_is_installed(tmp_path) -> None:
     ]
     assert any("kind=subagent_stop" in c for c in commands)
     # It is a plain signal hook: its response is discarded, unlike Stop's.
-    assert all("-o /dev/null" in c for c in commands)
+    # How a shell spells "discard" (`-o /dev/null`, `-o NUL`) is the renderer's
+    # business, so the expected text comes from the same seam the installer
+    # wrote the command through rather than from a literal here.
+    shape = dict(
+        port_file=str(port_file),
+        header_file=str(tmp_path / "hook-auth"),
+        url_path="/hooks/claude",
+        event="subagent_stop",
+        timeout_s=2,
+    )
+    sink = re.search(r"-o \S+", osplat.scripts.hook_post_json(**shape, keep_body=False))
+    assert sink, "the renderer no longer discards a signal hook's response"
+    # It really is the discard, not boilerplate the kept-body form shares.
+    assert sink.group(0) not in osplat.scripts.hook_post_json(**shape, keep_body=True)
+    assert all(sink.group(0) in c for c in commands)
 
 
 def test_subagent_stop_hook_reaches_the_endpoint(tmp_path) -> None:

--- a/backend/tests/test_claude_hooks.py
+++ b/backend/tests/test_claude_hooks.py
@@ -164,3 +164,43 @@ def test_subagent_stop_hook_reaches_the_endpoint(tmp_path) -> None:
     payloads, stdout = _run_hook(tmp_path, "subagent_stop", b'{"ok":true}')
     assert payloads, "the hook sent nothing"
     assert stdout == "", "a signal hook's response must not reach the CLI"
+
+
+def test_a_windows_install_writes_powershell_and_says_so(tmp_path, monkeypatch) -> None:
+    """On Windows a hook's `command` runs under Git Bash, or PowerShell when
+    Git Bash is not installed — and the entry declares which it was written
+    for. Nothing here can assume sh, so the renderer is the seam and this
+    exercises its Windows arm on whatever machine runs the suite.
+    """
+    from agent_team_backend import claude_hooks, osplat
+    from agent_team_backend.osplat import _windows
+
+    monkeypatch.setattr(osplat, "scripts", _windows.scripts)
+    monkeypatch.setattr(claude_hooks, "_rewake_wanted", lambda: True)
+
+    settings_file = tmp_path / "settings.json"
+    port_file = tmp_path / "port"
+    port_file.write_text("1234", encoding="utf-8")
+    claude_hooks.install_hooks(str(port_file), settings_file=settings_file)
+
+    entries = [
+        h
+        for event in json.loads(settings_file.read_text(encoding="utf-8"))["hooks"].values()
+        for entry in event
+        for h in entry.get("hooks", [])
+    ]
+    assert entries
+    for hook in entries:
+        assert hook["shell"] == "powershell"
+        # The marker comment, then one PowerShell line — `#` comments in both
+        # shells, so the marker still reads the same to the installer.
+        marker, command = hook["command"].split("\n", 1)
+        assert marker.startswith("# agent-team-hook")
+        assert "\n" not in command
+        assert command.startswith("$PORT = Get-Content -ErrorAction SilentlyContinue ")
+        assert "curl.exe" in command
+        assert command.endswith("exit 0") or command.endswith("exit 2 }; exit 0")
+
+    rewake = [h for h in entries if h.get("asyncRewake")]
+    assert rewake, "the rewake waiter was not installed"
+    assert "[Console]::Error.WriteLine($BODY); exit 2" in rewake[0]["command"]

--- a/backend/tests/test_cli_hook_endpoint.py
+++ b/backend/tests/test_cli_hook_endpoint.py
@@ -485,9 +485,17 @@ def test_the_hook_secret_lives_in_a_private_file_the_command_only_names(tmp_path
     secret = hook_auth.token()
     for command in (
         _build_curl_command(str(tmp_path / "port"), "stop"),
-        _build_command(str(tmp_path / "port")),
+        # Both of Copilot's spellings: its hook file carries one per shell.
+        _build_command(str(tmp_path / "port"), "bash"),
+        _build_command(str(tmp_path / "port"), "powershell"),
     ):
-        assert f"-H @{path}" in command or f"-H @'{path}'" in command
+        # sh names the file after curl's `@`; PowerShell quotes the whole
+        # argument, because `@` starts a splat there.
+        assert (
+            f"-H @{path}" in command
+            or f"-H @'{path}'" in command
+            or f"-H '@{path}'" in command
+        )
         assert secret not in command
 
 

--- a/backend/tests/test_copilot_hooks.py
+++ b/backend/tests/test_copilot_hooks.py
@@ -41,8 +41,30 @@ def test_the_command_always_exits_zero(tmp_path) -> None:
     # is not running. Reporting that as a hook failure would be noise at best.
     copilot_hooks.install_hooks("/tmp/port-file", hooks_directory=tmp_path)
 
-    command = _document(tmp_path)["hooks"]["notification"][0]["command"]
-    assert command.rstrip().endswith("exit 0")
+    handler = _document(tmp_path)["hooks"]["notification"][0]
+    for key in ("command", "bash", "powershell"):
+        assert handler[key].rstrip().endswith("exit 0"), key
+
+
+def test_both_shells_are_written_on_every_platform(tmp_path) -> None:
+    """`command` is the cross-platform fallback Copilot copies into whichever
+    shell it runs; `bash` and `powershell` take precedence per platform. This
+    one file is read wherever Copilot runs, not only where it was installed,
+    so all three are written on every platform — a sh one-liner handed to
+    PowerShell is a syntax error, not a failed request.
+    """
+    copilot_hooks.install_hooks("/tmp/port-file", hooks_directory=tmp_path)
+
+    handler = _document(tmp_path)["hooks"]["notification"][0]
+    assert handler["bash"] == handler["command"]
+    assert handler["bash"].startswith("PORT=$(cat /tmp/port-file 2>/dev/null); ")
+    # `curl` alone is a PowerShell alias for Invoke-WebRequest; `@` starts a splat.
+    assert handler["powershell"].startswith(
+        "$PORT = Get-Content -ErrorAction SilentlyContinue '/tmp/port-file'; "
+    )
+    assert "curl.exe -fsS -m 2 -o NUL -X POST" in handler["powershell"]
+    assert "--data-binary '@-'" in handler["powershell"]
+    assert "/hooks/copilot" in handler["powershell"]
 
 
 def test_the_command_reads_the_port_at_fire_time(tmp_path) -> None:
@@ -50,9 +72,10 @@ def test_the_command_reads_the_port_at_fire_time(tmp_path) -> None:
     # must not bake one in.
     copilot_hooks.install_hooks("/var/run/navide.port", hooks_directory=tmp_path)
 
-    command = _document(tmp_path)["hooks"]["notification"][0]["command"]
-    assert "/var/run/navide.port" in command
-    assert "$PORT" in command
+    handler = _document(tmp_path)["hooks"]["notification"][0]
+    for key in ("command", "bash", "powershell"):
+        assert "/var/run/navide.port" in handler[key], key
+        assert "$PORT" in handler[key], key
 
 
 def test_reinstalling_overwrites_rather_than_accumulates(tmp_path) -> None:

--- a/backend/tests/test_git_askpass.py
+++ b/backend/tests/test_git_askpass.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import socket
+import sys
 from pathlib import Path
 
 import pytest
@@ -261,3 +263,40 @@ class TestAskpassFailures:
             assert received == []
         finally:
             await cleanup()
+
+
+@pytest.mark.asyncio
+async def test_the_askpass_entry_mode_answers_a_prompt_like_the_helper_does():
+    """`<backend> --askpass-helper "<prompt>"` is what every launcher runs.
+
+    The frozen builds have no interpreter to hand the `.py` to, so the helper
+    is reached by re-entering this executable in that entry mode instead. It
+    has to answer on stdout exactly like a directly exec'd helper, and it must
+    reach the helper before anything the backend imports can print a line of
+    its own -- git reads the first line of stdout as the credential.
+    """
+    received: list[str] = []
+
+    async def on_request(request_id: str, prompt: str) -> None:
+        received.append(prompt)
+        git_service.resolve_credential(request_id, "s3cr3t-token")
+
+    env, cleanup = await git_service.create_askpass_context(on_request)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "agent_team_backend",
+            "--askpass-helper",
+            "Password for 'https://x':",
+            env={**os.environ, **env},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=60)
+    finally:
+        await cleanup()
+
+    assert proc.returncode == 0
+    assert stdout.splitlines()[0] == b"s3cr3t-token"
+    assert received == ["Password for 'https://x':"]

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -605,6 +605,37 @@ def test_cli_health_builds_confirmed_npm_removal_for_owned_install(
     assert "Continue? [y/N]" in candidate["removal_command"]
 
 
+def test_cli_health_removal_command_is_the_terminal_shells_language(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The user runs this in a terminal the app opens, which is PowerShell on
+    Windows — where the sh spelling (`read -r`, `case ... esac`) is a syntax
+    error before it can ask anything.
+    """
+    from agent_team_backend import osplat
+    from agent_team_backend.osplat import _windows
+
+    _, binary, target = _make_npm_claude_install(tmp_path / "node")
+    other = _make_executable(tmp_path / "native" / "claude")
+    monkeypatch.setattr(ob, "_distinct_executables", lambda _command: [
+        _candidate_entry(binary, target),
+        _candidate_entry(other),
+    ])
+    monkeypatch.setattr(ob, "_probe_alternate", _probe_ok)
+    monkeypatch.setattr(ob, "_dismissed_cli_health_fingerprint", lambda: "")
+    monkeypatch.setattr(osplat, "scripts", _windows.scripts)
+
+    health = ob.build_cli_health([_claude_status(binary)])
+    command = health["entries"][0]["candidates"][0]["removal_command"]
+
+    assert command.startswith("Write-Host 'Remove ")
+    assert "$a = Read-Host 'Continue? [y/N]'" in command
+    assert "if ($a -match '^[Yy]') { & " in command
+    assert "uninstall -g @anthropic-ai/claude-code }" in command
+    assert "else { Write-Host 'Cancelled.' }" in command
+    assert "read -r" not in command
+
+
 def test_cli_health_never_offers_removal_for_the_only_install(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/backend/tests/test_osplat.py
+++ b/backend/tests/test_osplat.py
@@ -247,10 +247,16 @@ class TestPaths:
         assert _windows.paths.quote_arg("plain") == "plain"
 
 
+#: What git_service hands the seam: this build's own executable plus the entry
+#: mode that answers a prompt. Never the bare name `python`.
+_LAUNCH_ARGV = ["/opt/navide/agent_team_backend", "--askpass-helper"]
+
+
 class TestAskpassLauncher:
-    """`GIT_ASKPASS` is exec'd by git with no shell: POSIX runs the script's
-    shebang, Windows cannot exec a `.py` and needs a launcher around an
-    interpreter."""
+    """`GIT_ASKPASS` is exec'd by git with no shell: a source checkout runs the
+    script's shebang, and every frozen build needs a launcher around the
+    backend's own askpass entry mode -- Windows always, because it cannot exec
+    a `.py` at all."""
 
     @pytest.mark.skipif(sys.platform == "win32", reason="the exec bit does not exist on NTFS")
     def test_posix_returns_the_script_made_executable(self, tmp_path):
@@ -259,43 +265,63 @@ class TestAskpassLauncher:
         helper = tmp_path / "git_askpass_helper.py"
         helper.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
         helper.chmod(0o644)
-        assert _darwin.paths.askpass_launcher(helper, "/usr/bin/python3") == helper
+        assert _darwin.paths.askpass_launcher(helper, _LAUNCH_ARGV) == helper
         assert os.stat(helper).st_mode & stat.S_IXUSR
         helper.chmod(0o644)
-        assert _linux.paths.askpass_launcher(helper, None) == helper
+        assert _linux.paths.askpass_launcher(helper, _LAUNCH_ARGV) == helper
         assert os.stat(helper).st_mode & stat.S_IXUSR
+
+    # A frozen build has no `python3` to promise the shebang, so POSIX stops
+    # relying on one too: the launcher runs the executable git_service named.
+    @pytest.mark.skipif(sys.platform == "win32", reason="the exec bit does not exist on NTFS")
+    def test_posix_frozen_build_writes_an_sh_launcher(self, tmp_path, monkeypatch):
+        from agent_team_backend.osplat import _darwin
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        helper = tmp_path / "git_askpass_helper.py"
+        helper.write_text("", encoding="utf-8")
+        launcher = _darwin.paths.askpass_launcher(helper, _LAUNCH_ARGV)
+        assert launcher == tmp_path / "git_askpass_helper.sh"
+        assert launcher.read_text(encoding="utf-8") == (
+            '#!/bin/sh\nexec /opt/navide/agent_team_backend --askpass-helper "$@"\n'
+        )
+        assert stat.S_IMODE(os.stat(launcher).st_mode) == 0o755
 
     def test_windows_writes_a_cmd_wrapper_beside_the_script(self, tmp_path):
         from agent_team_backend.osplat import _windows
 
         helper = tmp_path / "git_askpass_helper.py"
         helper.write_text("", encoding="utf-8")
-        launcher = _windows.paths.askpass_launcher(helper, r"C:\Python\python.exe")
+        launcher = _windows.paths.askpass_launcher(
+            helper, [r"C:\Program Files\Navide\backend.exe", "--askpass-helper"]
+        )
         assert launcher == tmp_path / "git_askpass_helper.cmd"
         assert launcher.read_bytes() == (
-            b'@"C:\\Python\\python.exe" "' + str(helper).encode() + b'" %*\r\n'
+            b'@"C:\\Program Files\\Navide\\backend.exe" --askpass-helper %*\r\n'
         )
 
-    # A frozen build carries no interpreter of its own: the launcher falls
-    # back to `python` on PATH, the same dependency the POSIX shebang has.
-    def test_windows_frozen_build_uses_python_from_path(self, tmp_path):
+    # The regression this whole entry mode exists for: `python` on a stock
+    # Windows is the Store's alias stub, which hands git an empty credential.
+    def test_windows_never_names_a_bare_interpreter(self, tmp_path):
         from agent_team_backend.osplat import _windows
 
         helper = tmp_path / "git_askpass_helper.py"
         helper.write_text("", encoding="utf-8")
-        launcher = _windows.paths.askpass_launcher(helper, None)
-        assert launcher.read_text(encoding="utf-8").startswith('@"python" "')
+        launcher = _windows.paths.askpass_launcher(helper, _LAUNCH_ARGV)
+        text = launcher.read_text(encoding="utf-8")
+        assert "python" not in text
+        assert text.startswith("@/opt/navide/agent_team_backend --askpass-helper")
 
     def test_windows_leaves_an_up_to_date_launcher_untouched(self, tmp_path):
         from agent_team_backend.osplat import _windows
 
         helper = tmp_path / "git_askpass_helper.py"
         helper.write_text("", encoding="utf-8")
-        launcher = _windows.paths.askpass_launcher(helper, "py")
+        launcher = _windows.paths.askpass_launcher(helper, _LAUNCH_ARGV)
         before = launcher.stat().st_mtime_ns
         os.utime(launcher, ns=(before - 10**9, before - 10**9))
         stamped = launcher.stat().st_mtime_ns
-        assert _windows.paths.askpass_launcher(helper, "py") == launcher
+        assert _windows.paths.askpass_launcher(helper, _LAUNCH_ARGV) == launcher
         assert launcher.stat().st_mtime_ns == stamped
 
     # git_service resolves the launcher at import: a directory that cannot be
@@ -313,7 +339,7 @@ class TestAskpassLauncher:
             raise PermissionError(13, "Access is denied", str(self))
 
         monkeypatch.setattr(Path, "write_bytes", denied)
-        launcher = _windows.paths.askpass_launcher(helper, "py")
+        launcher = _windows.paths.askpass_launcher(helper, _LAUNCH_ARGV)
         assert launcher == tmp_path / "git_askpass_helper.cmd"
         assert not launcher.exists()
         assert "cannot write git askpass launcher" in caplog.text
@@ -357,7 +383,6 @@ PLATFORM_BRANCH_ALLOWLIST = {
     "cli_vendors/cursor.py",
     "credential_vault.py",
     "proc_rusage.py",
-    "process_cpu.py",
     "process_memory.py",
 }
 
@@ -471,3 +496,141 @@ class TestPortedModulesStayPosixFree:
         source = posix.read_text(encoding="utf-8")
         assert _POSIX_IMPORT_RE.search(source)
         assert _POSIX_CALL_RE.search(source)
+
+
+class TestScripts:
+    """The texts a *shell* runs: hook commands and the confirm-then-run line.
+
+    Both implementations are exercised on whichever machine runs the suite --
+    they are pure string rendering, and Copilot's hook file carries the
+    PowerShell spelling even when written on a Mac.
+    """
+
+    def test_the_selected_renderer_is_this_platform(self):
+        expected = "WindowsScripts" if sys.platform == "win32" else "PosixScripts"
+        assert type(osplat.scripts).__name__ == expected
+        assert set(osplat.scripts_by_shell) == {"bash", "powershell"}
+
+    def test_posix_hook_entry_stays_the_shape_the_installer_has_always_written(self):
+        from agent_team_backend.osplat import _posix_paths
+
+        entry = _posix_paths.scripts.hook_entry("echo hi")
+        assert entry == {"type": "command", "command": "echo hi"}
+
+    # Without `shell`, Claude Code runs the command under Git Bash whenever it
+    # is installed -- and this text is PowerShell.
+    def test_windows_hook_entry_declares_powershell(self):
+        from agent_team_backend.osplat import _windows
+
+        entry = _windows.scripts.hook_entry("exit 0")
+        assert entry == {"type": "command", "shell": "powershell", "command": "exit 0"}
+
+    def test_posix_hook_post_json_reads_the_port_at_fire_time(self):
+        from agent_team_backend.osplat import _posix_paths
+
+        command = _posix_paths.scripts.hook_post_json(
+            port_file="/tmp/navide.port",
+            header_file="/tmp/hook.header",
+            url_path="/hooks/claude",
+            event="stop",
+            timeout_s=4,
+            keep_body=True,
+        )
+        assert command.startswith("PORT=$(cat /tmp/navide.port 2>/dev/null); ")
+        assert "-o /dev/null" not in command  # the Stop hook's answer is read
+        assert command.endswith('"http://127.0.0.1:$PORT/hooks/claude" || true')
+
+    def test_posix_exit_zero_swallows_a_failed_curl(self):
+        from agent_team_backend.osplat import _posix_paths
+
+        command = _posix_paths.scripts.hook_post_json(
+            port_file="/tmp/navide.port",
+            header_file="/tmp/hook.header",
+            url_path="/hooks/copilot",
+            event="notification",
+            timeout_s=2,
+            exit_zero=True,
+        )
+        assert command.endswith(">/dev/null 2>&1; exit 0")
+
+    def test_windows_hook_post_json_is_a_powershell_one_liner(self):
+        from agent_team_backend.osplat import _windows
+
+        command = _windows.scripts.hook_post_json(
+            port_file=r"C:\Users\a b\navide.port",
+            header_file=r"C:\Users\a b\hook.header",
+            url_path="/hooks/copilot",
+            event="notification",
+            timeout_s=2,
+            exit_zero=True,
+        )
+        assert "\n" not in command
+        # `curl` alone is a PowerShell alias for Invoke-WebRequest, which takes
+        # none of these arguments.
+        assert "curl.exe -fsS -m 2 -o NUL -X POST" in command
+        assert command.startswith(
+            "$PORT = Get-Content -ErrorAction SilentlyContinue 'C:\\Users\\a b\\navide.port'; "
+        )
+        # `@` starts a splat in PowerShell, so both curl `@` arguments are quoted.
+        assert "-H '@C:\\Users\\a b\\hook.header'" in command
+        assert "--data-binary '@-'" in command
+        assert command.endswith('"http://127.0.0.1:$PORT/hooks/copilot" }; exit 0')
+
+    def test_windows_keeps_the_body_when_the_cli_reads_it(self):
+        from agent_team_backend.osplat import _windows
+
+        command = _windows.scripts.hook_post_json(
+            port_file="p",
+            header_file="h",
+            url_path="/hooks/claude",
+            event="stop",
+            timeout_s=4,
+            keep_body=True,
+        )
+        assert "-o NUL" not in command
+
+    def test_windows_rewake_writes_the_body_to_stderr_and_exits_two(self):
+        from agent_team_backend.osplat import _windows
+
+        command = _windows.scripts.hook_rewake(
+            port_file="p", header_file="h", url_path="/hooks/claude/rewake", timeout_s=1860
+        )
+        assert "\n" not in command
+        assert "if (-not $PORT) { exit 0 }" in command
+        assert "$BODY = curl.exe -fsS -m 1860 -X POST" in command
+        assert command.endswith(
+            "if ($BODY) { [Console]::Error.WriteLine($BODY); exit 2 }; exit 0"
+        )
+
+    def test_posix_confirm_then_run_asks_before_running(self):
+        from agent_team_backend.osplat import _posix_paths
+
+        script = _posix_paths.scripts.confirm_then_run("Remove claude", "/usr/bin/npm uninstall")
+        assert script == (
+            "printf '%s\\n' 'Remove claude'; "
+            "printf 'Continue? [y/N] '; read -r answer; "
+            'case "$answer" in [Yy]*) /usr/bin/npm uninstall ;; *) echo \'Cancelled.\' ;; esac'
+        )
+
+    # `external-terminal.ts` runs this through `powershell -NoExit -Command`,
+    # which is a syntax error away from the sh spelling above.
+    def test_windows_confirm_then_run_is_powershell(self):
+        from agent_team_backend.osplat import _windows
+
+        script = _windows.scripts.confirm_then_run(
+            "Remove claude from C:\\a b", '"C:\\a b\\npm.cmd" uninstall -g x'
+        )
+        assert script == (
+            "Write-Host 'Remove claude from C:\\a b'; "
+            "$a = Read-Host 'Continue? [y/N]'; "
+            "if ($a -match '^[Yy]') { & \"C:\\a b\\npm.cmd\" uninstall -g x } "
+            "else { Write-Host 'Cancelled.' }"
+        )
+
+    # A single quote is the one character a PowerShell single-quoted string
+    # cannot carry as-is, and a directory name may well have one.
+    def test_windows_doubles_a_quote_in_the_description(self):
+        from agent_team_backend.osplat import _windows
+
+        script = _windows.scripts.confirm_then_run("Remove o'brien's cli", "npm x")
+        assert "Write-Host 'Remove o''brien''s cli'" in script

--- a/backend/tests/test_osplat_windows_terminal.py
+++ b/backend/tests/test_osplat_windows_terminal.py
@@ -570,6 +570,45 @@ class TestHandle:
         handle._pump.join(1)
         assert not handle._watcher.is_alive() and not handle._pump.is_alive()
 
+    def test_a_chunk_delivered_into_a_closed_loop_ends_the_pump_quietly(
+        self, monkeypatch
+    ):
+        """A pane's loop can go away before its pump does — window close, app
+        shutdown. POSIX reaches that moment with an `add_reader` callback the
+        loop simply stops calling; here it is a cross-thread call into a closed
+        loop, and it must end the pump rather than escape as a thread exception.
+        """
+        import threading
+
+        caught: list[object] = []
+        monkeypatch.setattr(threading, "excepthook", lambda args: caught.append(args))
+
+        pty = _FakePTY(80, 24)
+        parked = threading.Event()
+        opened = threading.Event()
+        pending = ["late output"]
+
+        def read(blocking: bool = False) -> str:
+            opened.set()
+            parked.wait(5)
+            if not pending:
+                raise RuntimeError("Standard out reached EOF")
+            return pending.pop(0)
+
+        pty.read = read  # type: ignore[method-assign]
+        handle = _handle(pty)
+        # A loop of its own: this one is closed under the pump, which is what
+        # the running test loop must not have done to it.
+        loop = asyncio.new_event_loop()
+        handle.start_reading(loop, lambda: None)
+        assert opened.wait(5), "the pump never reached its first read"
+        loop.close()
+        parked.set()
+
+        handle._pump.join(5)
+        assert not handle._pump.is_alive(), "the pump outlived the loop it fed"
+        assert not caught, f"the pump raised on its way out: {caught!r}"
+
     def test_read_without_data_blocks_and_none_at_eof(self):
         handle = _handle(_FakePTY(80, 24))
         with pytest.raises(BlockingIOError):

--- a/backend/tests/test_osplat_windows_terminal.py
+++ b/backend/tests/test_osplat_windows_terminal.py
@@ -687,3 +687,64 @@ class TestResourceProbe:
             lambda: SimpleNamespace(memory_info=lambda: SimpleNamespace(peak_wset=123)),
         )
         assert _windows.resource_probe.peak_rss_bytes() == 123
+
+    def test_the_probe_reports_itself_usable_and_names_its_counter(self):
+        assert _windows.resource_probe.available() is True
+        assert _windows.resource_probe.memory_kind() == "private_bytes"
+
+    # Bytes and seconds, the same units the Darwin and Linux probes report:
+    # the private working set as-is, and user plus system CPU added up.
+    def test_sample_reports_private_bytes_and_total_cpu_seconds(self, monkeypatch):
+        _fake_processes(monkeypatch, {
+            10: _proc(private=4096, rss=999_999, user=1.5, system=0.25),
+            11: _proc(private=8192, rss=999_999, user=600.0, system=0.0),
+        })
+        assert _windows.resource_probe.sample([10, 11]) == {
+            10: (4096, 1.75),
+            11: (8192, 600.0),
+        }
+
+    # RSS on Windows is the working set, which charges a shared DLL to every
+    # process mapping it; it is the fallback only, for a psutil that does not
+    # carry the Windows-only field.
+    def test_sample_falls_back_to_rss_without_a_private_counter(self, monkeypatch):
+        _fake_processes(monkeypatch, {12: _proc(private=None, rss=2048, user=1.0, system=0.0)})
+        assert _windows.resource_probe.sample([12]) == {12: (2048, 1.0)}
+
+    # A pid that died mid-sweep, or that belongs to another user, is absent
+    # rather than zero — so the caller can tell "not measured" from "nothing".
+    def test_a_dead_or_foreign_pid_is_absent_not_zero(self, monkeypatch):
+        _fake_processes(
+            monkeypatch,
+            {13: _proc(private=1024, rss=1024, user=0.0, system=0.0)},
+            missing={14: psutil.NoSuchProcess(14), 15: psutil.AccessDenied(15)},
+        )
+        assert _windows.resource_probe.sample([13, 14, 15]) == {13: (1024, 0.0)}
+
+    def test_impossible_pids_are_never_looked_up(self, monkeypatch):
+        def must_not_run(_pid):
+            raise AssertionError("pid 0 and below are not processes")
+
+        monkeypatch.setattr(_windows.psutil, "Process", must_not_run)
+        assert _windows.resource_probe.sample([0, -1]) == {}
+        assert _windows.resource_probe.sample([]) == {}
+
+
+def _proc(*, private, rss, user, system) -> SimpleNamespace:
+    """One psutil.Process as this probe uses it: memory_info + cpu_times."""
+    memory = SimpleNamespace(rss=rss)
+    if private is not None:
+        memory.private = private
+    return SimpleNamespace(
+        memory_info=lambda: memory,
+        cpu_times=lambda: SimpleNamespace(user=user, system=system),
+    )
+
+
+def _fake_processes(monkeypatch, alive: dict, missing: dict | None = None) -> None:
+    def factory(pid):
+        if missing and pid in missing:
+            raise missing[pid]
+        return alive[pid]
+
+    monkeypatch.setattr(_windows.psutil, "Process", factory)

--- a/backend/tests/test_process_cpu.py
+++ b/backend/tests/test_process_cpu.py
@@ -34,8 +34,9 @@ class TestSyscallSweep:
 
     @pytest.fixture(autouse=True)
     def _sweep_available(self, monkeypatch):
-        # Windows reports the sweep unavailable; the stubbed probe is the
-        # subject here, so the platform gate must not short-circuit it.
+        # The stubbed probe is the subject here, so the availability gate —
+        # which asks the real probe and then the real PATH — must not get a
+        # say in whether the sweep runs.
         monkeypatch.setattr(process_cpu, "available", lambda: True)
 
     def test_reads_the_kernel_counter_without_spawning_anything(self, monkeypatch):
@@ -110,10 +111,38 @@ class TestSweep:
         assert measured == {}
         assert taken_at > 0
 
-    def test_measures_nothing_on_windows(self, monkeypatch):
-        monkeypatch.setattr(process_cpu.sys, "platform", "win32")
+    # The platform probe answers everywhere the backend ships (Windows reads
+    # psutil); `ps` is what is left for a machine where it cannot be resolved,
+    # and a machine with neither measures nothing rather than guessing.
+    def test_the_probe_alone_makes_the_sweep_available(self, monkeypatch):
+        monkeypatch.setattr(process_cpu.osplat.resource_probe, "available", lambda: True)
+        monkeypatch.setattr(process_cpu.shutil, "which", _must_not_run)
+        assert process_cpu.available() is True
+
+    def test_without_a_probe_the_answer_is_whether_ps_exists(self, monkeypatch):
+        monkeypatch.setattr(process_cpu.osplat.resource_probe, "available", lambda: False)
+        monkeypatch.setattr(process_cpu, "_HAS_PS", None)
+        monkeypatch.setattr(process_cpu.shutil, "which", lambda name: None)
         assert process_cpu.available() is False
         assert process_cpu.cpu_times([1])[0] == {}
+        monkeypatch.setattr(process_cpu, "_HAS_PS", None)
+        monkeypatch.setattr(process_cpu.shutil, "which", lambda name: "/bin/ps")
+        assert process_cpu.available() is True
+
+    # A PATH scan on a path that samples on a timer: asked once, then cached.
+    def test_the_ps_lookup_is_resolved_only_once(self, monkeypatch):
+        calls = {"n": 0}
+
+        def counting(name):
+            calls["n"] += 1
+            return "/bin/ps"
+
+        monkeypatch.setattr(process_cpu.osplat.resource_probe, "available", lambda: False)
+        monkeypatch.setattr(process_cpu, "_HAS_PS", None)
+        monkeypatch.setattr(process_cpu.shutil, "which", counting)
+        assert process_cpu.available() is True
+        assert process_cpu.available() is True
+        assert calls["n"] == 1
 
     # The caller divides by the interval between two readings, so the clock has
     # to be read after the subprocess returns — charging its duration to the

--- a/backend/tests/test_rewake_hook.py
+++ b/backend/tests/test_rewake_hook.py
@@ -16,13 +16,18 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 from fastapi.testclient import TestClient
 
 from agent_team_backend import app as app_module
-from agent_team_backend import claude_hooks, hook_auth, push_delivery
+from agent_team_backend import claude_hooks, hook_auth, osplat, push_delivery
 from agent_team_backend.app import app
+from tests import hook_shell
 
 
 @pytest.fixture()
@@ -316,18 +321,85 @@ def test_the_waiter_names_the_secret_file_and_never_the_secret(tmp_path) -> None
     """The command goes into a world-readable settings file; only the path of
     the 0600 header file may appear in it, and curl reads that when it fires."""
     hook = _rewake_hooks(_installed(tmp_path), "SessionStart")[0]
-    assert f"-H @{hook_auth.header_file()}" in hook["command"] or f"-H @'{hook_auth.header_file()}'" in hook["command"]
+    # Which shell's quoting wraps that path (`-H @'/p'` under sh, `-H '@C:\p'`
+    # under PowerShell) is the renderer's business, so the expected text comes
+    # out of the renderer the installer used, not out of a literal here.
+    reference = osplat.scripts.hook_rewake(
+        port_file=str(tmp_path / "port"),
+        header_file=str(hook_auth.header_file()),
+        url_path="/hooks/claude/rewake",
+        timeout_s=1,
+    )
+    named = re.search(
+        r"""-H\s+['"]?@['"]?""" + re.escape(str(hook_auth.header_file())) + r"""['"]?""",
+        reference,
+    )
+    assert named, f"the renderer stopped pointing curl at the header file: {reference!r}"
+    assert named.group(0) in hook["command"]
     assert hook_auth.token() not in hook["command"]
     assert "?t=" not in hook["command"]
 
 
 def test_the_waiter_exits_zero_when_the_backend_has_nothing_to_say(tmp_path) -> None:
-    """Exit 2 is the wake signal, so it must be reachable only with a body."""
-    hook = _rewake_hooks(_installed(tmp_path), "SessionStart")[0]
-    command = hook["command"]
-    assert '[ -n "$BODY" ] || exit 0' in command
-    assert command.rstrip().endswith("exit 2")
-    assert ">&2" in command
+    """Exit 2 is the wake signal, so it must be reachable only with a body.
+
+    Fired rather than read: the control flow that reaches exit 2 is written in
+    whichever shell this box installed the hook for, and the guarantee is the
+    exit code and the stderr the CLI turns into a system reminder — not the
+    spelling either shell uses to get there.
+    """
+    quiet = _fire_waiter(tmp_path / "quiet", b"")
+    assert quiet.returncode == 0, f"an empty answer woke the agent: {quiet.stderr!r}"
+    assert quiet.stderr.strip() == ""
+
+    envelope = b'{"kind":"msg","from":"builder"}'
+    woken = _fire_waiter(tmp_path / "woken", envelope)
+    assert woken.returncode == 2, f"a real answer did not wake the agent: {woken!r}"
+    assert envelope.decode() in woken.stderr
+    assert woken.stdout.strip() == ""
+
+
+def _fire_waiter(home, body: bytes):
+    """Install the hooks, then run the parked waiter against a one-shot server
+    that answers `body`; returns the finished process."""
+    home.mkdir(parents=True, exist_ok=True)
+    port_file = home / "backend.port"
+    settings = home / "settings.json"
+    claude_hooks.install_hooks(str(port_file), settings_file=settings)
+    hook = _rewake_hooks(json.loads(settings.read_text(encoding="utf-8"))["hooks"], "Stop")[0]
+    # Resolved before the server thread starts, so a box with neither shell
+    # skips instead of leaving one waiting out its timeout.
+    argv = hook_shell.shell_argv(hook)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.rfile.read(int(self.headers.get("Content-Length") or 0))
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    server.timeout = 15
+    thread = threading.Thread(target=server.handle_request)
+    thread.start()
+    port_file.write_text(str(server.server_port), encoding="utf-8")
+    try:
+        return subprocess.run(
+            argv,
+            input='{"hook_event_name":"SessionStart","session_id":"session-1"}',
+            text=True,
+            capture_output=True,
+            timeout=20,
+            check=False,
+        )
+    finally:
+        thread.join(timeout=16)
+        server.server_close()
 
 
 def test_reinstalling_does_not_stack_waiters(tmp_path) -> None:

--- a/backend/tests/test_secret_file_protection.py
+++ b/backend/tests/test_secret_file_protection.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import ctypes
 import os
 import stat
+import re
 import subprocess
 import sys
 from types import SimpleNamespace
@@ -342,13 +343,15 @@ class TestWindowsAclForReal:
         )
         assert proc.returncode == 0, proc.stderr
         # `icacls <file>` prints the path, then one `ACCOUNT:(rights)` entry
-        # per ACE, then a summary line.
+        # per ACE, then a summary line ("Successfully processed 1 files;
+        # Failed processing 0 files") — which is why an ACE is recognised by
+        # its shape rather than by skipping lines that look like a summary.
+        ace_re = re.compile(r"^(?P<account>[^:]+):\((?P<rights>[^)]*)\)")
         aces = []
         for line in proc.stdout.splitlines():
             text = line.replace(str(path), "", 1).strip()
-            if not text or "processed file" in text.lower():
-                continue
-            aces.append(text)
+            if ace_re.match(text):
+                aces.append(text)
         assert aces, f"no ACE printed: {proc.stdout!r}"
         user = _windows._current_user()
         assert user

--- a/backend/tests/test_secret_file_protection.py
+++ b/backend/tests/test_secret_file_protection.py
@@ -306,11 +306,26 @@ class TestWindowsAclForReal:
     """The one check that runs `icacls` against the file it just protected.
 
     Everything above stubs the call; this is what proves the flags mean what
-    the command shape claims — that after `write_private_plain` no account but
-    this one appears in the file's DACL.
+    the command shape claims — that after `write_private_plain` no *user*
+    account but this one can reach the file.
+
+    The machine's own principals are not user accounts and they stay. A file
+    created here carries SYSTEM, and for an administrator the local
+    Administrators group, as *explicit* ACEs taken from the creating process
+    token's default DACL: `/inheritance:r` does not touch them because they
+    were never inherited, and `/grant:r` rewrites only the entry it names.
+    Removing them would buy nothing anyway — an administrator holds
+    SeTakeOwnership and can put any DACL back — so this is the same boundary
+    0600 draws on POSIX, where root reads the file too. What must never appear
+    is a second person.
     """
 
-    def test_only_the_current_user_appears_in_the_dacl(self, tmp_path):
+    #: What the OS itself and its administrators are called, as an en-US
+    #: Windows prints them; a localized box would need the SIDs (S-1-5-18,
+    #: S-1-5-32-544) resolved instead, and neither CI nor a dev box is one.
+    _MACHINE_PRINCIPALS = {"nt authority\\system", "builtin\\administrators"}
+
+    def test_no_other_user_account_appears_in_the_dacl(self, tmp_path):
         path = tmp_path / "backend-ws-token"
         osplat.secret_files.write_private_plain(path, b"tok")
         assert path.read_bytes() == b"tok"
@@ -319,7 +334,7 @@ class TestWindowsAclForReal:
         )
         assert proc.returncode == 0, proc.stderr
         # `icacls <file>` prints the path, then one `ACCOUNT:(rights)` entry
-        # per ACE, then a summary line. Every ACE has to name this account.
+        # per ACE, then a summary line.
         aces = []
         for line in proc.stdout.splitlines():
             text = line.replace(str(path), "", 1).strip()
@@ -329,8 +344,15 @@ class TestWindowsAclForReal:
         assert aces, f"no ACE printed: {proc.stdout!r}"
         user = _windows._current_user()
         assert user
+
+        def account_of(ace: str) -> str:
+            return ace.split(":", 1)[0]
+
+        mine = [a for a in aces if account_of(a).split("\\")[-1].casefold() == user.casefold()]
+        assert mine, f"this account cannot reach its own secret: {aces!r}"
         for ace in aces:
-            account = ace.split(":", 1)[0]
-            assert account.split("\\")[-1].casefold() == user.casefold(), (
-                f"unexpected account in the DACL: {ace!r}"
+            if ace in mine:
+                continue
+            assert account_of(ace).casefold() in self._MACHINE_PRINCIPALS, (
+                f"a third party is in the DACL: {ace!r}"
             )

--- a/backend/tests/test_secret_file_protection.py
+++ b/backend/tests/test_secret_file_protection.py
@@ -2,9 +2,11 @@
 
 POSIX is tested against the real implementation on whatever machine runs the
 suite — mode bits are mode bits. The Windows implementation is imported
-directly and run with `crypt32` stubbed, which tests everything *around* the
-Win32 call (the header, the blob marshalling, legacy plaintext, atomicity)
-but not `CryptProtectData` itself; that needs a Windows box.
+directly and run with `crypt32` and `subprocess.run` stubbed, which tests
+everything *around* the Win32 calls (the header, the blob marshalling, legacy
+plaintext, atomicity, the `icacls` command shape) but not `CryptProtectData`
+or `icacls` themselves. Those need a Windows box, and the win32-only class at
+the end of this file is what checks them there.
 """
 
 from __future__ import annotations
@@ -12,7 +14,9 @@ from __future__ import annotations
 import ctypes
 import os
 import stat
+import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -183,13 +187,150 @@ class TestWindowsDpapi:
         with pytest.raises(FileNotFoundError):
             _windows.secret_files.read_private(tmp_path / "missing")
 
-    # Directory ACLs are out of scope on Windows (see `_windows`); the seam
-    # still creates the directory and still reports a missing file.
-    def test_directory_and_harden_are_creation_only(self, tmp_path, crypt32):
+    # Mode bits protect nothing on NTFS, so the seam still has to create the
+    # directory and still has to report a missing file the POSIX way.
+    def test_the_directory_is_created_and_a_missing_file_still_raises(
+        self, tmp_path, crypt32, icacls
+    ):
         target = tmp_path / "a" / "b"
         _windows.secret_files.make_private_dir(target)
         assert target.is_dir()
         with pytest.raises(FileNotFoundError):
             _windows.secret_files.harden_file(tmp_path / "missing")
-        (tmp_path / "present").write_bytes(b"x")
-        _windows.secret_files.harden_file(tmp_path / "present")
+        # Nothing was handed to icacls for a file that does not exist.
+        assert [argv[1] for argv in icacls.argvs] == [str(target)]
+
+
+class _FakeIcacls:
+    """Stands in for `subprocess.run`: records argv, answers as told."""
+
+    def __init__(self) -> None:
+        self.argvs: list[list[str]] = []
+        self.returncode = 0
+        self.raises: Exception | None = None
+
+    def __call__(self, argv, **kwargs):
+        self.argvs.append(list(argv))
+        if self.raises is not None:
+            raise self.raises
+        return SimpleNamespace(returncode=self.returncode, stdout="", stderr="denied")
+
+
+@pytest.fixture
+def icacls(monkeypatch):
+    fake = _FakeIcacls()
+    monkeypatch.setattr(_windows.subprocess, "run", fake)
+    monkeypatch.setenv("USERNAME", "navide")
+    monkeypatch.setattr(_windows.os, "getlogin", lambda: "navide")
+    return fake
+
+
+class TestWindowsOwnerOnlyAcl:
+    """The ACL that replaces mode bits, with `icacls` stubbed."""
+
+    # `/inheritance:r` drops what the parent handed down (SYSTEM,
+    # Administrators, and on a widened tree, Users); `/grant:r` replaces this
+    # account's grant instead of adding a second ACE, so a repeated write does
+    # not accumulate them.
+    def test_write_private_plain_restricts_the_file_after_the_replace(
+        self, tmp_path, crypt32, icacls
+    ):
+        path = tmp_path / "backend-ws-token"
+        _windows.secret_files.write_private_plain(path, b"tok")
+        assert path.read_bytes() == b"tok"
+        assert icacls.argvs == [
+            ["icacls", str(path), "/inheritance:r", "/grant:r", "navide:F"]
+        ]
+
+    def test_harden_file_restricts_an_existing_file(self, tmp_path, crypt32, icacls):
+        path = tmp_path / "hosts.yml"
+        path.write_bytes(b"token: x")
+        _windows.secret_files.harden_file(path)
+        assert icacls.argvs == [
+            ["icacls", str(path), "/inheritance:r", "/grant:r", "navide:F"]
+        ]
+
+    # A directory needs the object and container inherit flags, so the files
+    # written into it afterwards start owner-only too.
+    def test_make_private_dir_grants_inheritable_rights(self, tmp_path, crypt32, icacls):
+        path = tmp_path / "vault"
+        _windows.secret_files.make_private_dir(path)
+        assert icacls.argvs == [
+            ["icacls", str(path), "/inheritance:r", "/grant:r", "navide:(OI)(CI)F"]
+        ]
+
+    # The secret is already written and correct by the time icacls runs. A box
+    # where it is missing or refuses must still start, with the failure in the
+    # log rather than in the caller.
+    def test_a_failing_icacls_is_logged_and_swallowed(self, tmp_path, crypt32, icacls):
+        icacls.returncode = 5
+        path = tmp_path / "token"
+        _windows.secret_files.write_private_plain(path, b"tok")
+        assert path.read_bytes() == b"tok"
+
+        icacls.raises = OSError("icacls not found")
+        _windows.secret_files.write_private_plain(path, b"tok2")
+        assert path.read_bytes() == b"tok2"
+
+        icacls.raises = subprocess.TimeoutExpired("icacls", 10.0)
+        _windows.secret_files.write_private_plain(path, b"tok3")
+        assert path.read_bytes() == b"tok3"
+
+    # No console attached (a service-started backend): `os.getlogin` raises and
+    # the environment is the other place the session's user name is written.
+    def test_the_account_name_falls_back_to_the_environment(
+        self, tmp_path, crypt32, icacls, monkeypatch
+    ):
+        monkeypatch.setattr(_windows.os, "getlogin", _raise_no_console)
+        monkeypatch.setenv("USERNAME", "from-env")
+        _windows.secret_files.write_private_plain(tmp_path / "token", b"t")
+        assert icacls.argvs[0][-1] == "from-env:F"
+
+    def test_without_an_account_name_nothing_is_run(
+        self, tmp_path, crypt32, icacls, monkeypatch
+    ):
+        monkeypatch.setattr(_windows.os, "getlogin", _raise_no_console)
+        monkeypatch.delenv("USERNAME", raising=False)
+        path = tmp_path / "token"
+        _windows.secret_files.write_private_plain(path, b"t")
+        assert path.read_bytes() == b"t"
+        assert icacls.argvs == []
+
+
+def _raise_no_console():
+    raise OSError("no controlling console")
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="a real ACL needs a real NTFS")
+class TestWindowsAclForReal:
+    """The one check that runs `icacls` against the file it just protected.
+
+    Everything above stubs the call; this is what proves the flags mean what
+    the command shape claims — that after `write_private_plain` no account but
+    this one appears in the file's DACL.
+    """
+
+    def test_only_the_current_user_appears_in_the_dacl(self, tmp_path):
+        path = tmp_path / "backend-ws-token"
+        osplat.secret_files.write_private_plain(path, b"tok")
+        assert path.read_bytes() == b"tok"
+        proc = subprocess.run(
+            ["icacls", str(path)], capture_output=True, text=True, timeout=30
+        )
+        assert proc.returncode == 0, proc.stderr
+        # `icacls <file>` prints the path, then one `ACCOUNT:(rights)` entry
+        # per ACE, then a summary line. Every ACE has to name this account.
+        aces = []
+        for line in proc.stdout.splitlines():
+            text = line.replace(str(path), "", 1).strip()
+            if not text or "processed file" in text.lower():
+                continue
+            aces.append(text)
+        assert aces, f"no ACE printed: {proc.stdout!r}"
+        user = _windows._current_user()
+        assert user
+        for ace in aces:
+            account = ace.split(":", 1)[0]
+            assert account.split("\\")[-1].casefold() == user.casefold(), (
+                f"unexpected account in the DACL: {ace!r}"
+            )

--- a/backend/tests/test_secret_file_protection.py
+++ b/backend/tests/test_secret_file_protection.py
@@ -323,7 +323,15 @@ class TestWindowsAclForReal:
     #: What the OS itself and its administrators are called, as an en-US
     #: Windows prints them; a localized box would need the SIDs (S-1-5-18,
     #: S-1-5-32-544) resolved instead, and neither CI nor a dev box is one.
-    _MACHINE_PRINCIPALS = {"nt authority\\system", "builtin\\administrators"}
+    #: OWNER RIGHTS (S-1-3-4) is not a party at all: it is whoever owns the
+    #: file, which is the account that wrote it — the same principal the
+    #: named ACE above grants, spelled the way the creating token's default
+    #: DACL stamps it.
+    _MACHINE_PRINCIPALS = {
+        "nt authority\\system",
+        "builtin\\administrators",
+        "owner rights",
+    }
 
     def test_no_other_user_account_appears_in_the_dacl(self, tmp_path):
         path = tmp_path / "backend-ws-token"

--- a/backend/tests/test_windows_conpty_real.py
+++ b/backend/tests/test_windows_conpty_real.py
@@ -1,0 +1,180 @@
+"""The Windows terminal seam against a real ConPTY and a real child.
+
+Every other Windows terminal test stubs `winpty` and kernel32, which is what
+makes them runnable on any host — but it also means nothing there proves that
+a ConPTY actually delivers output, that a child's exit turns into EOF, or that
+closing a handle takes the process tree with it. Those are properties of the
+operating system, not of our call order, so this file runs only on Windows and
+drives `osplat.terminal_backend.spawn` the way `terminals` does: start the
+reader on the loop, drain with `read` until it would block, and close.
+
+Mirrors `test_terminals_e2e_input.py` (the POSIX end-to-end) one level lower,
+at the seam rather than at `TerminalService`. Every test is bounded by a
+timeout well under ten seconds, and the fixture force-kills whatever is left.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Callable
+
+import psutil
+import pytest
+
+from agent_team_backend import osplat
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="drives a real ConPTY; the other hosts run the stubbed suite instead",
+)
+
+#: Long enough for a child that must still be running when the test acts on it,
+#: short enough that a leaked one cannot outlive the run by much.
+_LONG_SLEEP = "30"
+
+
+@pytest.fixture
+def spawn(tmp_path):
+    """Spawn a Python child on a real ConPTY; kill whatever survives the test."""
+    handles = []
+
+    def make(code: str, *, rows: int = 24, cols: int = 80):
+        handle = osplat.terminal_backend.spawn(
+            [sys.executable, "-u", "-c", code],
+            cwd=str(tmp_path),
+            env={**os.environ, "TERM": "xterm-256color", "PYTHONIOENCODING": "utf-8"},
+            rows=rows,
+            cols=cols,
+        )
+        handles.append(handle)
+        return handle
+
+    yield make
+
+    for handle in handles:
+        try:
+            handle.close()
+        except Exception:  # noqa: BLE001 - teardown must not mask a failure
+            pass
+        _force_kill_tree(handle.pid)
+
+
+def _force_kill_tree(pid: int) -> None:
+    try:
+        root = psutil.Process(pid)
+        targets = root.children(recursive=True) + [root]
+    except psutil.Error:
+        return
+    for proc in targets:
+        try:
+            proc.kill()
+        except psutil.Error:
+            pass
+
+
+async def _drain_until(
+    handle, matched: Callable[[bytes], bool], *, timeout_s: float
+) -> tuple[str, bytes]:
+    """Run the handle's reader on this loop until `matched` or EOF.
+
+    Returns ("match" | "eof" | "timeout", everything read so far). The drain
+    loop is `terminals._on_readable` in miniature: read until `BlockingIOError`,
+    treat None as EOF.
+    """
+    loop = asyncio.get_running_loop()
+    seen: list[bytes] = []
+    done: asyncio.Future[str] = loop.create_future()
+
+    def on_readable() -> None:
+        while True:
+            try:
+                chunk = handle.read(4096)
+            except BlockingIOError:
+                break
+            except OSError:
+                chunk = None
+            if chunk is None:
+                if not done.done():
+                    done.set_result("eof")
+                return
+            seen.append(chunk)
+        if matched(b"".join(seen)) and not done.done():
+            done.set_result("match")
+
+    handle.start_reading(loop, on_readable)
+    try:
+        outcome = await asyncio.wait_for(done, timeout_s)
+    except (asyncio.TimeoutError, TimeoutError):
+        outcome = "timeout"
+    return outcome, b"".join(seen)
+
+
+async def _wait_gone(pids: list[int], *, timeout_s: float) -> list[int]:
+    """Poll until none of `pids` exists; returns whatever is still there."""
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    alive = list(pids)
+    while alive and asyncio.get_running_loop().time() < deadline:
+        alive = [pid for pid in alive if psutil.pid_exists(pid)]
+        if not alive:
+            break
+        await asyncio.sleep(0.1)
+    return alive
+
+
+async def test_child_output_reaches_the_reader_callback(spawn):
+    """What the child writes comes back through the pump, the loop and `read`."""
+    handle = spawn(
+        "import time; print('MARKER-OUT', flush=True); time.sleep(" + _LONG_SLEEP + ")"
+    )
+    outcome, seen = await _drain_until(
+        handle, lambda buf: b"MARKER-OUT" in buf, timeout_s=8.0
+    )
+    assert outcome == "match", f"never saw the marker ({outcome}); read: {seen!r}"
+
+
+async def test_a_child_that_exits_reaches_eof(spawn):
+    """The exit watcher's whole job: ConPTY keeps the pipe open, we make EOF.
+
+    Without it the pump stays parked in ReadFile after the child is gone and
+    the pane never closes — which is what POSIX gets free from the kernel.
+    """
+    handle = spawn("print('BYE', flush=True)")
+    outcome, seen = await _drain_until(handle, lambda buf: False, timeout_s=8.0)
+    assert outcome == "eof", f"no EOF after the child exited ({outcome}): {seen!r}"
+    assert b"BYE" in seen, f"output written before the exit was lost: {seen!r}"
+
+
+async def test_close_kills_the_whole_tree_of_a_running_child(spawn):
+    """`close()` on a live child ends it *and* what it spawned.
+
+    The job object is what makes the grandchild reachable: it was started after
+    the spawn, so no snapshot taken at create time would list it.
+    """
+    handle = spawn(
+        "import subprocess, sys, time; "
+        "kid = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(" + _LONG_SLEEP + ")']); "
+        "print('KID:' + str(kid.pid), flush=True); "
+        "time.sleep(" + _LONG_SLEEP + ")"
+    )
+    outcome, seen = await _drain_until(
+        handle, lambda buf: b"KID:" in buf, timeout_s=8.0
+    )
+    assert outcome == "match", f"the child never reported its kid ({outcome}): {seen!r}"
+    kid_pid = int(seen.split(b"KID:", 1)[1].split()[0])
+    assert psutil.pid_exists(kid_pid)
+
+    handle.close()
+
+    still_alive = await _wait_gone([handle.pid, kid_pid], timeout_s=5.0)
+    assert not still_alive, f"close left these processes running: {still_alive}"
+
+
+async def test_resize_does_not_raise(spawn):
+    """`ResizePseudoConsole` on a live pane, both bigger and smaller."""
+    handle = spawn("import time; time.sleep(" + _LONG_SLEEP + ")", rows=24, cols=80)
+    handle.resize(40, 120)
+    handle.resize(10, 40)
+    handle.resize(24, 80)

--- a/backend/tests/test_windows_conpty_real.py
+++ b/backend/tests/test_windows_conpty_real.py
@@ -55,6 +55,10 @@ def spawn(tmp_path):
 
     for handle in handles:
         try:
+            # Before close, and before this test's loop goes: the pump runs on
+            # a thread of its own and a chunk arriving after the loop is closed
+            # would otherwise be delivered into it.
+            handle.stop_reading()
             handle.close()
         except Exception:  # noqa: BLE001 - teardown must not mask a failure
             pass
@@ -108,6 +112,10 @@ async def _drain_until(
         outcome = await asyncio.wait_for(done, timeout_s)
     except (asyncio.TimeoutError, TimeoutError):
         outcome = "timeout"
+    finally:
+        # Always, including the timeout path: this loop is about to be closed
+        # by the test that owns it, and the pump is still on its own thread.
+        handle.stop_reading()
     return outcome, b"".join(seen)
 
 

--- a/docs/en-US/getting-started.md
+++ b/docs/en-US/getting-started.md
@@ -2,13 +2,15 @@
 
 English | [繁體中文](../zh-TW/getting-started.md) | [日本語](../ja-JP/getting-started.md) | [Documentation](README.md)
 
-Navide supports macOS 13 or newer on Apple silicon. The [v0.1.47 GitHub prerelease](https://github.com/nt-nerdtechnic/Navide/releases/tag/v0.1.47) provides unsigned DMG and ZIP downloads. It is not signed or notarized by Apple.
+Navide supports macOS 13 or newer on Apple silicon, Linux x64, and Windows x64. The [v0.2.1 GitHub release](https://github.com/nt-nerdtechnic/Navide/releases/tag/v0.2.1) provides DMG and ZIP downloads for macOS, signed with a Developer ID certificate and notarized by Apple.
 
-To install the preview, download the DMG, copy Navide to Applications, then Control-click the app in Finder and choose **Open**. If macOS still blocks it, use **System Settings → Privacy & Security → Open Anyway** for Navide. Do not disable Gatekeeper globally.
+To install on macOS, download the DMG and copy Navide to Applications, then open it normally — no Gatekeeper workaround is needed.
+
+Release CI also builds an AppImage and a `.deb` for Linux x64 and an NSIS installer for Windows x64, but no release has published them yet: they ship from the next release, so install from source on those platforms until then. The Windows build is not code-signed, so SmartScreen warns on first run.
 
 ## What you need to install from source
 
-- macOS 13+
+- macOS 13+ on Apple silicon, Linux x64, or Windows x64
 - Node.js 22.12+ (22.x)
 - pnpm 10+
 - Python 3.12+
@@ -19,6 +21,7 @@ To install the preview, download the DMG, copy Navide to Applications, then Cont
   - Antigravity CLI (`agy`)
   - Grok CLI (`grok`)
 - Optional: Ollama or a local GGUF model for local analysis
+- On Windows: Developer Mode (**Settings → For developers**) or running Navide elevated, so it can create the symbolic links behind per-pane CLI homes and managed skills
 
 Each coding CLI has its own installation, authentication, subscription, and data policy. Navide does not replace those requirements.
 

--- a/docs/en-US/roadmap.md
+++ b/docs/en-US/roadmap.md
@@ -208,8 +208,8 @@ Scope:
 - Compatibility test kit and adapter health diagnostics
 - Reusable roles, pipelines, policies, team configurations, and engineering templates
 - Safe template packaging with version and capability metadata
-- Linux support with PTY, paths, permissions, packaging, and update parity
-- Windows support with ConPTY, filesystem behavior, packaging, and policy parity
+- Linux support with PTY, paths, permissions, packaging, and update parity — in `main`, covered by the Linux CI gates and packaged as an AppImage and a `.deb`; remaining work is publishing those installers in a release
+- Windows support with ConPTY, filesystem behavior, packaging, and policy parity — in `main`, covered by the Windows CI gates and packaged as an NSIS installer; remaining work is code signing, Task Scheduler integration, and a graceful CLI shutdown signal
 - Platform and adapter capability matrix
 - Internationalization and accessible workflows
 

--- a/docs/ja-JP/getting-started.md
+++ b/docs/ja-JP/getting-started.md
@@ -2,13 +2,15 @@
 
 [English](../en-US/getting-started.md) | [繁體中文](../zh-TW/getting-started.md) | 日本語 | [ドキュメント](README.md)
 
-Navide は Apple silicon 上の macOS 13 以降をサポートします。[v0.1.47 GitHub Prerelease](https://github.com/nt-nerdtechnic/Navide/releases/tag/v0.1.47) では、未署名の DMG と ZIP を提供しています。Apple による署名も Notarization も行われていません。
+Navide は Apple silicon 上の macOS 13 以降、Linux x64、Windows x64 をサポートします。[v0.2.1 GitHub Release](https://github.com/nt-nerdtechnic/Navide/releases/tag/v0.2.1) では、macOS 向けの DMG と ZIP を提供しています。Developer ID で署名され、Apple の Notarization を通過しています。
 
-Preview をインストールするには、DMG をダウンロードして Navide を Applications にコピーし、Finder でアプリを Control-click して**開く**を選択します。それでも macOS にブロックされる場合は、Navide に対して**システム設定 → プライバシーとセキュリティ → このまま開く**を使用してください。Gatekeeper をシステム全体で無効化しないでください。
+macOS にインストールするには、DMG をダウンロードして Navide を Applications にコピーし、そのまま開きます。Gatekeeper の回避は不要です。
+
+Release CI は Linux x64 向けに AppImage と `.deb` を、Windows x64 向けに NSIS Installer もビルドしますが、まだどのリリースでも配布されていません。これらは次のリリースから配布されるため、それまでこの 2 つの Platform では Source からインストールしてください。Windows Build は Code Signing されていないため、初回起動時に SmartScreen が警告します。
 
 ## Source からインストールするために必要なもの
 
-- macOS 13+
+- Apple silicon 上の macOS 13+、Linux x64、または Windows x64
 - Node.js 22.12+（22.x）
 - pnpm 10+
 - Python 3.12+
@@ -19,6 +21,7 @@ Preview をインストールするには、DMG をダウンロードして Navi
   - Antigravity CLI (`agy`)
   - Grok CLI (`grok`)
 - 任意：Local Analysis 用の Ollama または Local GGUF Model
+- Windows の場合：開発者モード（**設定 → 開発者向け**）、または Navide を管理者権限で実行すること。Pane ごとの CLI Home と管理対象の Skills を支える Symbolic Link の作成に必要です
 
 各 Coding CLI には、それぞれ独自の Installation、Authentication、Subscription、Data Policy があります。Navide はそれらの要件を置き換えません。
 

--- a/docs/ja-JP/roadmap.md
+++ b/docs/ja-JP/roadmap.md
@@ -208,8 +208,8 @@ Scope：
 - Compatibility Test Kit と Adapter Health Diagnostics
 - 再利用可能な Role、Pipeline、Policy、Team Configuration、Engineering Template
 - Version と Capability Metadata を持つ安全な Template Packaging
-- PTY、Path、Permission、Packaging、Update が同等な Linux Support
-- ConPTY、Filesystem Behavior、Packaging、Policy が同等な Windows Support
+- PTY、Path、Permission、Packaging、Update が同等な Linux Support——`main` に取り込み済み。Linux CI Gate が対象とし、AppImage と `.deb` としてパッケージ化。残る作業はこれらの Installer をリリースで配布すること
+- ConPTY、Filesystem Behavior、Packaging、Policy が同等な Windows Support——`main` に取り込み済み。Windows CI Gate が対象とし、NSIS Installer としてパッケージ化。残る作業は Code Signing、Task Scheduler 統合、CLI を穏当に停止させるシグナル
 - Platform と Adapter の Capability Matrix
 - Internationalization と Accessible Workflow
 

--- a/docs/zh-TW/getting-started.md
+++ b/docs/zh-TW/getting-started.md
@@ -2,13 +2,15 @@
 
 [English](../en-US/getting-started.md) | 繁體中文 | [日本語](../ja-JP/getting-started.md) | [文件中心](README.md)
 
-Navide 支援配備 Apple 晶片且執行 macOS 13 以上版本的 Mac。[v0.1.47 GitHub Prerelease](https://github.com/nt-nerdtechnic/Navide/releases/tag/v0.1.47) 提供未簽章的 DMG 與 ZIP 下載；這些檔案尚未經 Apple 簽章或 Notarization。
+Navide 支援配備 Apple 晶片且執行 macOS 13 以上版本的 Mac，以及 Linux x64 與 Windows x64。[v0.2.1 GitHub Release](https://github.com/nt-nerdtechnic/Navide/releases/tag/v0.2.1) 提供 macOS 的 DMG 與 ZIP 下載，並已經 Developer ID 簽章與 Apple Notarization。
 
-若要安裝 Preview，請下載 DMG、將 Navide 複製到「應用程式」，然後在 Finder 中按住 Control 點擊 App 並選擇「打開」。若 macOS 仍阻擋執行，請前往「系統設定 → 隱私權與安全性」，針對 Navide 選擇「強制打開」。請勿停用整個系統的 Gatekeeper。
+若要在 macOS 安裝，請下載 DMG、將 Navide 複製到「應用程式」，接著正常開啟即可，無需繞過 Gatekeeper。
+
+Release CI 也會為 Linux x64 建置 AppImage 與 `.deb`、為 Windows x64 建置 NSIS 安裝程式，但尚未有任何版本發行這些檔案：它們將自下一個版本起隨發行提供，在此之前請於這兩個平台從原始碼安裝。Windows 版本尚未經過程式碼簽章，首次執行時 SmartScreen 會出現警告。
 
 ## 從原始碼安裝的前置需求
 
-- macOS 13+
+- 配備 Apple 晶片的 macOS 13+、Linux x64 或 Windows x64
 - Node.js 22.12+（22.x）
 - pnpm 10+
 - Python 3.12+
@@ -19,6 +21,7 @@ Navide 支援配備 Apple 晶片且執行 macOS 13 以上版本的 Mac。[v0.1.4
   - Antigravity CLI（`agy`）
   - Grok CLI（`grok`）
 - 選用：用於本機分析的 Ollama 或本機 GGUF 模型
+- Windows 專屬：開發人員模式（**設定 → 開發人員專用**）或以系統管理員身分執行 Navide，Navide 才能建立每個 Pane 的 CLI Home 與受管理 Skills 所需的符號連結
 
 每個 Coding CLI 都有自己的安裝、驗證、訂閱與資料政策。Navide 不會取代這些需求。
 

--- a/docs/zh-TW/roadmap.md
+++ b/docs/zh-TW/roadmap.md
@@ -208,8 +208,8 @@ Exit Criteria：
 - Compatibility Test Kit 與 Adapter Health Diagnostics
 - 可重用 Role、Pipeline、Policy、Team Configuration 與 Engineering Template
 - 具有 Version 與 Capability Metadata 的安全 Template Packaging
-- 具有 PTY、Path、Permission、Packaging 與 Update 對等性的 Linux Support
-- 具有 ConPTY、Filesystem Behavior、Packaging 與 Policy 對等性的 Windows Support
+- 具有 PTY、Path、Permission、Packaging 與 Update 對等性的 Linux Support——已在 `main`，由 Linux CI Gate 涵蓋，並打包為 AppImage 與 `.deb`；剩餘工作是在發行版中提供這些安裝檔
+- 具有 ConPTY、Filesystem Behavior、Packaging 與 Policy 對等性的 Windows Support——已在 `main`，由 Windows CI Gate 涵蓋，並打包為 NSIS 安裝程式；剩餘工作是程式碼簽章、Task Scheduler 整合，以及可優雅關閉 CLI 的訊號
 - Platform 與 Adapter Capability Matrix
 - Internationalization 與 Accessible Workflow
 

--- a/src/main/plugins/pluginBackendSupervisor.test.ts
+++ b/src/main/plugins/pluginBackendSupervisor.test.ts
@@ -1408,7 +1408,9 @@ describe('PluginBackendSupervisor', () => {
     await supervisor.start()
 
     await expect(supervisor.clientFor(authenticatedRuntime).call('fixture.stderr', null)).resolves.toEqual({ ok: true })
-    expect(stderr).toHaveBeenCalledWith('fixture diagnostic: /private/internal/path\n')
+    // The reply and the stderr line travel on different streams, so the call
+    // can resolve first; wait for the line rather than assuming it landed.
+    await vi.waitFor(() => expect(stderr).toHaveBeenCalledWith('fixture diagnostic: /private/internal/path\n'))
   })
 
   it('emits host-only diagnostic and original cause on sync spawn error before generic failure', async () => {


### PR DESCRIPTION
An audit of what the Windows CI job actually verifies (vs. what it skips or stubs) found features that are inert on Windows and shell text only a POSIX shell could run. This fixes them; each change is behind an `osplat` seam, and the platform-branch ratchet loses an entry rather than gaining one.

- **Resource probe** — `WindowsResourceProbe` samples with psutil (`private` bytes, falling back to `rss`; user+system CPU), so the resource manager's CPU/memory columns fill in. `process_cpu.available()` now asks the probe and then for a real `ps`, so it no longer branches on the platform.
- **Secret file ACLs** — plaintext secrets (ws token, hook auth header, MCP and gh/glab configs) get `icacls /inheritance:r /grant:r "<user>:F"`; `harden_file`/`make_private_dir` stop being no-ops. Every failure is logged and swallowed.
- **Frozen askpass** — new `--askpass-helper` entry mode, dispatched before the app import because git reads the first stdout line as the credential. The launcher names that executable on every platform, instead of relying on a `python3` on PATH (a trap on macOS and Linux too, not just the Microsoft Store stub on Windows).
- **Per-shell script text** — new `osplat.scripts` seam: Claude hook entries declare `shell: "powershell"` with a PowerShell one-liner on Windows, Copilot hooks carry both `bash` and `powershell` keys, and the CLI-health removal prompt is `Read-Host` rather than sh's `read -r` handed to PowerShell.
- **Real Windows tests** — new win32-only tests spawn a real ConPTY (output delivery, exit EOF, `close()` killing the tree, resize) and read back a real ACL. The Windows job had been proving the terminal against stubs alone.

Verification: macOS `ruff check backend` clean, `pytest backend/tests` **5375 passed, 9 skipped, 0 failed**; POSIX hook text is byte-identical to before. The win32-only tests are what this PR's Windows job is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
