### PR TITLE
fix(terminal): keep a live Windows CLI out of its own pane's teardown

### DIFF
--- a/backend/agent_team_backend/osplat/_windows.py
+++ b/backend/agent_team_backend/osplat/_windows.py
@@ -277,30 +277,46 @@ def _assign_to_job(job: int, pid: int) -> None:
         k.CloseHandle(handle)
 
 
-#: Root pid -> job handle for every live terminal. `kill_tree` on a root pid
-#: terminates the job instead of walking the table, which also reaches
-#: grandchildren that were spawned after the last snapshot.
-_jobs: dict[int, int] = {}
+#: Root pid -> (job handle, start-time identity) for every live terminal.
+#: `kill_tree` on a root pid terminates the job instead of walking the table,
+#: which also reaches grandchildren that were spawned after the last snapshot.
+#: The identity is what keeps a recycled pid from reaching another pane's
+#: job: a root that exited stays in the table until its handle is closed,
+#: and a new pane can be spawned onto the same pid in that window.
+_jobs: dict[int, tuple[int, str]] = {}
 _jobs_lock = threading.Lock()
 
 
 def _register_job(pid: int, job: int) -> None:
+    start = process_tree.start_time(pid)
     with _jobs_lock:
-        _jobs[pid] = job
+        _jobs[pid] = (job, start)
 
 
-def _release_job(pid: int) -> None:
-    """Close the job handle — with KILL_ON_JOB_CLOSE that ends the tree."""
+def _release_job(pid: int, job: int) -> None:
+    """Close the job handle — with KILL_ON_JOB_CLOSE that ends the tree.
+
+    Only the handle's own job is closed and only its own entry is dropped: a
+    pane spawned onto this pid after the first one exited owns the table
+    entry by then, and its job must survive the first pane's close.
+    """
     with _jobs_lock:
-        job = _jobs.pop(pid, None)
-    if job is not None:
-        _kernel32().CloseHandle(job)
+        entry = _jobs.get(pid)
+        if entry is not None and entry[0] == job:
+            del _jobs[pid]
+    _kernel32().CloseHandle(job)
 
 
 def _terminate_job(pid: int) -> bool:
     with _jobs_lock:
-        job = _jobs.get(pid)
-    if job is None:
+        entry = _jobs.get(pid)
+    if entry is None:
+        return False
+    job, start = entry
+    # A pid whose identity no longer matches (or never could be read) is not
+    # the process this job was made for: leave the job alone and let the
+    # caller walk the table for whatever runs under that pid now.
+    if not start or process_tree.start_time(pid) != start:
         return False
     return bool(_kernel32().TerminateJobObject(job, _TERMINATE_EXIT_CODE))
 
@@ -603,9 +619,31 @@ class WindowsTerminalHandle:
                     break
                 time.sleep(_PUMP_IDLE_S)
         finally:
-            with self._lock:
-                self._eof = True
-            self._notify()
+            # The read ending is not the child ending. Once `close()` has
+            # cut the read, or without a watcher to say otherwise, it is
+            # EOF; but an output stream that ends under a child that is
+            # still running must not become one — `terminals` closes the
+            # session on EOF, and that close tears the pseudoconsole out
+            # from under a live CLI. The watcher owns the exit: it makes
+            # the EOF once the process handle signals.
+            if self._closed or not self._process_handle or self._child_exited():
+                with self._lock:
+                    self._eof = True
+                self._notify()
+            else:
+                log.warning(
+                    "conpty output ended while pid %s is still running; "
+                    "waiting for its exit before reporting EOF",
+                    self.pid,
+                )
+
+    def _child_exited(self) -> bool:
+        """Whether the process handle has signalled (the watcher's reading:
+        anything but a timeout, `WAIT_FAILED` on a handle `poll()` has
+        already released included)."""
+        return (
+            _kernel32().WaitForSingleObject(self._process_handle, 0) != WAIT_TIMEOUT
+        )
 
     def _watch_exit(self, pty: Any, process_handle: int) -> None:
         """Worker: turn the child's exit into EOF on the output.
@@ -724,7 +762,7 @@ class WindowsTerminalHandle:
         # Closing the job handle is the kill (KILL_ON_JOB_CLOSE) — the same
         # outcome the POSIX close reaches through SIGHUP on the master.
         if self._job is not None:
-            _release_job(self.pid)
+            _release_job(self.pid, self._job)
         else:
             try:
                 process_tree.kill_tree(self.pid, force=True)

--- a/backend/agent_team_backend/pty_registry.py
+++ b/backend/agent_team_backend/pty_registry.py
@@ -212,6 +212,23 @@ def _signal_each(targets: "list[tuple[int, bool]]", *, force: bool) -> None:
             pass
 
 
+def _still_same(
+    targets: "list[tuple[int, bool]]", table: dict[int, tuple[int, str]]
+) -> "list[tuple[int, bool]]":
+    """The targets whose start-time identity in a fresh table still matches
+    the one in `table` (the snapshot the verdict was made on). A pid gone or
+    recycled in between is dropped; a failed fresh probe drops everything —
+    an identity that cannot be re-checked never authorizes a second kill."""
+    fresh = _ps_table()
+    if fresh is None:
+        return []
+    return [
+        (pid, group)
+        for pid, group in targets
+        if pid in fresh and _lstart_eq(fresh[pid][1], table[pid][1])
+    ]
+
+
 def _collect_stale(
     entries: dict[str, dict], table: dict[int, tuple[int, str]]
 ) -> "tuple[list[int], list[int], list[int], dict[str, dict]]":
@@ -295,7 +312,10 @@ def reap_stale(grace: float = 1.0) -> list[int]:
         if targets:
             _signal_each(targets, force=False)
             time.sleep(grace)
-            _signal_each(targets, force=True)
+            # The grace is long enough for a pid to be recycled — on Windows
+            # by this backend's own first panes — so the force round is
+            # re-verified against a fresh table instead of re-sent blind.
+            _signal_each(_still_same(targets, table), force=True)
             log.info(
                 "reaped %d orphaned PTY process group(s) %s and %d detached descendant(s) %s",
                 len(roots), roots, len(desc_group) + len(desc_solo), desc_group + desc_solo,

--- a/backend/agent_team_backend/terminals.py
+++ b/backend/agent_team_backend/terminals.py
@@ -324,14 +324,18 @@ def _ps_snapshot() -> dict[int, tuple[int, int, str]]:
     return osplat.process_tree.snapshot()
 
 
-def _descendant_pids(root_pid: int) -> list[int]:
-    """Every PID descended from root_pid (child, grandchild, ...) from one
-    snapshot. killpg on the PTY child's process group misses any grandchild
-    that called setsid to start its own session/group (some CLIs do) — those
-    outlive the group kill and become orphans. Snapshot the tree while root is
-    still alive; once it dies the grandchildren reparent to launchd (ppid 1)
-    and the ancestry is gone."""
-    return osplat.process_tree.descendants(root_pid)
+def _descendant_pids(root_pid: int) -> dict[int, str]:
+    """Every PID descended from root_pid (child, grandchild, ...) with its
+    start-time identity, from one snapshot. killpg on the PTY child's process
+    group misses any grandchild that called setsid to start its own
+    session/group (some CLIs do) — those outlive the group kill and become
+    orphans. Snapshot the tree while root is still alive; once it dies the
+    grandchildren reparent to launchd (ppid 1) and the ancestry is gone. The
+    identity is what `_kill_breakaway` checks before signalling, so a pid
+    recycled between this snapshot and the kill is left alone."""
+    snap = _ps_snapshot()
+    pids = _walk_descendants(_children_map(snap), root_pid)
+    return {pid: snap[pid][2] for pid in pids}
 
 
 # Steady-state cadence of the descendant-snapshot loop. MCP servers and other
@@ -351,13 +355,35 @@ _DESCENDANT_SNAPSHOT_FAST_S = 5.0
 _EXIT_ORPHAN_GRACE_S = 1.0
 
 
-def _kill_breakaway(pids: "list[int] | tuple[int, ...]") -> None:
-    """SIGKILL each pid still alive — the breakaway grandchildren a process-
-    group kill could not reach. Idempotent: pids already reaped by the group
-    kill raise ProcessLookupError and are skipped. Best-effort: a pid recycled
-    within the ~1s grace could in theory be mis-hit, but macOS/Linux recycle
-    pids slowly enough that this is negligible on a kill path."""
-    for pid in pids:
+def _same_process(recorded: str, current: str) -> bool:
+    """Whether two start-time identities name the same process. Empty on
+    either side is never a match — an unverifiable identity must never
+    authorize a kill. Whitespace-normalized: `ps` pads the day-of-month."""
+    return (
+        bool(recorded)
+        and bool(current)
+        and " ".join(recorded.split()) == " ".join(current.split())
+    )
+
+
+def _kill_breakaway(pids: dict[int, str]) -> None:
+    """SIGKILL each recorded pid that is still the recorded process — the
+    breakaway grandchildren a process-group kill could not reach. Takes one
+    fresh snapshot and signals only pids whose start-time identity still
+    matches the one recorded when the tree was snapshotted: a pid recycled
+    since then belongs to someone else. On Windows that someone can be the
+    backend's own next pane (the pid space is small and reused fast), so no
+    identity means no kill; a failed snapshot kills nothing. Blocking (one
+    process-table read) — call via asyncio.to_thread from the loop."""
+    if not pids:
+        return
+    snap = _ps_snapshot()
+    if not snap:
+        return  # cannot verify identities — do not kill blind
+    for pid, recorded in pids.items():
+        entry = snap.get(pid)
+        if entry is None or not _same_process(recorded, entry[2]):
+            continue
         try:
             osplat.process_tree.kill(pid, force=True)
         except (ProcessLookupError, PermissionError):
@@ -854,7 +880,7 @@ class TerminalService:
         session: TerminalSession,
         pgid: int,
         grace: float = 1.0,
-        descendants: "list[int] | tuple[int, ...]" = (),
+        descendants: dict[int, str] | None = None,
     ) -> None:
         deadline = self._loop.time() + grace
         # ASYNC110 suppressed: bounded poll (<= grace) with awaited sleeps —
@@ -875,7 +901,7 @@ class TerminalService:
             except subprocess.TimeoutExpired:
                 pass
         # Reap breakaway grandchildren that escaped the process group via setsid.
-        _kill_breakaway(descendants)
+        await asyncio.to_thread(_kill_breakaway, descendants or {})
         if session.proc.poll() is not None:
             await self._loop.run_in_executor(
                 _LIFECYCLE_EXECUTOR, pty_registry.unregister, session.proc.pid
@@ -975,15 +1001,15 @@ class TerminalService:
         launchd (ppid 1) or to this backend (observed macOS behavior) — and
         (b) still the same process, verified by comparing its ps lstart
         against the one recorded at snapshot time (defeats pid recycling;
-        empty lstart on either side skips the check). A verified orphan's
-        current subtree is killed with it (a leaked `npm exec` wrapper still
-        parents its own node child at sweep time)."""
+        an empty lstart on either side is no match — never kill unverified).
+        A verified orphan's current subtree is killed with it (a leaked
+        `npm exec` wrapper still parents its own node child at sweep time)."""
         snap = await asyncio.to_thread(_ps_snapshot)
         if not snap:
             return  # ps failed — cannot verify identities, do not kill blind
         children = _children_map(snap)
         me = os.getpid()
-        targets: list[int] = []
+        targets: dict[int, str] = {}
         for pid, recorded_lstart in descendants.items():
             entry = snap.get(pid)
             if entry is None:
@@ -991,13 +1017,14 @@ class TerminalService:
             ppid, _pgid, lstart = entry
             if not osplat.process_tree.is_orphan_parent(ppid, me):
                 continue  # still parented by a live process — not our orphan
-            if recorded_lstart and lstart and lstart != recorded_lstart:
-                continue  # pid recycled since the snapshot — different process
-            targets.append(pid)
-            targets.extend(_walk_descendants(children, pid))
+            if not _same_process(recorded_lstart, lstart):
+                continue  # recycled since the snapshot, or unverifiable — not ours
+            targets[pid] = lstart
+            for child in _walk_descendants(children, pid):
+                targets[child] = snap[child][2]
         if targets:
-            log.info("reaping %d orphaned descendant(s): %s", len(targets), targets)
-            _kill_breakaway(targets)
+            log.info("reaping %d orphaned descendant(s): %s", len(targets), list(targets))
+            await asyncio.to_thread(_kill_breakaway, targets)
 
     async def kill_all(self, grace: float = 1.0) -> None:
         """Terminate every live PTY child. Children run with
@@ -1008,17 +1035,19 @@ class TerminalService:
             self._snapshot_task.cancel()
             self._snapshot_task = None
         targets: list[tuple[TerminalSession, int]] = []
-        breakaway: list[int] = []
+        breakaway: dict[int, str] = {}
         # One shared ps snapshot for every session's descendant sweep. The
         # previous per-session snapshot (a full `ps -Ao` each, 5s budget)
         # pushed a many-pane shutdown past Electron's SIGKILL deadline, so
         # the sweep never got to the actual kills. Off the loop via to_thread.
-        children = _children_map(await asyncio.to_thread(_ps_snapshot))
+        snap = await asyncio.to_thread(_ps_snapshot)
+        children = _children_map(snap)
         for session in list(self._sessions.values()):
             if session.closed:
                 continue
             # Snapshot descendants while the child is still alive (see kill()).
-            breakaway.extend(_walk_descendants(children, session.proc.pid))
+            for pid in _walk_descendants(children, session.proc.pid):
+                breakaway[pid] = snap[pid][2]
             try:
                 targets.append((session, osplat.process_tree.group_of(session.proc.pid)))
             except ProcessLookupError:
@@ -1064,7 +1093,7 @@ class TerminalService:
         if self._reap_task is not None and not self._reap_task.done():
             await asyncio.gather(self._reap_task, return_exceptions=True)
         # Reap breakaway grandchildren that escaped every process group.
-        _kill_breakaway(breakaway)
+        await asyncio.to_thread(_kill_breakaway, breakaway)
 
     def _require(self, session_id: str) -> TerminalSession:
         session = self._sessions.get(session_id)

--- a/backend/tests/test_osplat_windows_terminal.py
+++ b/backend/tests/test_osplat_windows_terminal.py
@@ -125,6 +125,9 @@ def kernel32(monkeypatch) -> _FakeKernel32:
     fake = _FakeKernel32()
     monkeypatch.setattr(_windows, "_kernel32", lambda: fake)
     monkeypatch.setattr(_windows, "_jobs", {})
+    # The job table keys on pid + creation time; give every pid a stable one
+    # so the tests do not depend on what runs under 4242 on the host.
+    monkeypatch.setattr(_windows.process_tree, "start_time", lambda pid: f"T{pid}")
     return fake
 
 
@@ -189,7 +192,7 @@ class TestSpawn:
         assert pid == 4242
         assert kernel32.calls[4] == ("AssignProcessToJobObject", job, assign_handle)
         assert kernel32.calls[5] == ("CloseHandle", assign_handle)
-        assert _windows._jobs == {4242: job}
+        assert _windows._jobs == {4242: (job, "T4242")}
 
     def test_a_command_line_string_is_parsed_by_the_os_rules_then_rebuilt(
         self, kernel32, winpty, which_cmd_shim, monkeypatch
@@ -260,13 +263,41 @@ class TestSpawn:
 
 class TestKills:
     def test_kill_tree_terminates_the_job_when_the_root_has_one(self, kernel32):
-        _windows._jobs[77] = 555
+        _windows._jobs[77] = (555, "T77")
         _windows.process_tree.kill_tree(77, force=False)
         _windows.process_tree.kill_group(77, force=True)  # a "group" is the tree
         assert kernel32.calls == [
             ("TerminateJobObject", 555, _windows._TERMINATE_EXIT_CODE),
             ("TerminateJobObject", 555, _windows._TERMINATE_EXIT_CODE),
         ]
+
+    def test_kill_tree_leaves_the_job_of_a_recycled_pid_alone(self, kernel32, monkeypatch):
+        # The pane whose root was pid 77 has exited but not closed yet; 77 now
+        # belongs to a process started later. Its job must not be terminated
+        # (that would be a blind kill of whatever else the table says), and
+        # the walk must target what runs under 77 now.
+        _windows._jobs[77] = (555, "T77-old")
+        killed: list[int] = []
+
+        class Proc:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def children(self, recursive=False):
+                return []
+
+            def kill(self):
+                killed.append(self.pid)
+
+        monkeypatch.setattr(_windows.psutil, "Process", Proc)
+        _windows.process_tree.kill_tree(77, force=True)
+        assert kernel32.calls == []
+        assert killed == [77]
+        # An identity that could not be read at registration never matches.
+        _windows._jobs[78] = (556, "")
+        _windows.process_tree.kill_tree(78, force=True)
+        assert kernel32.calls == []
+        assert killed == [77, 78]
 
     def test_kill_tree_walks_the_table_root_first_without_a_job(self, kernel32, monkeypatch):
         order: list[int] = []
@@ -542,6 +573,49 @@ class TestHandle:
         handle._watcher.join(1)
         assert not handle._watcher.is_alive()
 
+    async def test_pump_eof_under_a_live_child_waits_for_the_watcher(self, monkeypatch):
+        import threading
+
+        # The reader ends (pipe EOF / cancelled read) while the process handle
+        # says the child is still running. That must not reach the loop as
+        # EOF: `terminals` would close the session and tear the pseudoconsole
+        # out from under a live CLI. The watcher reports the real exit.
+        pty = _FakePTY(80, 24)
+        pty.reads = ["hi", RuntimeError("Standard out reached EOF")]
+        exited = threading.Event()
+
+        class Kernel:
+            def WaitForSingleObject(self, handle, millis):
+                assert handle == 77
+                return _windows.WAIT_OBJECT_0 if exited.wait(millis / 1000) else WAIT_TIMEOUT
+
+        monkeypatch.setattr(_windows, "_kernel32", lambda: Kernel())
+        handle = _windows.WindowsTerminalHandle(pty, pty.pid, None, 77)
+        loop = asyncio.get_running_loop()
+        collected: list[bytes] = []
+        done = asyncio.Event()
+
+        def on_readable() -> None:
+            while True:
+                try:
+                    chunk = handle.read(64)
+                except BlockingIOError:
+                    return
+                if chunk is None:
+                    done.set()
+                    return
+                collected.append(chunk)
+
+        handle.start_reading(loop, on_readable)
+        await asyncio.sleep(0.1)
+        handle._pump.join(1)
+        assert not handle._pump.is_alive()  # the reader is gone...
+        assert collected == [b"hi"] and not done.is_set()  # ...but no EOF was invented
+        exited.set()
+        await asyncio.wait_for(done.wait(), 2)
+        handle._watcher.join(1)
+        assert not handle._watcher.is_alive()
+
     async def test_close_ends_the_exit_watcher_without_an_exit(self, monkeypatch):
         import threading
 
@@ -657,7 +731,7 @@ class TestHandle:
         handle = _windows.terminal_backend.spawn(
             ["claude"], cwd="C:\\", env={}, rows=1, cols=1
         )
-        job = _windows._jobs[4242]
+        job, _start = _windows._jobs[4242]
         kernel32.calls.clear()
         pty = _FakePTY.last
         handle.close()
@@ -682,13 +756,31 @@ class TestHandle:
         assert handle.proc.poll() == 9
         assert kernel32.calls.count(("CloseHandle", handle._process_handle)) == 1
 
+    def test_close_of_an_exited_pane_spares_a_successor_on_the_same_pid(
+        self, kernel32, winpty, which_cmd_shim
+    ):
+        # Pane A's root exited; before A is closed, pane B is spawned and the
+        # OS hands it the same pid. A's close must close only A's job and
+        # leave B's entry in the table — closing B's job would kill B
+        # (KILL_ON_JOB_CLOSE) right after it started.
+        first = _windows.terminal_backend.spawn(["claude"], cwd="C:\\", env={}, rows=1, cols=1)
+        job_a, _ = _windows._jobs[4242]
+        _windows.terminal_backend.spawn(["claude"], cwd="C:\\", env={}, rows=1, cols=1)
+        job_b, _ = _windows._jobs[4242]
+        assert job_a != job_b
+        kernel32.calls.clear()
+        first.close()
+        assert ("CloseHandle", job_a) in kernel32.calls
+        assert ("CloseHandle", job_b) not in kernel32.calls
+        assert _windows._jobs[4242][0] == job_b
+
     def test_close_releases_the_process_handle_of_an_exited_child(
         self, kernel32, winpty, which_cmd_shim
     ):
         handle = _windows.terminal_backend.spawn(
             ["claude"], cwd="C:\\", env={}, rows=1, cols=1
         )
-        job = _windows._jobs[4242]
+        job, _start = _windows._jobs[4242]
         kernel32.calls.clear()
         kernel32.wait_result = _windows.WAIT_OBJECT_0
         kernel32.exit_code = 3

--- a/backend/tests/test_pty_registry.py
+++ b/backend/tests/test_pty_registry.py
@@ -322,6 +322,37 @@ def test_reap_never_signals_a_recycled_pid() -> None:
     assert _registry() == {}
 
 
+def test_reap_force_round_re_verifies_identity_after_the_grace(monkeypatch) -> None:
+    # The root matched at the first look and got the polite signal; during
+    # the grace its pid was recycled (a Windows backend's own first panes can
+    # land there). The force round must be re-checked against a fresh table:
+    # the recycled pid is dropped, the still-matching descendant is kept, and
+    # a fresh probe that fails authorizes nothing.
+    tables = [
+        {77: (77, "L77"), 88: (88, "L88")},        # verdict snapshot
+        {77: (77, "L77-recycled"), 88: (88, "L88")},  # after the grace
+    ]
+    monkeypatch.setattr(pty_registry, "_ps_table", lambda: tables.pop(0))
+    monkeypatch.setattr(pty_registry, "_backend_alive", lambda pid: False)
+    sent: list[tuple[list[tuple[int, bool]], bool]] = []
+    monkeypatch.setattr(
+        pty_registry, "_signal_each",
+        lambda targets, *, force: sent.append((list(targets), force)),
+    )
+    pty_registry._save({
+        "77": {"argv0": "x", "lstart": "L77", "owner": 1, "descendants": {"88": "L88"}},
+    })
+
+    assert pty_registry.reap_stale(grace=0.0) == [77, 88]
+    assert sent == [([(77, True), (88, True)], False), ([(88, True)], True)]
+
+    tables[:] = [{77: (77, "L77")}, None]  # the fresh probe fails
+    sent.clear()
+    pty_registry._save({"77": {"argv0": "x", "lstart": "L77", "owner": 1}})
+    pty_registry.reap_stale(grace=0.0)
+    assert sent == [([(77, True)], False), ([], True)]
+
+
 def test_reap_leaves_live_sibling_entries_untouched(monkeypatch) -> None:
     proc = subprocess.Popen(["sleep", "30"], start_new_session=True)
     try:

--- a/backend/tests/test_terminals_breakaway_kill.py
+++ b/backend/tests/test_terminals_breakaway_kill.py
@@ -5,7 +5,9 @@ killpg(child_pgid) to take down the child and everything in its group. But a
 grandchild that calls setsid() starts its OWN session/group and escapes that
 killpg — it outlives the pane and accumulates as an orphan (observed: dozens of
 leftover `claude` processes exhausting RAM). _descendant_pids snapshots the
-tree before close; _kill_breakaway SIGKILLs whatever the group kill missed.
+tree before close (pid -> start-time identity); _kill_breakaway SIGKILLs
+whatever the group kill missed, but only pids that are still the recorded
+process — a pid recycled in between belongs to someone else.
 
 The setsid-grandchild harness and ps stubs are shared with
 test_terminals_exit_orphan_reap.py via conftest fixtures.
@@ -49,28 +51,83 @@ def test_descendant_pids_returns_empty_when_ps_fails(monkeypatch):
     def boom(*a, **k):
         raise OSError("no ps")
     monkeypatch.setattr(terminals.subprocess, "run", boom)
-    assert _descendant_pids(100) == []
+    assert _descendant_pids(100) == {}
 
 
-# ---- _kill_breakaway: signalling (mocked os.kill) ----
+def test_descendant_pids_records_each_start_time_identity(monkeypatch):
+    # pid -> (ppid, pgid, start): 100 → 200 → 300, and an unrelated 999
+    snap = {
+        100: (1, 100, "L100"),
+        200: (100, 100, "L200"),
+        300: (200, 300, "L300"),
+        999: (1, 999, "L999"),
+    }
+    monkeypatch.setattr(terminals, "_ps_snapshot", lambda: snap)
+    assert _descendant_pids(100) == {200: "L200", 300: "L300"}
+
+
+# ---- _kill_breakaway: signalling ----
+# Which pids get signalled is platform-neutral, but HOW they are signalled is
+# not: POSIX goes through `os.kill`, Windows through psutil. A test about the
+# choice of pids therefore stubs the seam (`process_tree.kill`), and only the
+# one test that is about SIGKILL itself stubs `os.kill` — and skips elsewhere.
 
 @pytest.mark.skipif(not hasattr(signal, "SIGKILL"), reason="POSIX SIGKILL via os.kill")
 def test_kill_breakaway_sigkills_each_pid(monkeypatch):
     killed = []
     monkeypatch.setattr(terminals.os, "kill", lambda pid, sig: killed.append((pid, sig)))
-    _kill_breakaway([11, 22, 33])
+    monkeypatch.setattr(
+        terminals, "_ps_snapshot",
+        lambda: {11: (1, 11, "L11"), 22: (1, 22, "L22"), 33: (1, 33, "L33")},
+    )
+    _kill_breakaway({11: "L11", 22: "L22", 33: "L33"})
     assert killed == [(11, signal.SIGKILL), (22, signal.SIGKILL), (33, signal.SIGKILL)]
 
 
 def test_kill_breakaway_ignores_already_dead(monkeypatch):
-    def kill(pid, sig):
+    def kill(pid, *, force):
         if pid == 22:
             raise ProcessLookupError
         if pid == 33:
             raise PermissionError
-    monkeypatch.setattr(terminals.os, "kill", kill)
+    monkeypatch.setattr(terminals.osplat.process_tree, "kill", kill)
+    monkeypatch.setattr(
+        terminals, "_ps_snapshot",
+        lambda: {11: (1, 11, "L11"), 22: (1, 22, "L22"), 33: (1, 33, "L33")},
+    )
     # must not raise
-    _kill_breakaway([11, 22, 33])
+    _kill_breakaway({11: "L11", 22: "L22", 33: "L33"})
+
+
+def test_kill_breakaway_spares_a_recycled_or_unverifiable_pid(monkeypatch):
+    killed = []
+    monkeypatch.setattr(
+        terminals.osplat.process_tree, "kill",
+        lambda pid, *, force: killed.append(pid),
+    )
+    monkeypatch.setattr(
+        terminals, "_ps_snapshot",
+        lambda: {
+            11: (1, 11, "L11"),        # same process — killed
+            22: (1, 22, "L22-new"),    # pid recycled since the snapshot
+            33: (1, 33, ""),           # identity unreadable now
+            44: (1, 44, "L44"),        # identity unreadable at snapshot time
+            # 55 is gone from the table
+        },
+    )
+    _kill_breakaway({11: "L11", 22: "L22", 33: "L33", 44: "", 55: "L55"})
+    assert killed == [11]
+
+
+def test_kill_breakaway_kills_nothing_when_the_snapshot_fails(monkeypatch):
+    killed = []
+    monkeypatch.setattr(
+        terminals.osplat.process_tree, "kill",
+        lambda pid, *, force: killed.append(pid),
+    )
+    monkeypatch.setattr(terminals, "_ps_snapshot", lambda: {})
+    _kill_breakaway({11: "L11"})
+    assert killed == []
 
 
 # ---- integration: a real setsid grandchild ----

--- a/backend/tests/test_terminals_exit_orphan_reap.py
+++ b/backend/tests/test_terminals_exit_orphan_reap.py
@@ -195,6 +195,24 @@ async def test_reap_spares_recycled_pid_via_lstart_mismatch(monkeypatch):
     assert killed == []
 
 
+async def test_reap_never_kills_an_unverifiable_descendant(monkeypatch):
+    svc = TerminalService(emit=_noop_emit)
+    # No identity on one side or the other: the pid may well have been
+    # recycled (on Windows: by this backend's next pane) — never kill blind.
+    snap = {200: (1, 200, "L200"), 300: (1, 300, "")}
+    monkeypatch.setattr(terminals, "_ps_snapshot", lambda: snap)
+    monkeypatch.setattr(
+        terminals.osplat.process_tree, "is_orphan_parent",
+        lambda ppid, me: ppid in (1, me),
+    )
+    killed: list[int] = []
+    monkeypatch.setattr(
+        terminals, "_kill_breakaway", lambda pids: killed.extend(pids)
+    )
+    await svc._reap_exit_orphans({200: "", 300: "L300"})
+    assert killed == []
+
+
 async def test_reap_noop_when_ps_fails(monkeypatch):
     svc = TerminalService(emit=_noop_emit)
     monkeypatch.setattr(terminals, "_ps_snapshot", lambda: {})

--- a/src/renderer/src/lib/__tests__/spawnHistory.test.ts
+++ b/src/renderer/src/lib/__tests__/spawnHistory.test.ts
@@ -24,6 +24,7 @@ import {
   isTerminalCrashLoopOpen,
   recordTerminalExit,
   resetTerminalCrashLoop,
+  STATUS_CONTROL_C_EXIT,
   terminalCrashKey,
 } from '@navide/terminal'
 
@@ -415,6 +416,32 @@ describe('terminal crash-loop diagnostics', () => {
     expect(isTerminalCrashLoopOpen(key)).toBe(true)
   })
 
+  it('counts a Windows STATUS_CONTROL_C_EXIT death past the one-second window', () => {
+    resetTerminalCrashLoop(key)
+    // Observed on a Windows machine: the pseudoconsole was torn down ~1047ms
+    // after spawn, so the plain fast-exit window missed it and the pane was
+    // rebuilt forever.
+    const controlCExit = { reason: 'exit', exit_code: STATUS_CONTROL_C_EXIT, uptime_ms: 1_047 }
+
+    expect(recordTerminalExit(key, controlCExit)).toEqual({ count: 1, open: false })
+    expect(recordTerminalExit(key, controlCExit)).toEqual({ count: 2, open: false })
+    expect(recordTerminalExit(key, controlCExit)).toEqual({ count: 3, open: true })
+    expect(isTerminalCrashLoopOpen(key)).toBe(true)
+  })
+
+  it('does not widen the window for other exit codes', () => {
+    resetTerminalCrashLoop(key)
+    expect(recordTerminalExit(key, { reason: 'exit', exit_code: 1, uptime_ms: 1_047 }))
+      .toEqual({ count: 0, open: false })
+  })
+
+  it('does not treat a long-lived STATUS_CONTROL_C_EXIT as a crash', () => {
+    resetTerminalCrashLoop(key)
+    recordTerminalExit(key, { reason: 'exit', exit_code: STATUS_CONTROL_C_EXIT, uptime_ms: 1_047 })
+    expect(recordTerminalExit(key, { reason: 'exit', exit_code: STATUS_CONTROL_C_EXIT, uptime_ms: 60_000 }))
+      .toEqual({ count: 0, open: false })
+  })
+
   it('resets the consecutive count after a non-fast exit', () => {
     resetTerminalCrashLoop(key)
     recordTerminalExit(key, { reason: 'exit', exit_code: -9, uptime_ms: 50 })
@@ -422,6 +449,18 @@ describe('terminal crash-loop diagnostics', () => {
     expect(recordTerminalExit(key, { reason: 'exit', exit_code: 0, uptime_ms: 1_500 }))
       .toEqual({ count: 0, open: false })
     expect(isTerminalCrashLoopOpen(key)).toBe(false)
+  })
+
+  it('names STATUS_CONTROL_C_EXIT next to its raw Windows exit code', () => {
+    expect(formatTerminalExit({
+      reason: 'exit',
+      exit_code: STATUS_CONTROL_C_EXIT,
+      uptime_ms: 1_047,
+      startup_probe: { binary_path: 'C:\\Users\\USER\\AppData\\Roaming\\npm\\claude.CMD' },
+    })).toBe(
+      'Process exited with code 3221225786 (STATUS_CONTROL_C_EXIT: console control event or pseudoconsole closed)'
+      + ' 1047ms after spawn — C:\\Users\\USER\\AppData\\Roaming\\npm\\claude.CMD',
+    )
   })
 
   it('formats the exact signal, lifetime, and resolved binary', () => {

--- a/src/renderer/src/platform/terminal/index.ts
+++ b/src/renderer/src/platform/terminal/index.ts
@@ -75,6 +75,7 @@ export {
   recordTerminalExit,
   resetTerminalCrashLoop,
   terminalCrashKey,
+  STATUS_CONTROL_C_EXIT,
   TERMINAL_CREATE_TIMEOUT_MS,
 } from './lib/terminalLifecycle'
 export type { CrashLoopState, TerminalExitDetails, TerminalStartupProbe } from './lib/terminalLifecycle'

--- a/src/renderer/src/platform/terminal/lib/terminalLifecycle.ts
+++ b/src/renderer/src/platform/terminal/lib/terminalLifecycle.ts
@@ -20,6 +20,12 @@ export interface CrashLoopState {
 export const TERMINAL_CREATE_TIMEOUT_MS = 30_000
 
 const FAST_EXIT_MS = 1_000
+// Windows NTSTATUS for a process torn down by a console control event
+// (STATUS_CONTROL_C_EXIT). A CLI that dies this way right after spawn lost its
+// pseudoconsole rather than crashed on its own; it takes about a second, so the
+// plain FAST_EXIT_MS window misses it and the pane would be rebuilt forever.
+export const STATUS_CONTROL_C_EXIT = 0xC000013A
+const CONTROL_C_EXIT_MS = 5_000
 const CRASH_LIMIT = 3
 const crashLoops = new Map<string, CrashLoopState>()
 
@@ -39,9 +45,12 @@ export function recordTerminalExit(
   fastExitMs = FAST_EXIT_MS,
   crashLimit = CRASH_LIMIT,
 ): CrashLoopState {
+  const window = exit.exit_code === STATUS_CONTROL_C_EXIT
+    ? Math.max(fastExitMs, CONTROL_C_EXIT_MS)
+    : fastExitMs
   const isFastCrash = exit.reason === 'exit'
     && typeof exit.uptime_ms === 'number'
-    && exit.uptime_ms <= fastExitMs
+    && exit.uptime_ms <= window
   if (!isFastCrash) {
     crashLoops.delete(key)
     return { count: 0, open: false }
@@ -68,7 +77,9 @@ export function formatTerminalExit(exit: TerminalExitDetails): string {
     ? `was terminated by ${exit.signal}`
     : exit.exit_code === null
       ? `ended (${exit.reason})`
-      : `exited with code ${exit.exit_code}`
+      : exit.exit_code === STATUS_CONTROL_C_EXIT
+        ? `exited with code ${exit.exit_code} (STATUS_CONTROL_C_EXIT: console control event or pseudoconsole closed)`
+        : `exited with code ${exit.exit_code}`
   const binary = exit.startup_probe?.binary_path
   return `Process ${cause}${lifetime}${binary ? ` — ${binary}` : ''}`
 }


### PR DESCRIPTION
## Symptom

On a Windows machine (packaged build, main @ 626cc996) a Claude Code pane died about one second after spawn and was rebuilt forever:

```
[startup probe] C:\Users\USER\AppData\Roaming\npm\claude.CMD v2.1.211, 125ms
[session] Process exited with code 3221225786 1047ms after spawn — C:\Users\USER\AppData\Roaming\npm\claude.CMD
```

`3221225786 = 0xC000013A = STATUS_CONTROL_C_EXIT`. A process killed by `TerminateJobObject`/psutil exits with code 1; only a console control event (CTRL_C / CTRL_CLOSE) or a torn-down pseudoconsole produces this code. The tracked pid is `cmd.exe` (CreateProcess runs a `.CMD` through `%COMSPEC% /c`), so the code is cmd's: either its batch was interrupted before node took raw mode, or the pseudoconsole was closed under it.

The user's log is not in hand yet, so this PR does not bet on one root cause. It guards all three candidates so the pane survives whichever is real, and adds the one log line that will tell them apart once the log arrives.

## Candidate 1 — we tear down the pseudoconsole ourselves (false EOF)

`_windows.py` `_run_pump`: when winpty-rs's reader ended (read raised, or `iseof()/!isalive()`), the `finally` unconditionally set `_eof` → `terminals._on_readable` read `None` → `_close(reason="exit")` → `handle.close()` → job closed (`KILL_ON_JOB_CLOSE`) and pseudoconsole released. One early EOF from the reader and a live CLI is torn down by its own pane.

Now (`osplat/_windows.py` pump `finally` + `_child_exited`): the pump reports EOF only when `close()` cut the read, there is no watcher (no process handle), or the process handle has signalled (`WaitForSingleObject(h, 0) != WAIT_TIMEOUT`, the watcher's own reading). Otherwise it logs

```
conpty output ended while pid %s is still running; waiting for its exit before reporting EOF
```

and leaves the EOF to `_watch_exit`, which already sets it when the child really exits. **That warning is the discriminator for the user's log**: present → candidate 1; absent with a 0xC000013A → a control event reached the batch layer (candidate 3).

POSIX untouched: there the kernel's EOF (every slave fd closed) is already the authority, so `_on_readable`/`_close` are not gated.

Cost, stated: if a reader really ends early under a live child, that pane receives no more output until the child exits. It stays alive instead of being killed; the warning records it.

## Candidate 2 — a recycled pid gets killed by our own reapers

Windows reuses pids quickly, and the backend's own next pane is the likeliest taker. Four kill paths now verify pid + start-time identity before signalling, each closing a concrete hole:

| Path | Hole before | Now |
|---|---|---|
| `terminals._kill_breakaway` | took bare pids from a snapshot made before the kill and SIGKILLed whatever held them (comment admitted the recycle risk) | takes `pid → start`, re-snapshots, kills only `_same_process()` matches; empty identity on either side = no kill; failed snapshot = no kills. Callers (`_escalate_kill`, `_reap_exit_orphans`, `kill_all`) run it via `asyncio.to_thread` |
| `terminals._reap_exit_orphans` | `recorded and lstart and !=` skipped the check when either side was empty, then killed. On Windows `is_orphan_parent` is `ppid in (0, me)` — the backend's own children qualify — so an unverifiable recycled pid was a blind kill of our own process | fail-closed: unverifiable → skipped |
| `osplat/_windows.py` `_jobs` | keyed by pid only. Pane A's root exits; before A's `close()`, pane B spawns and lands on the same pid; `_register_job` overwrites the entry; A's `_release_job(pid)` pops **B's** job and `CloseHandle`s it → `KILL_ON_JOB_CLOSE` kills B's whole tree right after it started. `_terminate_job(pid)` had the same blindness | table is `pid → (job, start_time)`. `_release_job(pid, job)` only drops the entry if it is its own job and only ever closes its own handle; `_terminate_job` refuses when the identity is empty or no longer matches, so `kill_tree` walks the table for what runs under that pid now |
| `pty_registry.reap_stale` | verified identities once, sent SIGTERM, slept the grace, then sent SIGKILL to the same pid list unverified | `_still_same()` re-reads the table after the grace; only still-matching targets get the forced round; a failed re-probe sends nothing |

No feature module gained a platform branch (`test_osplat.py` ratchets stay green).

## Candidate 3 — a console control event reaches the cmd.exe layer

Analysed, deliberately not changed here. Writing `\x03` into ConPTY (`terminals.interrupt`) is exactly what Windows Terminal does on Ctrl+C: conhost turns it into CTRL_C_EVENT only while `ENABLE_PROCESSED_INPUT` is on; once the CLI is in raw mode it is one byte, same as macOS. `cmd.exe` has its own ctrl handler and does not die from CTRL_C — it terminates the batch, which is what yields 0xC000013A if the event lands before node takes raw mode (the first ~1s is the shim's own batch lines plus node startup). `GenerateConsoleCtrlEvent` cannot target another console without an AttachConsole dance and would reach cmd.exe as well; CTRL_BREAK needs `CREATE_NEW_PROCESS_GROUP`, which winpty-rs controls. The real fix is to resolve the npm `.CMD` shim to `node.exe <cli.js>` and drop the cmd.exe layer — a separate branch, coming next.

## Crash-loop brake (frontend)

`terminalLifecycle.ts`: `FAST_EXIT_MS = 1000` missed the observed 1047ms, so the brake never opened and the pane was rebuilt without end. A `STATUS_CONTROL_C_EXIT` exit now counts as a fast crash within 5s; no platform check needed since POSIX cannot produce that code. `formatTerminalExit` names the status next to the raw code so the pane line reads `exited with code 3221225786 (STATUS_CONTROL_C_EXIT: console control event or pseudoconsole closed)`.

## Tests

Every guard has a test that fails on the previous code (verified by stashing the production files: 13 backend + 2 frontend red):

- `test_osplat_windows_terminal.py`: `test_pump_eof_under_a_live_child_waits_for_the_watcher`, `TestKills::test_kill_tree_leaves_the_job_of_a_recycled_pid_alone`, `TestHandle::test_close_of_an_exited_pane_spares_a_successor_on_the_same_pid`
- `test_terminals_breakaway_kill.py`: `test_descendant_pids_records_each_start_time_identity`, `test_kill_breakaway_spares_a_recycled_or_unverifiable_pid`, `test_kill_breakaway_kills_nothing_when_the_snapshot_fails`
- `test_terminals_exit_orphan_reap.py`: `test_reap_never_kills_an_unverifiable_descendant`
- `test_pty_registry.py`: `test_reap_force_round_re_verifies_identity_after_the_grace`
- `spawnHistory.test.ts`: STATUS_CONTROL_C_EXIT at 1047ms opens the brake after three; other codes keep the 1s window; a 60s STATUS_CONTROL_C_EXIT is not a crash; the exit line names the status

## A test that had quietly stopped testing anything on Windows

The first Windows CI run failed `test_kill_breakaway_spares_a_recycled_or_unverifiable_pid` with `assert [] == [11]`, green on macOS. `_kill_breakaway` signals through the seam `osplat.process_tree.kill`, which is `os.kill` on POSIX and `psutil.Process(pid).kill()` on Windows — the test stubbed `terminals.os.kill`, which is simply not on the Windows path, so nothing was ever recorded.

The product is fine there, and that was checked rather than assumed: Windows' `process_tree.start_time()` returns `repr(float(create_time))` (e.g. `'1700000000.25'`, never empty), `identity()` is `'4242:1700000000.25'`, and `_same_process` only normalises and compares strings. The fail-closed rule cannot misfire on Windows for want of an identity.

The more serious find is the neighbour, `test_kill_breakaway_ignores_already_dead`. It stubbed `os.kill` too, so on Windows psutil ran for real — and since `psutil.Process(11).kill()` raises `NoSuchProcess`, which the code translates and swallows, the test **passed while testing nothing it claimed to**. A red test tells you something; a test that silently becomes empty on one platform tells you nothing and looks like coverage. Both tests now stub the seam.

The rule is left in the file where the next person adding a test will read it:

```
# Which pids get signalled is platform-neutral, but HOW they are signalled is
# not: POSIX goes through `os.kill`, Windows through psutil. A test about the
# choice of pids therefore stubs the seam (`process_tree.kill`), and only the
# one test that is about SIGKILL itself stubs `os.kill` — and skips elsewhere.
```

## Verification

- `uv --project backend run --locked ruff check backend` → All checks passed!
- `uv --project backend run --locked pytest backend/tests` → 5491 passed, 9 skipped (macOS, rebased onto main @ f917df37)
- `pnpm vitest run src/renderer/src/lib/__tests__/spawnHistory.test.ts src/main/permissions.test.ts` → 75 passed
- `pnpm run typecheck:web` → clean

Flake noted, not touched: on a first `-x` run made while a typecheck loaded the machine, `test_terminals_ctty.py::test_child_stays_its_own_session_and_group_leader` failed once (real-PTY probe printed nothing). The file passed 6/6 alone and the full suite passed on the second run; this PR does not touch the POSIX read path. Tracked separately.

## Relation to #63

#63 (`feat/windows-launch-paths`) edits the `Paths` section of `osplat/_windows.py` and adds `pty_launch_parts`; this PR edits the job table, pump and kill sections of the same file. Based on the same `origin/main` (36e5dd3b); no overlap expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

