### PR TITLE
Start the server-link settle window after the hello, not before it

### DIFF
--- a/backend/tests/test_server_link_verification.py
+++ b/backend/tests/test_server_link_verification.py
@@ -330,17 +330,23 @@ def _running_link(server: ScriptedServer) -> ServerLink:
 
 
 async def _run_briefly(link: ServerLink, seconds: float, until=None) -> None:
-    """Run the link for `seconds`, or until `until()` holds when one is given:
-    a fixed 0.2 s window lost a race on the Windows runner (timer slices are
-    ~15 ms there), and the outcome-shaped tests only need the hello to land."""
+    """Run the link for `seconds`; when `until` is given, wait for it to hold
+    first and only then start that window.
+
+    A window measured from the task's first tick lost races on the Windows
+    runner, where timer slices are ~15 ms: the link had not even connected
+    when it closed. Waiting for the thing under test to happen and then
+    watching for `seconds` is both steadier and stricter — the quiet the
+    caller asserts is quiet *after* the event, not instead of it.
+    """
     task = asyncio.create_task(link._run())
     try:
-        if until is None:
-            await asyncio.sleep(seconds)
-        else:
-            deadline = asyncio.get_running_loop().time() + max(seconds, 2.0)
-            while not until() and asyncio.get_running_loop().time() < deadline:
+        if until is not None:
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + max(seconds, 2.0)
+            while not until() and loop.time() < deadline:
                 await asyncio.sleep(0.01)
+        await asyncio.sleep(seconds)
     finally:
         link._stopped = True
         task.cancel()
@@ -364,7 +370,7 @@ async def test_a_verified_account_does_not_reconnect_in_a_loop(
     server = ScriptedServer(verified=True, status=[])
     link = _running_link(server)
 
-    await _run_briefly(link, 0.3)
+    await _run_briefly(link, 0.3, until=lambda: server.hellos >= 1)
 
     assert server.hellos == 1
 
@@ -381,7 +387,7 @@ async def test_an_old_server_does_not_provoke_a_reconnect_loop_either(
     server = ScriptedServer(verified=False, status=[])  # every status: UNKNOWN_TYPE
     link = _running_link(server)
 
-    await _run_briefly(link, 0.3)
+    await _run_briefly(link, 0.3, until=lambda: server.hellos >= 1)
 
     assert server.hellos == 1
 


### PR DESCRIPTION
The release workflow's Windows gate failed `test_a_verified_account_does_not_reconnect_in_a_loop` and `test_an_old_server_does_not_provoke_a_reconnect_loop_either` with `assert 0 == 1`. Both measured their 0.3 s window from the task's first tick; on a Windows runner, where timer slices are ~15 ms, the link had not connected before the window closed.

`_run_briefly` now waits for the caller's predicate first and only then runs the window, so the quiet these tests assert is quiet *after* the hello rather than instead of it — steadier and stricter at once. POSIX timing is unchanged (the predicate holds almost immediately there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)