### PR TITLE
Give powershell.exe room to start in the hook test harness

### DIFF
--- a/backend/tests/test_claude_delegated_refresh.py
+++ b/backend/tests/test_claude_delegated_refresh.py
@@ -185,7 +185,10 @@ async def test_missing_cli_is_reported_and_briefly_gated(
     )
 
     assert await dr.attempt(FakeVault()) == dr.OUTCOME_CLI_UNAVAILABLE
-    assert 0 < dr.cooldown_remaining_seconds() <= dr.SHORT_COOLDOWN_S
+    # The bound is approximate on purpose: monotonic() counts from boot, so
+    # (t + 20.0) - t is 20.000000000000057 in float64 on a machine that has
+    # been up a while — as the Windows runner is.
+    assert 0 < dr.cooldown_remaining_seconds() == pytest.approx(dr.SHORT_COOLDOWN_S, abs=0.5)
 
 
 async def test_no_baseline_means_unobservable_and_no_probe(

--- a/backend/tests/test_claude_hooks.py
+++ b/backend/tests/test_claude_hooks.py
@@ -42,7 +42,9 @@ def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
             pass
 
     server = HTTPServer(("127.0.0.1", 0), Handler)
-    server.timeout = 5
+    # Generous because powershell.exe can take seconds to start on a busy
+    # Windows runner; sh returns long before any of these are reached.
+    server.timeout = 30
     thread = threading.Thread(target=server.handle_request)
     thread.start()
     port_file.write_text(str(server.server_port), encoding="utf-8")
@@ -50,10 +52,10 @@ def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
 
     try:
         result = subprocess.run(
-            argv, input=payload, text=True, capture_output=True, timeout=10, check=False
+            argv, input=payload, text=True, capture_output=True, timeout=40, check=False
         )
     finally:
-        thread.join(timeout=6)
+        thread.join(timeout=31)
         server.server_close()
 
     assert received == [payload.encode()]

--- a/backend/tests/test_claude_hooks.py
+++ b/backend/tests/test_claude_hooks.py
@@ -4,9 +4,42 @@ import subprocess
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
+import psutil
+
 from agent_team_backend import osplat
 from agent_team_backend.claude_hooks import _build_curl_command
 from tests import hook_shell
+
+
+def _run_to_completion(
+    argv: list[str], payload: str, *, timeout: float
+) -> subprocess.CompletedProcess[str]:
+    """Run the hook, and on a timeout take its whole tree down with it.
+
+    `subprocess.run` kills only the process it started, so a hook that hangs
+    would leave the curl it spawned behind — and on Windows a survivor of the
+    test session has been enough to stop the CI job from ever finishing.
+    """
+    process = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        stdout, stderr = process.communicate(payload, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            root = psutil.Process(process.pid)
+            for child in root.children(recursive=True):
+                child.kill()
+        except psutil.Error:
+            pass
+        process.kill()
+        process.communicate()
+        raise
+    return subprocess.CompletedProcess(argv, process.returncode, stdout, stderr)
 
 
 def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
@@ -42,20 +75,19 @@ def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
             pass
 
     server = HTTPServer(("127.0.0.1", 0), Handler)
-    # Generous because powershell.exe can take seconds to start on a busy
-    # Windows runner; sh returns long before any of these are reached.
-    server.timeout = 30
+    # Room for powershell.exe to start on a busy Windows runner — sh returns
+    # long before any of these — but not so much room that a hook which hangs
+    # keeps the suite (and the runner) busy for a minute.
+    server.timeout = 20
     thread = threading.Thread(target=server.handle_request)
     thread.start()
     port_file.write_text(str(server.server_port), encoding="utf-8")
     payload = '{"hook_event_name":"Stop","session_id":"session-1"}'
 
     try:
-        result = subprocess.run(
-            argv, input=payload, text=True, capture_output=True, timeout=40, check=False
-        )
+        result = _run_to_completion(argv, payload, timeout=20)
     finally:
-        thread.join(timeout=31)
+        thread.join(timeout=21)
         server.server_close()
 
     assert received == [payload.encode()]


### PR DESCRIPTION
main's Windows job timed out in `test_stop_hook_puts_the_response_on_stdout_where_the_cli_reads_decisions`: the harness allowed the hook 10 s end to end, and Windows PowerShell 5.1 can take seconds to start on a runner that has just spawned thousands of processes. The same test passed twice on the PR branch, so this is start-up latency, not behaviour. sh returns long before any of these caps, so POSIX timing is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)