### PR TITLE
Launch programs the way each platform can run them

### DIFF
--- a/backend/agent_team_backend/ai_chat_cli_engine.py
+++ b/backend/agent_team_backend/ai_chat_cli_engine.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import shutil
 from pathlib import Path
 from typing import Any
 
@@ -49,7 +48,7 @@ def resolve_cli_binary(engine: str = "claude") -> str:
     override = onboarding_deps.cli_binary_override(spec["agent_key"])
     if override:
         return override
-    return shutil.which(spec["command"]) or ""
+    return osplat.paths.resolve_program(spec["command"]) or ""
 
 
 def _cwd_for(workspace_path: str) -> str | None:
@@ -105,9 +104,12 @@ async def run_cli_text(
         raise RuntimeError(
             f"{engine} CLI not found — install it or select a binary in onboarding."
         )
-    args = [binary, "-p", prompt, "--output-format", "text"]
+    cli_args = ["-p", prompt, "--output-format", "text"]
     if system_prompt:
-        args += ["--append-system-prompt", system_prompt]
+        cli_args += ["--append-system-prompt", system_prompt]
+    # Through the interpreter the binary needs: an npm-installed CLI is a
+    # `.cmd` shim on Windows, which CreateProcess cannot start on its own.
+    args = osplat.paths.launch_argv(binary, cli_args)
     try:
         proc = await asyncio.create_subprocess_exec(
             *args,

--- a/backend/agent_team_backend/analyzer.py
+++ b/backend/agent_team_backend/analyzer.py
@@ -15,9 +15,10 @@ import json
 import logging
 import os
 import re
-import shutil
 from pathlib import Path
 from typing import Any
+
+from . import osplat
 
 log = logging.getLogger("agent_team_backend.analyzer")
 
@@ -233,8 +234,12 @@ async def _run_llama_cli(
             f"<|im_start|>user\n{user_message}<|im_end|>\n"
             f"<|im_start|>assistant\n"
         )
-        cmd = [
-            cli,
+        # Resolved through the seam, then started through whatever runs it: a
+        # llama.cpp shipped as a script wrapper is a `.cmd` on Windows. A name
+        # nothing on PATH answers to is kept as it is, so the failure stays
+        # the FileNotFoundError that names it.
+        program = osplat.paths.resolve_program(cli) or cli
+        cmd = osplat.paths.launch_argv(program, [
             "-m", str(gguf_path),
             "-p", full_prompt,
             "-no-cnv",              # single-shot, no interactive loop
@@ -245,7 +250,7 @@ async def _run_llama_cli(
             "-c", str(CONTEXT_SIZE),
             # NOTE: do NOT add --log-disable — it suppresses generated text too.
             # Logs go to stderr (we now parse them for token counts).
-        ]
+        ])
         log.debug("llama-cli spawn: %s -m %s ngl=%d ...", cli, gguf_path.name, n_gpu_layers)
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -541,13 +546,13 @@ async def health(
 ) -> dict[str, Any]:
     """Check if llama-cli is in PATH and executable, and (if set) that the GGUF file exists."""
     cli = llama_cli_override or LLAMA_CLI
-    cli_path = shutil.which(cli)
+    cli_path = osplat.paths.resolve_program(cli)
     if not cli_path:
         return {"ok": False, "error": f"'{cli}' not found in PATH"}
     proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
-            cli_path, "--version",
+            *osplat.paths.launch_argv(cli_path, ["--version"]),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/backend/agent_team_backend/app.py
+++ b/backend/agent_team_backend/app.py
@@ -8,8 +8,6 @@ import mimetypes
 import os
 import re
 import secrets
-import shlex
-import shutil
 import signal
 import subprocess
 import threading
@@ -2465,6 +2463,21 @@ def _with_replaced_executable(command: Any, text: str, executable: str) -> Any:
     return replaced
 
 
+def _names_a_known_command(program: str, names: "tuple[str, ...]") -> bool:
+    """Whether `program` is one of `names`, as this platform spells them.
+
+    A Windows PATH lookup answers `claude.cmd`, so comparing the bare stem
+    against the pinned name would say no and leave the rewrite undone — the
+    very rewrite that exists to make the spawn work.
+    """
+    spelled = {
+        candidate.casefold()
+        for name in names
+        for candidate in osplat.paths.executable_candidates(name)
+    }
+    return Path(program).name.casefold() in spelled
+
+
 def _command_with_persisted_cli_binary(agent_key: str, command: Any) -> Any:
     """Replace the CLI executable while preserving shell flags and list wrappers."""
     selected = onboarding_deps.cli_binary_override(agent_key)
@@ -2473,10 +2486,10 @@ def _command_with_persisted_cli_binary(agent_key: str, command: Any) -> Any:
         return command
     text = _command_text(command)
     try:
-        parts = shlex.split(text)
-    except ValueError:
+        parts = osplat.terminal_backend.parse_command(text)
+    except (ValueError, OSError):
         return command
-    if not parts or Path(parts[0]).name != dep.check_cmd[0]:
+    if not parts or not _names_a_known_command(parts[0], (dep.check_cmd[0],)):
         return command
     return _with_replaced_executable(command, text, selected)
 
@@ -2494,12 +2507,12 @@ def _command_with_installed_cli_alias(agent_key: str, command: Any) -> Any:
         return command
     text = _command_text(command)
     try:
-        parts = shlex.split(text)
-    except ValueError:
+        parts = osplat.terminal_backend.parse_command(text)
+    except (ValueError, OSError):
         return command
-    if not parts or Path(parts[0]).name not in (dep.check_cmd[0], *dep.alt_commands):
+    if not parts or not _names_a_known_command(parts[0], (dep.check_cmd[0], *dep.alt_commands)):
         return command
-    if shutil.which(parts[0]):
+    if osplat.paths.resolve_program(parts[0]):
         return command  # the requested name resolves — nothing to fix
     installed = onboarding_deps.resolve_executable(dep)
     if not installed:
@@ -2557,13 +2570,13 @@ def _probe_agent_cli_for_spawn(agent_key: str, requested_command: Any = None) ->
         return None
     executable = None
     try:
-        command_parts = shlex.split(_command_text(requested_command))
-    except ValueError:
+        command_parts = osplat.terminal_backend.parse_command(_command_text(requested_command))
+    except (ValueError, OSError):
         command_parts = []
     requested_executable = command_parts[0] if command_parts else ""
     known_names = (dep.check_cmd[0], *dep.alt_commands)
-    if requested_executable and Path(requested_executable).name in known_names:
-        executable = shutil.which(requested_executable)
+    if requested_executable and _names_a_known_command(requested_executable, known_names):
+        executable = osplat.paths.resolve_program(requested_executable)
     executable = executable or onboarding_deps.resolve_executable(dep)
     if not executable:
         raise AgentCliProbeError(
@@ -2579,7 +2592,10 @@ def _probe_agent_cli_for_spawn(agent_key: str, requested_command: Any = None) ->
     executable_display = (
         f"{executable} → {resolved}" if resolved != executable else executable
     )
-    command = [executable, *dep.check_cmd[1:]]
+    # The interpreter included: a Windows CLI installed by npm is a `.cmd`
+    # shim, which only cmd.exe can start. Reported as the probe command too,
+    # so the detail names what actually ran.
+    command = osplat.paths.launch_argv(executable, dep.check_cmd[1:])
     started = time.monotonic()
     try:
         proc = subprocess.run(

--- a/backend/agent_team_backend/app.py
+++ b/backend/agent_team_backend/app.py
@@ -2468,13 +2468,16 @@ def _names_a_known_command(program: str, names: "tuple[str, ...]") -> bool:
 
     A Windows PATH lookup answers `claude.cmd`, so comparing the bare stem
     against the pinned name would say no and leave the rewrite undone — the
-    very rewrite that exists to make the spawn work.
+    very rewrite that exists to make the spawn work. The pinned name itself
+    stays accepted: a pane command names the CLI without an extension, which
+    is not among the candidates Windows would try on PATH.
     """
-    spelled = {
+    spelled = {name.casefold() for name in names}
+    spelled.update(
         candidate.casefold()
         for name in names
         for candidate in osplat.paths.executable_candidates(name)
-    }
+    )
     return Path(program).name.casefold() in spelled
 
 

--- a/backend/agent_team_backend/cli_vendors/claude.py
+++ b/backend/agent_team_backend/cli_vendors/claude.py
@@ -720,7 +720,7 @@ async def read_usage_panel(binary: str) -> str:
     a timeout, a non-zero exit with the CLI's first stderr line, or — when the
     exit carried no usage line at all — a note that the CLI needs updating."""
     proc = await asyncio.create_subprocess_exec(
-        binary, *USAGE_ARGS,
+        *osplat.paths.launch_argv(binary, USAGE_ARGS),
         stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -923,8 +923,7 @@ async def _run_probe(binary: str, timeout: float) -> tuple[bool, str]:
 
     try:
         proc = await asyncio.create_subprocess_exec(
-            binary,
-            *_PROBE_ARGS,
+            *osplat.paths.launch_argv(binary, _PROBE_ARGS),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             env=_refresh_probe_env(),

--- a/backend/agent_team_backend/cli_vendors/copilot.py
+++ b/backend/agent_team_backend/cli_vendors/copilot.py
@@ -107,11 +107,11 @@ import yaml
 
 import asyncio
 import re
-import shutil
 import sqlite3
 import sys
 import time
 
+from .. import osplat
 from .base import Dep, McpServerConfig, McpValue, McpWiring, SkillsWiring, VendorSpec, command_text
 from ..usage_common import (
     HTTP_TIMEOUT,
@@ -1112,12 +1112,14 @@ async def _copilot_gh_token(login: str, host: str) -> str | None:
     Keychain and prints them read-only without prompting or rotating anything
     (verified live). None when gh is missing, fails or prints nothing; gh's
     active account may differ from Copilot's, hence the explicit ``--user``."""
-    binary = shutil.which("gh")
+    binary = osplat.paths.resolve_program("gh")
     if not binary:
         return None
     try:
         proc = await asyncio.create_subprocess_exec(
-            binary, "auth", "token", "--user", login, "--hostname", host,
+            *osplat.paths.launch_argv(
+                binary, ("auth", "token", "--user", login, "--hostname", host)
+            ),
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
         )
         out = await _communicate_or_kill(proc, timeout=COPILOT_GH_TOKEN_TIMEOUT)

--- a/backend/agent_team_backend/cli_vendors/grok.py
+++ b/backend/agent_team_backend/cli_vendors/grok.py
@@ -33,10 +33,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import asyncio
-import shutil
 import time
 from typing import Any
 
+from .. import osplat
 from .base import Dep, McpServerConfig, McpValue, McpWiring, SkillsWiring, VendorSpec
 from ..usage_common import _num, _snapshot, _window
 from ..log_readers.base import (
@@ -610,7 +610,7 @@ async def grok_billing_rpc(binary: str, env: dict | None = None) -> dict:
     ``env`` (``None`` = inherit the parent environment) lets a profile point the
     CLI at its isolated ``HOME`` shim so billing reflects that account."""
     proc = await asyncio.create_subprocess_exec(
-        binary, "agent", "stdio",
+        *osplat.paths.launch_argv(binary, ("agent", "stdio")),
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
@@ -661,7 +661,7 @@ async def fetch_grok(home: Path, env: dict | None = None) -> dict:
     creds = read_grok_credentials(home, env)
     if creds is None:
         return _snapshot("grok", "no-credentials")
-    binary = shutil.which("grok")
+    binary = osplat.paths.resolve_program("grok")
     if not binary:
         return _snapshot("grok", "unavailable", error="grok CLI not found")
     try:

--- a/backend/agent_team_backend/host_shell.py
+++ b/backend/agent_team_backend/host_shell.py
@@ -250,6 +250,22 @@ def validate_argv(args: Sequence[str]) -> list[str]:
     return list(args)
 
 
+def _launch_argv(argv: Sequence[str], env: Mapping[str, str] | None) -> list[str] | None:
+    """`argv` resolved to a real file and wrapped in whatever starts it.
+
+    The allowlist check above stays on the bare name — resolution happens
+    after it, so it is still `gh` that is permitted and never a path the
+    caller chose. What resolution adds is the extension: `gh` installed by
+    npm or scoop on Windows is a `gh.cmd` shim, which `CreateProcess` only
+    appends `.exe` for and therefore cannot see. None when nothing on PATH
+    answers to the name, which the callers report the way a failed exec did.
+    """
+    program = paths.resolve_program(argv[0], path=(env or {}).get("PATH"))
+    if not program:
+        return None
+    return paths.launch_argv(program, argv[1:])
+
+
 def parse_allowlisted_command(command: str) -> list[str]:
     """Parse a display-oriented command without enabling shell syntax."""
     if not isinstance(command, str) or not command.strip() or _SHELL_SYNTAX.search(command):
@@ -767,10 +783,13 @@ async def run_allowlisted(
         argv = validate_argv(args)
     except ValueError as exc:
         return 126, b"", str(exc).encode("utf-8")
+    launch = _launch_argv(argv, env)
+    if launch is None:
+        return 127, b"", f"{argv[0]} not found".encode()
     process: asyncio.subprocess.Process | None = None
     try:
         process = await asyncio.create_subprocess_exec(
-            *argv,
+            *launch,
             cwd=cwd,
             env=dict(env) if env is not None else None,
             stdin=asyncio.subprocess.PIPE if input_bytes is not None else None,
@@ -855,10 +874,13 @@ async def run_allowlisted_capped(
         argv = validate_argv(args)
     except ValueError as exc:
         return 126, b"", str(exc).encode("utf-8"), False
+    launch = _launch_argv(argv, env)
+    if launch is None:
+        return 127, b"", f"{argv[0]} not found".encode(), False
     process: asyncio.subprocess.Process | None = None
     try:
         process = await asyncio.create_subprocess_exec(
-            *argv,
+            *launch,
             cwd=cwd,
             env=dict(env) if env is not None else None,
             stdin=None,

--- a/backend/agent_team_backend/onboarding_deps.py
+++ b/backend/agent_team_backend/onboarding_deps.py
@@ -332,7 +332,7 @@ def resolve_executable(dep: Dep) -> str:
     installed CLI as missing and blocks its spawn.
     """
     for name in (dep.check_cmd[0], *dep.alt_commands):
-        found = shutil.which(name)
+        found = osplat.paths.resolve_program(name)
         if found:
             return found
     return ""
@@ -359,7 +359,8 @@ def detect_dep(dep: Dep, quick: bool = False) -> dict[str, Any]:
         started = time.monotonic()
         try:
             proc = subprocess.run(
-                [binary_path, *dep.check_cmd[1:]], capture_output=True, text=True, timeout=8
+                osplat.paths.launch_argv(binary_path, dep.check_cmd[1:]),
+                capture_output=True, text=True, timeout=8,
             )
             duration_ms = max(0, round((time.monotonic() - started) * 1000))
             exit_code = proc.returncode
@@ -456,7 +457,7 @@ def _probe_alternate(dep: Dep, executable: str) -> dict[str, Any]:
     status = "failed"
     try:
         proc = subprocess.run(
-            [executable, *dep.check_cmd[1:]],
+            osplat.paths.launch_argv(executable, dep.check_cmd[1:]),
             capture_output=True,
             text=True,
             timeout=3,

--- a/backend/agent_team_backend/osplat/_darwin.py
+++ b/backend/agent_team_backend/osplat/_darwin.py
@@ -9,6 +9,7 @@ asked.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 from .. import proc_rusage
@@ -100,6 +101,18 @@ class DarwinLayout(DarwinPaths):
 
     def quote_arg(self, arg: str) -> str:
         return _posix_paths.quote_arg(arg)
+
+    def resolve_program(self, name_or_path: str, *, path: str | None = None) -> str | None:
+        return _posix_paths.resolve_program(name_or_path, path=path)
+
+    def launch_kind(self, program: str) -> str:
+        return _posix_paths.launch_kind(program)
+
+    def launch_argv(self, program: str, args: Sequence[str] = ()) -> list[str]:
+        return _posix_paths.launch_argv(program, args)
+
+    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+        return _posix_paths.pty_launch_parts(program, args)
 
 
 paths = DarwinLayout()

--- a/backend/agent_team_backend/osplat/_linux.py
+++ b/backend/agent_team_backend/osplat/_linux.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Sequence
 from pathlib import Path
 
 from ._posix import process_tree, terminal_backend
@@ -234,6 +235,18 @@ class LinuxLayout(LinuxPaths):
 
     def quote_arg(self, arg: str) -> str:
         return _posix_paths.quote_arg(arg)
+
+    def resolve_program(self, name_or_path: str, *, path: str | None = None) -> str | None:
+        return _posix_paths.resolve_program(name_or_path, path=path)
+
+    def launch_kind(self, program: str) -> str:
+        return _posix_paths.launch_kind(program)
+
+    def launch_argv(self, program: str, args: Sequence[str] = ()) -> list[str]:
+        return _posix_paths.launch_argv(program, args)
+
+    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+        return _posix_paths.pty_launch_parts(program, args)
 
 
 paths = LinuxLayout()

--- a/backend/agent_team_backend/osplat/_posix_paths.py
+++ b/backend/agent_team_backend/osplat/_posix_paths.py
@@ -71,6 +71,8 @@ def askpass_launcher(helper_py: Path, launch_argv: list[str]) -> Path:
 # ---- appended: the members added for the Windows port ------------------------
 
 import os  # noqa: E402
+import shutil  # noqa: E402
+from collections.abc import Sequence  # noqa: E402
 
 
 def executable_candidates(name: str) -> list[str]:
@@ -114,6 +116,27 @@ def shell_command(command: str) -> list[str]:
 
 def quote_arg(arg: str) -> str:
     return shlex.quote(arg)
+
+
+# ---- appended: finding a program and starting it ----------------------------
+
+
+def resolve_program(name_or_path: str, *, path: str | None = None) -> str | None:
+    return shutil.which(name_or_path, path=path)
+
+
+def launch_kind(program: str) -> str:
+    # Nothing to interpret: the kernel reads the shebang, so every runnable
+    # file starts the same way.
+    return "direct"
+
+
+def launch_argv(program: str, args: Sequence[str] = ()) -> list[str]:
+    return [program, *args]
+
+
+def pty_launch_parts(program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+    return program, list(args)
 
 
 # ---- appended: the sh renderings of the scripts the backend writes -----------

--- a/backend/agent_team_backend/osplat/_windows.py
+++ b/backend/agent_team_backend/osplat/_windows.py
@@ -41,6 +41,7 @@ import subprocess
 import threading
 import time
 from collections import deque
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Callable
 
@@ -1138,6 +1139,51 @@ class WindowsDiscoveryLayout(WindowsLayout):
 
     def quote_arg(self, arg: str) -> str:
         return subprocess.list2cmdline([arg])
+
+    def resolve_program(self, name_or_path: str, *, path: str | None = None) -> str | None:
+        # `shutil.which` consults PATHEXT itself, but only for a bare name and
+        # only on a Windows interpreter: asking it once per candidate gives the
+        # same answer wherever this runs and also extends a stored override
+        # (`C:\...\npm\claude`) to the shim that is actually on disk.
+        for candidate in self.executable_candidates(name_or_path):
+            found = shutil.which(candidate, path=path)
+            if found:
+                return found
+        return None
+
+    def launch_kind(self, program: str) -> str:
+        suffix = Path(program).suffix.lower()
+        if suffix in (".cmd", ".bat"):
+            return "cmd"
+        if suffix == ".ps1":
+            return "powershell"
+        return "direct"
+
+    def launch_argv(self, program: str, args: Sequence[str] = ()) -> list[str]:
+        kind = self.launch_kind(program)
+        if kind == "cmd":
+            # No `/s` here, unlike `shell_command`. `/s` makes cmd strip the
+            # first and the last quote of everything after `/c` — which is
+            # exactly the pair `list2cmdline` puts around a program path that
+            # contains a space, leaving cmd looking for `C:\Program`. Without
+            # it cmd keeps that pair (its documented rule for a command line
+            # whose one quoted token is the name of an executable).
+            # `/d` skips AutoRun, the same reason `shell_command` passes it.
+            return ["cmd.exe", "/d", "/c", program, *args]
+        if kind == "powershell":
+            # `-File` and not `-Command`: `-File` takes the rest of the line as
+            # plain arguments, where `-Command` would re-parse them as
+            # PowerShell source. `-NoProfile` also keeps a user profile from
+            # printing into the script's output.
+            return [
+                "powershell.exe", "-NoLogo", "-NonInteractive", "-NoProfile",
+                "-ExecutionPolicy", "Bypass", "-File", program, *args,
+            ]
+        return [program, *args]
+
+    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+        argv = self.launch_argv(program, args)
+        return argv[0], argv[1:]
 
 
 class WindowsScheduler:

--- a/backend/agent_team_backend/osplat/spec.py
+++ b/backend/agent_team_backend/osplat/spec.py
@@ -18,6 +18,7 @@ degrades to "this panel shows nothing" instead of taking down the request.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Callable, NamedTuple, Protocol
 
@@ -191,6 +192,55 @@ class Paths(Protocol):
         is the MSVCRT convention `cmd.exe` and every Windows program parse.
         A path with a space quoted the POSIX way (`'C:\\a b'`) reaches a
         Windows program with the apostrophes still attached.
+        """
+        ...
+
+    def resolve_program(self, name_or_path: str, *, path: str | None = None) -> str | None:
+        """Where a program called `name_or_path` actually is, or None.
+
+        The one lookup every caller shares, so a stored binary override and a
+        fresh PATH lookup can never disagree about which file they mean. On
+        Windows that means `executable_candidates` order — a bare `claude` is
+        npm's `claude.cmd` shim — and the answer keeps the extension, which is
+        what `launch_kind` needs to read.
+
+        `path` overrides the PATH searched, for a caller that is about to run
+        the child with an environment of its own.
+        """
+        ...
+
+    def launch_kind(self, program: str) -> str:
+        """How this platform has to start `program`: "direct", "cmd" or "powershell".
+
+        Always "direct" on POSIX: the kernel reads the shebang. On Windows
+        `CreateProcess` can only start a real image, so a `.cmd`/`.bat` needs
+        cmd.exe and a `.ps1` needs powershell.exe — which is why handing
+        npm's `claude.cmd` straight to `subprocess` fails with WinError 193.
+        """
+        ...
+
+    def launch_argv(self, program: str, args: Sequence[str] = ()) -> list[str]:
+        """argv that starts `program` with `args`, interpreter included.
+
+        `[program, *args]` wherever `launch_kind` is "direct"; the interpreter
+        and its flags in front of it otherwise. The result goes to
+        `subprocess` unchanged — it is not a shell command line — so a caller
+        never has to quote anything itself.
+        """
+        ...
+
+    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+        """`launch_argv` split the way a pseudo-terminal spawn wants it.
+
+        ConPTY (through winpty-rs) takes the application name and the rest of
+        the command line separately rather than one argv, so the terminal
+        backend needs the head and the tail apart. Same decision as
+        `launch_argv` otherwise: POSIX hands back `program` and its args
+        untouched, Windows the cmd.exe wrapping.
+
+        Note what the Windows shape costs a pane: a shell sits between the
+        terminal and the CLI, so Ctrl-C reaches cmd.exe first, the exit code
+        is cmd.exe's, and the job object holds one process more.
         """
         ...
 

--- a/backend/tests/test_ai_chat_cli_engine.py
+++ b/backend/tests/test_ai_chat_cli_engine.py
@@ -84,6 +84,23 @@ async def test_run_cli_text_returns_stdout(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_run_cli_text_starts_a_windows_shim_through_cmd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The editor's rewrite/complete path: the binary it resolves on Windows
+    is npm's `claude.cmd`, which CreateProcess refuses to start."""
+    from agent_team_backend.osplat import _windows
+
+    monkeypatch.setattr(eng.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(eng, "resolve_cli_binary", lambda engine="claude": r"C:\npm\claude.cmd")
+    calls = _spawner(monkeypatch, [FakeTextProc(stdout=b"plain answer\n")])
+
+    assert await eng.run_cli_text("question") == "plain answer"
+    assert calls[0][:4] == ["cmd.exe", "/d", "/c", r"C:\npm\claude.cmd"]
+    assert calls[0][calls[0].index("-p") + 1] == "question"
+
+
+@pytest.mark.asyncio
 async def test_run_cli_text_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     _spawner(monkeypatch, [FakeTextProc(stderr=b"broken pipes", returncode=2)])
 

--- a/backend/tests/test_analyzer_routing.py
+++ b/backend/tests/test_analyzer_routing.py
@@ -258,13 +258,12 @@ async def test_run_llama_cli_uses_override():
 async def test_health_uses_override():
     """health() should check the overridden CLI, not the default LLAMA_CLI."""
     from agent_team_backend.analyzer import health
-    import shutil
 
-    with patch("agent_team_backend.analyzer.shutil.which") as mock_which:
-        mock_which.return_value = None
+    with patch("agent_team_backend.analyzer.osplat.paths.resolve_program") as mock_resolve:
+        mock_resolve.return_value = None
         result = await health(llama_cli_override="nonexistent-binary-xyz")
 
-    mock_which.assert_called_with("nonexistent-binary-xyz")
+    mock_resolve.assert_called_with("nonexistent-binary-xyz")
     assert result["ok"] is False
     assert "nonexistent-binary-xyz" in result["error"]
 
@@ -280,7 +279,8 @@ async def test_health_gguf_warning_when_file_missing(tmp_path):
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"version 9330\n", b""))
 
-    with patch("agent_team_backend.analyzer.shutil.which", return_value="/usr/local/bin/llama-cli"), \
+    with patch("agent_team_backend.analyzer.osplat.paths.resolve_program",
+               return_value="/usr/local/bin/llama-cli"), \
          patch("agent_team_backend.analyzer.asyncio.create_subprocess_exec",
                new_callable=AsyncMock, return_value=mock_proc):
         result = await health(gguf_path_override=fake_gguf)
@@ -302,7 +302,8 @@ async def test_health_gguf_size_when_file_exists(tmp_path):
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"version 9330\n", b""))
 
-    with patch("agent_team_backend.analyzer.shutil.which", return_value="/usr/local/bin/llama-cli"), \
+    with patch("agent_team_backend.analyzer.osplat.paths.resolve_program",
+               return_value="/usr/local/bin/llama-cli"), \
          patch("agent_team_backend.analyzer.asyncio.create_subprocess_exec",
                new_callable=AsyncMock, return_value=mock_proc):
         result = await health(gguf_path_override=str(gguf_file))
@@ -310,6 +311,30 @@ async def test_health_gguf_size_when_file_exists(tmp_path):
     assert result["ok"] is True
     assert "gguf_warning" not in result
     assert result["gguf_size"] > 0
+
+
+@pytest.mark.asyncio
+async def test_health_starts_a_windows_shim_through_cmd(monkeypatch):
+    """A llama.cpp shipped as a `.cmd` wrapper needs cmd.exe in front of it."""
+    from agent_team_backend import analyzer
+    from agent_team_backend.osplat import _windows
+
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate = AsyncMock(return_value=(b"version 9330\n", b""))
+
+    monkeypatch.setattr(analyzer.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(
+        _windows.paths, "resolve_program", lambda _name, *, path=None: r"C:\llama\llama-cli.cmd"
+    )
+    with patch("agent_team_backend.analyzer.asyncio.create_subprocess_exec",
+               new_callable=AsyncMock, return_value=mock_proc) as mock_exec:
+        result = await analyzer.health()
+
+    assert result["ok"] is True
+    assert mock_exec.call_args.args == (
+        "cmd.exe", "/d", "/c", r"C:\llama\llama-cli.cmd", "--version",
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_claude_cli_usage.py
+++ b/backend/tests/test_claude_cli_usage.py
@@ -139,6 +139,20 @@ async def test_the_report_is_requested_in_print_mode_without_mcp(monkeypatch) ->
     assert "ANTHROPIC_API_KEY" not in calls[0]["env"]
 
 
+async def test_a_windows_shim_is_started_through_cmd(monkeypatch) -> None:
+    """npm installs the CLI as `claude.cmd` on Windows, which CreateProcess
+    cannot start — and this poll fires on a timer, so it would fail forever."""
+    from agent_team_backend.osplat import _windows
+
+    monkeypatch.setattr(cu.osplat, "paths", _windows.paths)
+    calls = _fake_exec(monkeypatch, _FakeProc(stdout=PRINTED_REPORT.encode()))
+
+    await cu.read_usage_panel(r"C:\npm\claude.cmd")
+
+    assert calls[0]["argv"][:4] == ("cmd.exe", "/d", "/c", r"C:\npm\claude.cmd")
+    assert calls[0]["argv"][4:] == cu.USAGE_ARGS
+
+
 async def test_a_hung_cli_is_killed_and_reported_as_a_timeout(monkeypatch) -> None:
     killed: list[int] = []
 

--- a/backend/tests/test_claude_delegated_refresh.py
+++ b/backend/tests/test_claude_delegated_refresh.py
@@ -287,6 +287,34 @@ async def test_a_timed_out_probe_takes_down_the_whole_process_group(
     assert len(killed) == 1  # the group killer ran, not a bare proc.kill()
 
 
+async def test_the_probe_starts_a_windows_shim_through_cmd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`auth status` on a `.cmd` shim: without the interpreter the probe
+    reports "spawn failed" and the credential is never renewed."""
+    from agent_team_backend.osplat import _windows
+
+    argv: list[tuple] = []
+
+    class DoneProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_exec(*a, **k):
+        argv.append(a)
+        return DoneProc()
+
+    monkeypatch.setattr(dr.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    ran, detail = await dr._run_probe(r"C:\npm\claude.cmd", 5.0)
+
+    assert (ran, detail) == (True, "")
+    assert argv[0] == ("cmd.exe", "/d", "/c", r"C:\npm\claude.cmd", *dr._PROBE_ARGS)
+
+
 def test_fingerprint_never_returns_the_secret() -> None:
     digest = dr._live_fingerprint(FakeVault("super-secret-token"))
 

--- a/backend/tests/test_host_shell.py
+++ b/backend/tests/test_host_shell.py
@@ -939,6 +939,57 @@ async def test_run_broker_returns_validation_failure_instead_of_raising() -> Non
     assert "not allowlisted" in stderr
 
 
+@pytest.mark.asyncio
+async def test_an_allowlisted_name_resolves_to_a_windows_shim(monkeypatch) -> None:
+    """`gh` from npm or scoop is a `gh.cmd`, and CreateProcess only ever
+    appends `.exe` — so the shim used to be invisible and every call rc 127.
+
+    The allowlist still guards the bare name: resolution happens after it, and
+    never lets the caller name a path of its own."""
+    from agent_team_backend.osplat import _windows
+
+    argv: list[tuple] = []
+
+    class VersionProc:
+        returncode = 0
+
+        async def communicate(self, *_a):
+            return b"gh version 2.0.0\n", b""
+
+    async def fake_exec(*a, **_k):
+        argv.append(a)
+        return VersionProc()
+
+    monkeypatch.setattr(host_shell, "paths", _windows.paths)
+    monkeypatch.setattr(
+        _windows.paths, "resolve_program", lambda name, *, path=None: rf"C:\scoop\{name}.cmd"
+    )
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    rc, stdout, _ = await run_allowlisted_text(["gh", "--version"])
+
+    assert rc == 0 and stdout.startswith("gh version")
+    assert argv[0] == ("cmd.exe", "/d", "/c", r"C:\scoop\gh.cmd", "--version")
+
+    # The refusal is unchanged, and nothing is resolved or spawned for it.
+    argv.clear()
+    rc, _, stderr = await run_allowlisted_text(["rm", "-rf", "."])
+    assert rc == 126 and "not allowlisted" in stderr and argv == []
+
+
+@pytest.mark.asyncio
+async def test_a_name_nothing_on_path_answers_to_reports_not_found(monkeypatch) -> None:
+    """The same 127 an exec failure produced, so callers read it the same way."""
+    monkeypatch.setattr(
+        host_shell.paths, "resolve_program", lambda _name, *, path=None: None
+    )
+
+    rc, stdout, stderr = await run_allowlisted_text(["git", "--version"])
+
+    assert (rc, stdout) == (127, "")
+    assert "git not found" in stderr
+
+
 # ── run_allowlisted_capped ────────────────────────────────────────────────────
 # The capped runner exists so a caller that only shows the head of a command's
 # output does not first buffer all of it. These pin the two halves that make it

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -24,24 +24,52 @@ def _fake_run(stdout: str):
     return run
 
 
+def _resolves_to(monkeypatch: pytest.MonkeyPatch, found: str | None) -> None:
+    """What the launch seam finds on PATH for every name asked about."""
+    monkeypatch.setattr(
+        ob.osplat.paths, "resolve_program", lambda _name, *, path=None: found
+    )
+
+
 def test_detect_ok(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/usr/bin/node")
+    _resolves_to(monkeypatch, "/usr/bin/node")
     monkeypatch.setattr(ob.subprocess, "run", _fake_run("v22.3.0"))
     r = ob.detect_dep(_NODE)
     assert r["status"] == "ok" and r["version"] == "22.3.0"
 
 
 def test_detect_outdated(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/usr/bin/node")
+    _resolves_to(monkeypatch, "/usr/bin/node")
     monkeypatch.setattr(ob.subprocess, "run", _fake_run("v18.0.0"))
     r = ob.detect_dep(_NODE)
     assert r["status"] == "outdated" and r["version"] == "18.0.0"
 
 
 def test_detect_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)
+    _resolves_to(monkeypatch, None)
     r = ob.detect_dep(_NODE)
     assert r["status"] == "missing" and r["version"] == ""
+
+
+# npm on Windows installs a CLI as a `claude.cmd` batch shim, and CreateProcess
+# cannot start one (WinError 193). Without the interpreter in front of it every
+# dep's version probe fails and the wizard reports the whole toolchain missing.
+def test_detect_probes_a_windows_shim_through_cmd(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_team_backend.osplat import _windows
+
+    monkeypatch.setattr(ob.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(
+        _windows.paths, "resolve_program", lambda _name, *, path=None: r"C:\npm\node.cmd"
+    )
+    probed: list[list[str]] = []
+
+    def run(cmd, *_a, **_k):
+        probed.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "v22.3.0", "")
+
+    monkeypatch.setattr(ob.subprocess, "run", run)
+    assert ob.detect_dep(_NODE)["status"] == "ok"
+    assert probed == [["cmd.exe", "/d", "/c", r"C:\npm\node.cmd", "--version"]]
 
 
 # ── install-method classification (picks which official command applies) ──────
@@ -85,13 +113,14 @@ def test_detect_dep_requirements_come_from_the_resolved_install(monkeypatch: pyt
               min_version="22.0.0",
               install_cmds={"darwin": PlatformInstall("brew install node", ("brew",))})
     monkeypatch.setattr(ob.osplat, "platform_id", "darwin")
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)
+    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)  # the requirement probe
+    _resolves_to(monkeypatch, None)
     r = ob.detect_dep(dep)
     assert r["requirements"] == [{"name": "brew", "ok": False}]
 
 
 def test_detect_dep_exposes_official_maintenance_commands(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/usr/local/bin/claude")
+    _resolves_to(monkeypatch, "/usr/local/bin/claude")
     monkeypatch.setattr(ob.subprocess, "run", _fake_run("2.1.219 (Claude Code)"))
     r = ob.detect_dep(ob.DEPS_BY_ID["claude"])
     assert r["update_cmd"] == "claude update"

--- a/backend/tests/test_onboarding_install_flow.py
+++ b/backend/tests/test_onboarding_install_flow.py
@@ -14,6 +14,7 @@ import pytest
 
 from agent_team_backend import app as app_mod
 from agent_team_backend import onboarding_deps as ob
+from agent_team_backend import osplat
 from agent_team_backend.onboarding_deps import Dep
 
 
@@ -22,20 +23,28 @@ _ALIASED = Dep("cursor", "Cursor CLI", "", "agent_cli", ["agent", "--version"],
                install_cmd="curl https://example.invalid/install | bash")
 
 
-def _which(available: dict[str, str]):
-    return lambda name: available.get(Path(name).name)
+def _installed(monkeypatch: pytest.MonkeyPatch, available: dict[str, str]) -> None:
+    """What the launch seam finds on PATH, keyed by the bare command name.
+
+    One patch covers both callers: `onboarding_deps` and `app` now ask
+    `osplat.paths.resolve_program` rather than `shutil.which` each.
+    """
+    monkeypatch.setattr(
+        osplat.paths, "resolve_program",
+        lambda name, *, path=None: available.get(Path(name).name),
+    )
 
 
 # ── alternate executables ────────────────────────────────────────────────────
 def test_resolve_prefers_the_primary_name(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", _which({
+    _installed(monkeypatch, {
         "agent": "/opt/bin/agent", "cursor-agent": "/opt/bin/cursor-agent",
-    }))
+    })
     assert ob.resolve_executable(_ALIASED) == "/opt/bin/agent"
 
 
 def test_resolve_falls_back_to_the_legacy_name(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", _which({"cursor-agent": "/opt/bin/cursor-agent"}))
+    _installed(monkeypatch, {"cursor-agent": "/opt/bin/cursor-agent"})
     assert ob.resolve_executable(_ALIASED) == "/opt/bin/cursor-agent"
 
 
@@ -44,7 +53,7 @@ def test_detect_finds_a_cli_installed_under_its_legacy_name(
 ) -> None:
     # The whole point: a machine carrying only `cursor-agent` used to be told
     # "not installed" and offered an install it did not need.
-    monkeypatch.setattr(ob.shutil, "which", _which({"cursor-agent": "/opt/bin/cursor-agent"}))
+    _installed(monkeypatch, {"cursor-agent": "/opt/bin/cursor-agent"})
     probed: list[list[str]] = []
 
     def run(cmd, *_a, **_k):
@@ -62,14 +71,13 @@ def test_registry_declares_the_cursor_alias() -> None:
 
 
 def test_deps_without_an_alias_are_unaffected(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", _which({}))
+    _installed(monkeypatch, {})
     assert ob.resolve_executable(ob.DEPS_BY_ID["claude"]) == ""
 
 
 # ── spawn command rewriting ──────────────────────────────────────────────────
 def test_spawn_command_switches_to_the_installed_alias(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_mod.shutil, "which", _which({"agent": "/opt/bin/agent"}))
-    monkeypatch.setattr(ob.shutil, "which", _which({"agent": "/opt/bin/agent"}))
+    _installed(monkeypatch, {"agent": "/opt/bin/agent"})
     command = ["/bin/zsh", "-ilc", "cursor-agent --resume abc"]
     assert app_mod._command_with_installed_cli_alias("cursor", command) == [
         "/bin/zsh", "-ilc", "/opt/bin/agent --resume abc",
@@ -80,16 +88,35 @@ def test_spawn_command_untouched_when_the_requested_name_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     available = {"cursor-agent": "/opt/bin/cursor-agent", "agent": "/opt/bin/agent"}
-    monkeypatch.setattr(app_mod.shutil, "which", _which(available))
-    monkeypatch.setattr(ob.shutil, "which", _which(available))
+    _installed(monkeypatch, available)
     command = ["/bin/zsh", "-ilc", "cursor-agent --resume abc"]
     assert app_mod._command_with_installed_cli_alias("cursor", command) == command
+
+
+def test_spawn_command_matches_the_name_as_windows_spells_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Windows PATH lookup answers `cursor-agent.cmd`; the rewrite has to
+    recognise that as the pinned name, or the spawn it exists to fix is left
+    pointing at a name this machine does not have."""
+    from agent_team_backend.osplat import _windows
+
+    monkeypatch.setattr(app_mod.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(
+        _windows.paths, "resolve_program",
+        lambda name, *, path=None: r"C:\npm\agent.cmd" if Path(name).stem == "agent" else None,
+    )
+    monkeypatch.setattr(ob, "resolve_executable", lambda _dep: r"C:\npm\agent.cmd")
+    command = ["cmd.exe", "/d", "/c", r"cursor-agent.cmd --resume abc"]
+    assert app_mod._command_with_installed_cli_alias("cursor", command) == [
+        "cmd.exe", "/d", "/c", r"C:\npm\agent.cmd --resume abc",
+    ]
 
 
 def test_spawn_command_untouched_for_a_cli_without_aliases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(app_mod.shutil, "which", _which({}))
+    _installed(monkeypatch, {})
     command = ["/bin/zsh", "-ilc", "claude --dangerously-skip-permissions"]
     assert app_mod._command_with_installed_cli_alias("claude", command) == command
 
@@ -97,15 +124,13 @@ def test_spawn_command_untouched_for_a_cli_without_aliases(
 def test_spawn_command_untouched_when_nothing_is_installed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(app_mod.shutil, "which", _which({}))
-    monkeypatch.setattr(ob.shutil, "which", _which({}))
+    _installed(monkeypatch, {})
     command = ["/bin/zsh", "-ilc", "cursor-agent"]
     assert app_mod._command_with_installed_cli_alias("cursor", command) == command
 
 
 def test_spawn_probe_accepts_the_legacy_binary(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(app_mod.shutil, "which", _which({"cursor-agent": "/opt/bin/cursor-agent"}))
-    monkeypatch.setattr(ob.shutil, "which", _which({"cursor-agent": "/opt/bin/cursor-agent"}))
+    _installed(monkeypatch, {"cursor-agent": "/opt/bin/cursor-agent"})
     monkeypatch.setattr(
         app_mod.subprocess, "run",
         lambda cmd, *_a, **_k: subprocess.CompletedProcess(cmd, 0, "2026.1.5", ""),

--- a/backend/tests/test_onboarding_install_flow.py
+++ b/backend/tests/test_onboarding_install_flow.py
@@ -113,6 +113,25 @@ def test_spawn_command_matches_the_name_as_windows_spells_it(
     ]
 
 
+def test_spawn_command_matches_the_bare_pinned_name_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pane command names the CLI without an extension, which is not one of
+    the candidates Windows tries on PATH — the rewrite still has to see it."""
+    from agent_team_backend.osplat import _windows
+
+    monkeypatch.setattr(app_mod.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(
+        _windows.paths, "resolve_program",
+        lambda name, *, path=None: r"C:\npm\agent.cmd" if Path(name).stem == "agent" else None,
+    )
+    monkeypatch.setattr(ob, "resolve_executable", lambda _dep: r"C:\npm\agent.cmd")
+    command = ["cmd.exe", "/d", "/c", "cursor-agent --resume abc"]
+    assert app_mod._command_with_installed_cli_alias("cursor", command) == [
+        "cmd.exe", "/d", "/c", r"C:\npm\agent.cmd --resume abc",
+    ]
+
+
 def test_spawn_command_untouched_for_a_cli_without_aliases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/test_osplat.py
+++ b/backend/tests/test_osplat.py
@@ -305,6 +305,10 @@ class TestLaunching:
         )
         assert _windows.paths.pty_launch_parts(r"C:\Git\git.exe") == (r"C:\Git\git.exe", [])
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="the exec bit decides the answer, and NTFS has none",
+    )
     def test_posix_resolution_is_the_plain_path_search(self, tmp_path):
         from agent_team_backend.osplat import _darwin, _linux
 
@@ -341,8 +345,12 @@ class TestLaunching:
     def test_posix_command_splitting_is_unchanged(self):
         import shlex
 
+        from agent_team_backend.osplat import _posix
+
         text = "claude -p 'two words' --resume abc"
-        assert osplat.terminal_backend.parse_command(text) == shlex.split(text)
+        # The POSIX backend is the subject; on Windows the host parser is
+        # CommandLineToArgvW, which reads the single quotes literally.
+        assert _posix.terminal_backend.parse_command(text) == shlex.split(text)
 
 
 #: What git_service hands the seam: this build's own executable plus the entry

--- a/backend/tests/test_osplat.py
+++ b/backend/tests/test_osplat.py
@@ -247,6 +247,104 @@ class TestPaths:
         assert _windows.paths.quote_arg("plain") == "plain"
 
 
+class TestLaunching:
+    """Finding a program, and putting in front of it whatever starts it.
+
+    Both implementations run on whichever machine runs the suite: the answer
+    is a function of the path's extension, which a Mac can reason about for
+    Windows perfectly well — and has to, since npm's `claude.cmd` is the shim
+    every Windows install of a coding CLI actually gets.
+    """
+
+    def test_posix_starts_every_runnable_file_the_same_way(self):
+        from agent_team_backend.osplat import _darwin, _linux
+
+        for paths in (_darwin.paths, _linux.paths):
+            assert paths.launch_kind("/usr/local/bin/claude") == "direct"
+            # The extension means nothing here: the kernel reads the shebang.
+            assert paths.launch_kind("/usr/local/bin/odd.cmd") == "direct"
+            assert paths.launch_argv("/bin/git", ["status", "-s"]) == ["/bin/git", "status", "-s"]
+            assert paths.launch_argv("/bin/git") == ["/bin/git"]
+            assert paths.pty_launch_parts("/bin/zsh", ("-l",)) == ("/bin/zsh", ["-l"])
+
+    def test_windows_names_the_interpreter_the_extension_needs(self):
+        from agent_team_backend.osplat import _windows
+
+        paths = _windows.paths
+        assert paths.launch_kind(r"C:\npm\claude.CMD") == "cmd"  # the case is not part of it
+        assert paths.launch_kind(r"C:\npm\run.bat") == "cmd"
+        assert paths.launch_kind(r"C:\tools\setup.ps1") == "powershell"
+        assert paths.launch_kind(r"C:\Program Files\Git\git.exe") == "direct"
+        assert paths.launch_argv(r"C:\npm\claude.cmd", ["-p", "hi"]) == [
+            "cmd.exe", "/d", "/c", r"C:\npm\claude.cmd", "-p", "hi",
+        ]
+        assert paths.launch_argv(r"C:\tools\setup.ps1") == [
+            "powershell.exe", "-NoLogo", "-NonInteractive", "-NoProfile",
+            "-ExecutionPolicy", "Bypass", "-File", r"C:\tools\setup.ps1",
+        ]
+        assert paths.launch_argv(r"C:\Git\git.exe", ["status"]) == [r"C:\Git\git.exe", "status"]
+
+    # `/s` tells cmd to strip the first and last quote of everything after
+    # `/c` — the very pair `list2cmdline` puts around a program path with a
+    # space in it. The string form still wants it; this one must not have it.
+    def test_the_cmd_wrapper_leaves_out_slash_s(self):
+        from agent_team_backend.osplat import _windows
+
+        assert _windows.paths.launch_argv(r"C:\a b\claude.cmd") == [
+            "cmd.exe", "/d", "/c", r"C:\a b\claude.cmd",
+        ]
+        assert _windows.paths.shell_command("echo hi") == ["cmd.exe", "/d", "/s", "/c", "echo hi"]
+
+    # ConPTY (winpty-rs) takes the application name and the rest of the line
+    # as two arguments, so the terminal backend needs the split, not an argv.
+    def test_pty_parts_split_the_launch_argv_for_conpty(self):
+        from agent_team_backend.osplat import _windows
+
+        assert _windows.paths.pty_launch_parts(r"C:\npm\claude.cmd", ("--resume",)) == (
+            "cmd.exe", ["/d", "/c", r"C:\npm\claude.cmd", "--resume"],
+        )
+        assert _windows.paths.pty_launch_parts(r"C:\Git\git.exe") == (r"C:\Git\git.exe", [])
+
+    def test_posix_resolution_is_the_plain_path_search(self, tmp_path):
+        from agent_team_backend.osplat import _darwin, _linux
+
+        tool = tmp_path / "mytool"
+        tool.write_text("#!/bin/sh\n")
+        tool.chmod(0o755)
+        assert _darwin.paths.resolve_program("mytool", path=str(tmp_path)) == str(tool)
+        # No PATHEXT here: a name is the whole name.
+        assert _darwin.paths.resolve_program("mytool.cmd", path=str(tmp_path)) is None
+        assert _linux.paths.resolve_program("absent", path=str(tmp_path)) is None
+
+    def test_windows_resolution_walks_pathext_in_order(self, tmp_path, monkeypatch):
+        from agent_team_backend.osplat import _windows
+
+        monkeypatch.setenv("PATHEXT", ".COM;.EXE;.CMD")
+        for name in ("claude.cmd", "claude.exe"):
+            (tmp_path / name).write_text("")
+            (tmp_path / name).chmod(0o755)  # the mode bits this box's which() asks for
+        assert _windows.paths.resolve_program("claude", path=str(tmp_path)) == str(
+            tmp_path / "claude.exe"
+        )
+        monkeypatch.setenv("PATHEXT", ".CMD;.EXE")
+        assert _windows.paths.resolve_program("claude", path=str(tmp_path)) == str(
+            tmp_path / "claude.cmd"
+        )
+        # An extension already on the name is kept, not extended again.
+        assert _windows.paths.resolve_program("claude.cmd", path=str(tmp_path)) == str(
+            tmp_path / "claude.cmd"
+        )
+        assert _windows.paths.resolve_program("absent", path=str(tmp_path)) is None
+
+    # The three command-text splits in `app` moved onto the terminal backend,
+    # which is `shlex.split` here and `CommandLineToArgvW` on Windows.
+    def test_posix_command_splitting_is_unchanged(self):
+        import shlex
+
+        text = "claude -p 'two words' --resume abc"
+        assert osplat.terminal_backend.parse_command(text) == shlex.split(text)
+
+
 #: What git_service hands the seam: this build's own executable plus the entry
 #: mode that answers a prompt. Never the bare name `python`.
 _LAUNCH_ARGV = ["/opt/navide/agent_team_backend", "--askpass-helper"]

--- a/backend/tests/test_spawn_probe_degrade.py
+++ b/backend/tests/test_spawn_probe_degrade.py
@@ -24,8 +24,10 @@ from agent_team_backend.app import (
 
 @pytest.fixture
 def fake_claude(monkeypatch):
-    """Make shutil.which resolve claude to a fake path so the probe runs."""
-    monkeypatch.setattr(app.shutil, "which", lambda _name: "/fake/bin/claude")
+    """Make the launch seam resolve claude to a fake path so the probe runs."""
+    monkeypatch.setattr(
+        app.osplat.paths, "resolve_program", lambda _name, *, path=None: "/fake/bin/claude"
+    )
 
 
 def _run_returns(monkeypatch, *, returncode=0, stdout="2.1.205 (Claude Code)"):
@@ -58,7 +60,9 @@ def test_exec_error_degrades(fake_claude, monkeypatch):
 
 
 def test_missing_binary_still_blocks(monkeypatch):
-    monkeypatch.setattr(app.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        app.osplat.paths, "resolve_program", lambda _name, *, path=None: None
+    )
     with pytest.raises(app.AgentCliProbeError) as ei:
         _probe_agent_cli_for_spawn("claude")
     assert ei.value.details["reason"] == "not_found"

--- a/backend/tests/test_terminal_spawn_probe.py
+++ b/backend/tests/test_terminal_spawn_probe.py
@@ -151,8 +151,10 @@ def test_agent_cli_probe_uses_explicit_binary_from_spawn_command(
         ) if command[0] == "/opt/homebrew/bin/claude" else None,
     )
 
+    # Double quotes on purpose: both parsers strip them, where a single quote
+    # is a literal character to the one Windows uses.
     result = app._probe_agent_cli_for_spawn(
-        "claude", "'/opt/homebrew/bin/claude' --session-id test"
+        "claude", '"/opt/homebrew/bin/claude" --session-id test'
     )
 
     assert result is not None

--- a/backend/tests/test_terminal_spawn_probe.py
+++ b/backend/tests/test_terminal_spawn_probe.py
@@ -10,12 +10,19 @@ import pytest
 from agent_team_backend import app
 
 
+def _resolves_to(monkeypatch: pytest.MonkeyPatch, target: str | None) -> None:
+    """Where the launch seam finds the CLI — the probe's only PATH lookup."""
+    monkeypatch.setattr(
+        app.osplat.paths, "resolve_program", lambda _name, *, path=None: target
+    )
+
+
 def test_agent_cli_probe_reports_resolved_binary_and_version(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     binary = tmp_path / "claude"
     binary.write_text("#!/bin/sh\n")
-    monkeypatch.setattr(app.shutil, "which", lambda _name: str(binary))
+    _resolves_to(monkeypatch, str(binary))
     monkeypatch.setattr(
         app.subprocess,
         "run",
@@ -39,7 +46,7 @@ def test_agent_cli_probe_reports_resolved_binary_and_version(
 def test_agent_cli_probe_surfaces_sigkill_with_structured_details(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(app.shutil, "which", lambda _name: "/opt/bin/claude")
+    _resolves_to(monkeypatch, "/opt/bin/claude")
     monkeypatch.setattr(
         app.subprocess,
         "run",
@@ -61,7 +68,7 @@ def test_agent_cli_probe_surfaces_sigkill_with_structured_details(
 def test_agent_cli_probe_non_sigkill_signal_has_no_hint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(app.shutil, "which", lambda _name: "/opt/bin/claude")
+    _resolves_to(monkeypatch, "/opt/bin/claude")
     monkeypatch.setattr(
         app.subprocess,
         "run",
@@ -84,7 +91,7 @@ def test_agent_cli_probe_error_shows_symlink_target(
     link = tmp_path / "claude"
     link.symlink_to(real)
     resolved = str(real.resolve())
-    monkeypatch.setattr(app.shutil, "which", lambda _name: str(link))
+    _resolves_to(monkeypatch, str(link))
     monkeypatch.setattr(
         app.subprocess,
         "run",
@@ -106,7 +113,7 @@ def test_agent_cli_probe_success_payload_carries_resolved_symlink_target(
     real.write_text("#!/bin/sh\n")
     link = tmp_path / "claude"
     link.symlink_to(real)
-    monkeypatch.setattr(app.shutil, "which", lambda _name: str(link))
+    _resolves_to(monkeypatch, str(link))
     monkeypatch.setattr(
         app.subprocess,
         "run",
@@ -129,11 +136,11 @@ def test_agent_cli_probe_uses_explicit_binary_from_spawn_command(
 ) -> None:
     calls: list[str] = []
 
-    def which(name: str) -> str | None:
+    def resolve(name: str, *, path: str | None = None) -> str | None:
         calls.append(name)
         return name if name == "/opt/homebrew/bin/claude" else "/broken/bin/claude"
 
-    monkeypatch.setattr(app.shutil, "which", which)
+    monkeypatch.setattr(app.osplat.paths, "resolve_program", resolve)
     monkeypatch.setattr(
         app.subprocess,
         "run",
@@ -152,6 +159,39 @@ def test_agent_cli_probe_uses_explicit_binary_from_spawn_command(
     assert result["binary_path"] == "/opt/homebrew/bin/claude"
     assert result["version"] == "2.1.168"
     assert calls == ["/opt/homebrew/bin/claude"]
+
+
+# The shim npm installs on Windows: `CreateProcess` refuses a `.cmd`, so the
+# probe has to name the interpreter. Before this the OSError was caught and
+# downgraded to "degraded", leaving the probe permanently useless there.
+def test_agent_cli_probe_runs_a_windows_shim_through_cmd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_team_backend.osplat import _windows
+
+    monkeypatch.setattr(app.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(
+        _windows.paths,
+        "resolve_program",
+        lambda _name, *, path=None: r"C:\Users\a\AppData\Roaming\npm\claude.cmd",
+    )
+    monkeypatch.setattr(
+        app.subprocess,
+        "run",
+        lambda command, **_kwargs: SimpleNamespace(
+            returncode=0, stdout="2.1.210 (Claude Code)\n", stderr=""
+        ),
+    )
+
+    result = app._probe_agent_cli_for_spawn("claude")
+
+    assert result is not None
+    assert result["probe_command"] == [
+        "cmd.exe", "/d", "/c",
+        r"C:\Users\a\AppData\Roaming\npm\claude.cmd", "--version",
+    ]
+    assert result["binary_path"] == r"C:\Users\a\AppData\Roaming\npm\claude.cmd"
+    assert result["version"] == "2.1.210"
 
 
 def test_plain_terminal_skips_agent_cli_probe() -> None:

--- a/backend/tests/test_usage_service.py
+++ b/backend/tests/test_usage_service.py
@@ -2652,6 +2652,73 @@ async def test_grok_billing_rpc_with_fake_stdio(tmp_path, monkeypatch):
     assert windows and windows[0]["usedPercent"] == 10.0
 
 
+async def test_grok_billing_rpc_starts_a_windows_shim_through_cmd(monkeypatch):
+    """`grok` installed by npm is a `.cmd` shim: without cmd.exe in front the
+    RPC never spawns and the badge reports the CLI unavailable."""
+    from agent_team_backend.osplat import _windows
+
+    argv: list[tuple] = []
+
+    class ClosedProc:
+        returncode = 0
+
+        class _Stdin:
+            def write(self, _data): ...
+
+            async def drain(self): ...
+
+        class _Stdout:
+            async def readline(self):
+                return b""
+
+        stdin = _Stdin()
+        stdout = _Stdout()
+
+    async def fake_exec(*a, **_k):
+        argv.append(a)
+        return ClosedProc()
+
+    monkeypatch.setattr(grok_vendor.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(grok_vendor.asyncio, "create_subprocess_exec", fake_exec)
+
+    try:
+        await grok_vendor.grok_billing_rpc(r"C:\npm\grok.cmd")
+    except ConnectionError:
+        pass  # the fake closes stdout at once; the spawn is what is under test
+
+    assert argv[0] == ("cmd.exe", "/d", "/c", r"C:\npm\grok.cmd", "agent", "stdio")
+
+
+async def test_copilot_gh_token_starts_a_windows_shim_through_cmd(monkeypatch):
+    """A scoop- or npm-installed `gh` is a `gh.cmd`, which CreateProcess never
+    finds (it only appends `.exe`) — so the token read used to return None."""
+    from agent_team_backend.osplat import _windows
+
+    argv: list[tuple] = []
+
+    class TokenProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b"gho_shim\n", b""
+
+    async def fake_exec(*a, **_k):
+        argv.append(a)
+        return TokenProc()
+
+    monkeypatch.setattr(copilot_vendor.osplat, "paths", _windows.paths)
+    monkeypatch.setattr(
+        _windows.paths, "resolve_program", lambda _name, *, path=None: r"C:\scoop\gh.cmd"
+    )
+    monkeypatch.setattr(copilot_vendor.asyncio, "create_subprocess_exec", fake_exec)
+
+    assert await copilot_vendor._copilot_gh_token("octo", "github.com") == "gho_shim"
+    assert argv[0] == (
+        "cmd.exe", "/d", "/c", r"C:\scoop\gh.cmd",
+        "auth", "token", "--user", "octo", "--hostname", "github.com",
+    )
+
+
 # ── Codex fetch: stranded in-pane login promotion ───────────────────────────
 
 async def test_fetch_codex_promotes_stranded_pane_login(monkeypatch, tmp_path, set_home):


### PR DESCRIPTION
An npm-installed CLI on Windows is a batch shim (`claude.CMD`, `gh.cmd`, `npm.cmd`), and CreateProcess cannot execute one. A sweep found ten sites that took a path from PATH and handed it to exec, plus three name comparisons and one command parse that silently failed on Windows paths. The loudest is `detect_dep`: the first thing a Windows user meets is an onboarding wizard reporting every CLI as missing.

New `osplat` members decide it once — `resolve_program` (PATHEXT-ordered lookup), `launch_kind`, `launch_argv` (wraps `.cmd`/`.bat` in `cmd.exe /d /c`, `.ps1` in powershell), and `pty_launch_parts` for the ConPTY spawn, which needs the same answer in winpty's shape. POSIX returns the program unchanged, so nothing there moves.

Routed: the dep probes and the duplicate-install probe, the pre-spawn probe (its reported `probe_command` is now what actually ran), the AI-chat runner, claude's usage and refresh probes, grok's billing RPC, copilot's `gh auth token`, `host_shell`'s allowlisted commands (the allowlist still decides the name; the seam only resolves it, and an unresolvable name keeps its rc 127), and the analyzer. The pane command is parsed with the OS's own parser instead of `shlex`, and the override/alias name checks ask for the name as the platform spells it.

Verification: macOS `ruff check backend` clean, `pytest backend/tests` **5396 passed, 9 skipped, 0 failed**; the platform-branch ratchet is untouched; every new test was mutation-checked against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)