### PR TITLE
fix(linux): ws token data dir, bash rc PATH probe, ssh askpass

### DIFF
--- a/backend/agent_team_backend/git_service.py
+++ b/backend/agent_team_backend/git_service.py
@@ -3088,8 +3088,10 @@ async def create_askpass_context(
     """Start a one-shot loopback TCP server for a GIT_ASKPASS helper to call back into.
 
     Returns (env, cleanup):
-      env     -- vars to merge into the git subprocess environment: GIT_ASKPASS
-                 pointing at git_askpass_helper.py, plus the port/token the
+      env     -- vars to merge into the git subprocess environment: the
+                 platform's `git_subprocess_env` (GIT_ASKPASS pointing at
+                 git_askpass_helper.py and, on POSIX, the SSH_ASKPASS trio so
+                 ssh's own prompts arrive here too), plus the port/token the
                  helper needs to reach this server.
       cleanup -- async function that closes the server; callers must invoke it
                  once the git subprocess has finished (success, failure, or
@@ -3166,7 +3168,7 @@ async def create_askpass_context(
     port = server.sockets[0].getsockname()[1]
 
     env = {
-        "GIT_ASKPASS": _ASKPASS_HELPER_PATH,
+        **paths.git_subprocess_env(_ASKPASS_HELPER_PATH),
         "NAVIDE_ASKPASS_PORT": str(port),
         "NAVIDE_ASKPASS_TOKEN": token,
     }

--- a/backend/agent_team_backend/onboarding_deps.py
+++ b/backend/agent_team_backend/onboarding_deps.py
@@ -212,18 +212,24 @@ def _path_probe_command() -> list[str] | None:
     return osplat.paths.login_path_probe()
 
 
-# Standard install prefixes merged into PATH even when the login-shell probe
-# fails (slow shell config hits the 3s timeout, GUI launches get launchd's
-# minimal PATH) — otherwise brew itself is invisible to detection and installs.
-# ~/.local/bin is where vendor install scripts (aider, opencode, cursor, kimi)
-# drop their binary and export the dir from a shell rc file — invisible
-# whenever the rc probe times out, which made a just-installed CLI still read
-# as missing. Kept in this one tuple so tests can disable every fallback at once.
-_FALLBACK_PATH_DIRS = (
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-    os.path.expanduser("~/.local/bin"),
-)
+def _parse_login_path(stdout: str) -> list[str]:
+    """PATH entries from the probe's stdout: the `LOGIN_PATH_MARKER` line."""
+    marked = [line for line in stdout.splitlines() if line.startswith(osplat.spec.LOGIN_PATH_MARKER)]
+    if not marked:
+        return []
+    value = marked[-1][len(osplat.spec.LOGIN_PATH_MARKER):].strip()
+    return [entry for entry in value.split(os.pathsep) if entry]
+
+
+def _fallback_path_dirs() -> list[str]:
+    """Standard install prefixes merged into PATH even when the login-shell
+    probe fails (slow shell config hits the 3s timeout, GUI launches get the
+    session's minimal PATH) — otherwise brew itself is invisible to detection
+    and installs, and a CLI whose installer exported its dir from a shell rc
+    file (aider, opencode, cursor, kimi into ~/.local/bin; nvm and bun on
+    Linux) still reads as missing right after installing. Which dirs those
+    are is the platform's to say — see `Paths.login_path_fallbacks`."""
+    return osplat.paths.login_path_fallbacks(Path.home())
 
 
 # The login-shell probe costs ~1-3s (interactive zsh reads the full rc chain),
@@ -260,14 +266,12 @@ def _refresh_path_from_login_shell(force: bool = False) -> None:
             text=True,
             timeout=3,
         )
-        raw = proc.stdout or ""
-        # Take the last non-empty line (login shells may emit banner text first)
-        lines = [l for l in raw.splitlines() if l.strip()]
-        if lines:
-            shell_paths = lines[-1].split(os.pathsep)
+        # Only the marked line: rc files print banners, and an interactive
+        # bash's last line was a motd on more than one machine.
+        shell_paths = _parse_login_path(proc.stdout or "")
     except Exception:  # noqa: BLE001
         pass
-    shell_paths.extend(d for d in _FALLBACK_PATH_DIRS if os.path.isdir(d))
+    shell_paths.extend(d for d in _fallback_path_dirs() if os.path.isdir(d))
     current_paths = os.environ.get("PATH", "").split(os.pathsep)
     current_set = set(current_paths)
     seen: set[str] = set()

--- a/backend/agent_team_backend/osplat/_darwin.py
+++ b/backend/agent_team_backend/osplat/_darwin.py
@@ -78,6 +78,9 @@ class DarwinLayout(DarwinPaths):
     def askpass_launcher(self, helper_py: Path, launch_argv: list[str]) -> Path:
         return _posix_paths.askpass_launcher(helper_py, launch_argv)
 
+    def git_subprocess_env(self, askpass: str) -> dict[str, str]:
+        return _posix_paths.git_subprocess_env(askpass)
+
     def executable_candidates(self, name: str) -> list[str]:
         return _posix_paths.executable_candidates(name)
 
@@ -86,6 +89,16 @@ class DarwinLayout(DarwinPaths):
 
     def login_path_probe(self) -> list[str] | None:
         return _posix_paths.login_path_probe()
+
+    def login_path_fallbacks(self, home: Path) -> list[str]:
+        # Homebrew's two prefixes plus ~/.local/bin, where Claude Code's
+        # installer and uv put their binaries.
+        return [
+            str(home / ".local" / "bin"),
+            "/usr/local/bin",
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+        ]
 
     def backend_entry_on_disk(self, entry: str) -> str:
         return _posix_paths.backend_entry_on_disk(entry)

--- a/backend/agent_team_backend/osplat/_linux.py
+++ b/backend/agent_team_backend/osplat/_linux.py
@@ -212,6 +212,9 @@ class LinuxLayout(LinuxPaths):
     def askpass_launcher(self, helper_py: Path, launch_argv: list[str]) -> Path:
         return _posix_paths.askpass_launcher(helper_py, launch_argv)
 
+    def git_subprocess_env(self, askpass: str) -> dict[str, str]:
+        return _posix_paths.git_subprocess_env(askpass)
+
     def executable_candidates(self, name: str) -> list[str]:
         return _posix_paths.executable_candidates(name)
 
@@ -219,7 +222,25 @@ class LinuxLayout(LinuxPaths):
         return _posix_paths.is_executable(path)
 
     def login_path_probe(self) -> list[str] | None:
-        return _posix_paths.login_path_probe()
+        # `-i` for bash too: the stock Debian/Ubuntu ~/.bashrc, where nvm and
+        # bun put their PATH lines, returns at once in a non-interactive shell.
+        return _posix_paths.login_path_probe(interactive_bash=True)
+
+    def login_path_fallbacks(self, home: Path) -> list[str]:
+        # The dirs the Linux installers use and the session PATH omits: the
+        # XDG-adjacent ones (uv, pnpm, `npm config set prefix`), the Rust and
+        # bun toolchains, nvm's per-version bins, and snap's, which most
+        # distributions leave off a .desktop-launched PATH.
+        return [
+            str(home / ".local" / "bin"),
+            str(home / ".local" / "share" / "pnpm"),
+            str(home / ".npm-global" / "bin"),
+            str(home / ".cargo" / "bin"),
+            str(home / ".bun" / "bin"),
+            *_posix_paths.nvm_node_bins(home),
+            "/usr/local/bin",
+            "/snap/bin",
+        ]
 
     def backend_entry_on_disk(self, entry: str) -> str:
         return _posix_paths.backend_entry_on_disk(entry)

--- a/backend/agent_team_backend/osplat/_posix_paths.py
+++ b/backend/agent_team_backend/osplat/_posix_paths.py
@@ -14,6 +14,8 @@ import stat
 import sys
 from pathlib import Path
 
+from . import spec
+
 log = logging.getLogger(__name__)
 
 
@@ -83,7 +85,12 @@ def is_executable(path: Path) -> bool:
     return os.access(path, os.X_OK)
 
 
-def login_path_probe() -> list[str]:
+#: What the probe runs: `printf` rather than `echo` so the marker and the
+#: value land on one line whatever the rc files printed before it.
+LOGIN_PATH_PROBE_SCRIPT = f'printf "{spec.LOGIN_PATH_MARKER}%s\\n" "$PATH"'
+
+
+def login_path_probe(*, interactive_bash: bool = False) -> list[str]:
     """The shell invocation used to read the user's real PATH.
 
     Uses $SHELL, not bash: installers write PATH exports into the user's own
@@ -91,11 +98,49 @@ def login_path_probe() -> list[str]:
     INTERACTIVE mode — a plain login shell (-lc) misses it (real case: grok's
     installer writes to ~/.zshrc; `zsh -lc` couldn't see it, so both detection
     and spawn kept failing with command-not-found after install).
+
+    `interactive_bash` asks the same of bash. Linux wants it: the nvm, bun and
+    `npm config set prefix` instructions all append to ~/.bashrc, and the
+    Debian/Ubuntu stock ~/.bashrc returns at its first line unless the shell
+    is interactive, so `bash -lc` sees ~/.profile and nothing else. macOS
+    keeps `-lc` for bash — the shipped bash 3.2 rc files are not written with
+    an interactive-but-headless shell in mind, and that is what shipped there.
+    Same split as `loginShellFlags` in src/shared/osplat.ts.
     """
     shell = os.environ.get("SHELL") or "/bin/bash"
-    if os.path.basename(shell) == "zsh":
-        return [shell, "-ilc", "echo $PATH"]
-    return [shell, "-lc", "echo $PATH"]
+    name = os.path.basename(shell)
+    interactive = name == "zsh" or (interactive_bash and name == "bash")
+    return [shell, "-ilc" if interactive else "-lc", LOGIN_PATH_PROBE_SCRIPT]
+
+
+def git_subprocess_env(askpass: str) -> dict[str, str]:
+    return {
+        "GIT_ASKPASS": askpass,
+        "SSH_ASKPASS": askpass,
+        "SSH_ASKPASS_REQUIRE": "force",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
+def nvm_node_bins(home: Path) -> list[str]:
+    """Every `bin` nvm has installed under `home`, newest version first.
+
+    nvm exports exactly one of these (the `default` alias) and only from the
+    rc file the probe just failed to read, so which one the shell would have
+    chosen is unknowable here. A CLI installed with `npm install -g` lives
+    under the node version that installed it, so all of them go on `PATH`.
+    """
+    versions = home / ".nvm" / "versions" / "node"
+    try:
+        entries = [d for d in versions.iterdir() if (d / "bin").is_dir()]
+    except OSError:
+        return []
+
+    def key(d: Path) -> tuple[int, ...]:
+        digits = d.name.lstrip("v").split(".")
+        return tuple(int(part) if part.isdigit() else 0 for part in digits)
+
+    return [str(d / "bin") for d in sorted(entries, key=key, reverse=True)]
 
 
 def backend_entry_on_disk(entry: str) -> str:

--- a/backend/agent_team_backend/osplat/_windows.py
+++ b/backend/agent_team_backend/osplat/_windows.py
@@ -1120,6 +1120,16 @@ class WindowsDiscoveryLayout(WindowsLayout):
         # already carries it.
         return None
 
+    def login_path_fallbacks(self, home: Path) -> list[str]:
+        # Nothing the registry PATH would be missing.
+        return []
+
+    def git_subprocess_env(self, askpass: str) -> dict[str, str]:
+        # GIT_ASKPASS only, as before: whether the bundled OpenSSH execs the
+        # `.cmd` launcher as SSH_ASKPASS is unverified, and git's own prompts
+        # are the ones the Windows port has exercised.
+        return {"GIT_ASKPASS": askpass}
+
     def backend_entry_on_disk(self, entry: str) -> str:
         if Path(entry).suffix:
             return entry

--- a/backend/agent_team_backend/osplat/spec.py
+++ b/backend/agent_team_backend/osplat/spec.py
@@ -23,6 +23,12 @@ from pathlib import Path
 from typing import Callable, NamedTuple, Protocol
 
 
+#: What `Paths.login_path_probe` makes the shell print in front of `PATH`.
+#: Rc files chatter on stdout (banners, `neofetch`, a stray `echo`), and the
+#: line that carries this prefix is the only one the caller may trust.
+LOGIN_PATH_MARKER = "__NAVIDE_PATH__"
+
+
 class Paths(Protocol):
     """Where this platform keeps the kinds of directory the backend looks in.
 
@@ -118,6 +124,22 @@ class Paths(Protocol):
         """
         ...
 
+    def git_subprocess_env(self, askpass: str) -> dict[str, str]:
+        """The environment that makes every prompt a git subprocess can raise
+        go to `askpass` — git's own (HTTPS user/password) and, where ssh is
+        the transport, ssh's (key passphrase, host-key confirmation).
+
+        The backend runs git with no controlling terminal. `GIT_ASKPASS` alone
+        covers only git's prompts: ssh reads `/dev/tty` for its own, fails
+        when there is none, and honours `SSH_ASKPASS` only under a display or
+        when `SSH_ASKPASS_REQUIRE=force` says so (OpenSSH ≥ 8.4). Linux is
+        where this bites — no Keychain-backed agent holds the passphrase by
+        default — so a push over ssh died with "Permission denied (publickey)"
+        and nothing to answer. `GIT_TERMINAL_PROMPT=0` closes the last gap:
+        with askpass declined, git fails fast instead of waiting on a tty.
+        """
+        ...
+
     def executable_candidates(self, name: str) -> list[str]:
         """The file names a command called `name` may have on disk here.
 
@@ -144,6 +166,22 @@ class Paths(Protocol):
         GUI-launched backend never read; the probe recovers them. Windows
         keeps `PATH` in the registry and the process already has it, so there
         is nothing to probe — None tells the caller to keep what it has.
+
+        The line to read is the one prefixed with `LOGIN_PATH_MARKER`: the
+        shell's own rc chatter shares stdout, and "the last line" was the
+        motd on more than one machine.
+        """
+        ...
+
+    def login_path_fallbacks(self, home: Path) -> list[str]:
+        """Where user-installed tools live when the probe cannot answer.
+
+        Merged into `PATH` after whatever the probe found (or in its place
+        when the shell timed out), so a tool in one of these is found even
+        with a heavy rc file or an exotic shell. Each platform's own
+        conventions, mirroring `loginPathFallbacks` in src/shared/osplat.ts;
+        entries that do not exist on disk are the caller's to drop. Windows
+        has nothing to add: its `PATH` is the registry's and already complete.
         """
         ...
 

--- a/backend/linux_smoke.py
+++ b/backend/linux_smoke.py
@@ -83,12 +83,31 @@ def probe() -> str:
 
 
 def paths() -> str:
-    """Where state lands. XDG on Linux, and honouring the explicit override."""
+    """Where state lands. XDG on Linux, and honouring the explicit override.
+
+    The override this script pins at the top is the dev-launcher contract; a
+    packaged app never sets it, so the second half asks the question CI could
+    not see for a whole release: with no override, does the backend land under
+    ``$XDG_DATA_HOME`` — the directory main's ``resolveBackendDataDir`` reads
+    the ws token from — and not under ``$XDG_CONFIG_HOME``, which is where
+    Electron's ``appData`` points on Linux and where main once looked?
+    """
     from agent_team_backend import applog, osplat
 
     data = applog.app_data_dir()
     config = osplat.paths.app_support_dir("Cursor")
-    return f"data={data} cursor={config}"
+
+    override = os.environ.pop("AGENT_TEAM_DATA_DIR")
+    try:
+        packaged = applog.app_data_dir()
+    finally:
+        os.environ["AGENT_TEAM_DATA_DIR"] = override
+    expected = os.path.join(os.environ["XDG_DATA_HOME"], "Agent-Team")
+    if str(packaged) != expected:
+        raise AssertionError(f"no-override data dir is {packaged}, expected {expected}")
+    if str(packaged).startswith(os.environ["XDG_CONFIG_HOME"]):
+        raise AssertionError(f"no-override data dir {packaged} sits under XDG_CONFIG_HOME")
+    return f"data={data} packaged={packaged} cursor={config}"
 
 
 def pty_round_trip() -> str:

--- a/backend/tests/test_git_askpass.py
+++ b/backend/tests/test_git_askpass.py
@@ -300,3 +300,83 @@ async def test_the_askpass_entry_mode_answers_a_prompt_like_the_helper_does():
     assert proc.returncode == 0
     assert stdout.splitlines()[0] == b"s3cr3t-token"
     assert received == ["Password for 'https://x':"]
+
+
+# ── ssh prompts reach the same helper ────────────────────────────────────────
+
+_posix_only = pytest.mark.skipif(sys.platform == "win32", reason="POSIX askpass trio; Windows keeps GIT_ASKPASS only")
+
+
+class TestGitSubprocessEnv:
+    def test_posix_routes_ssh_prompts_to_the_same_helper(self):
+        from agent_team_backend.osplat import _darwin, _linux
+
+        for impl in (_linux.paths, _darwin.paths):
+            assert impl.git_subprocess_env("/state/ask.sh") == {
+                "GIT_ASKPASS": "/state/ask.sh",
+                "SSH_ASKPASS": "/state/ask.sh",
+                "SSH_ASKPASS_REQUIRE": "force",
+                "GIT_TERMINAL_PROMPT": "0",
+            }
+
+    def test_windows_keeps_git_askpass_only(self):
+        from agent_team_backend.osplat import _windows
+
+        assert _windows.paths.git_subprocess_env(r"C:\state\ask.cmd") == {"GIT_ASKPASS": r"C:\state\ask.cmd"}
+
+    @pytest.mark.asyncio
+    async def test_context_env_carries_the_platform_trio(self):
+        from agent_team_backend.osplat import paths
+
+        async def on_request(request_id: str, prompt: str) -> None:
+            pass
+
+        env, cleanup = await git_service.create_askpass_context(on_request)
+        try:
+            for key, value in paths.git_subprocess_env(env["GIT_ASKPASS"]).items():
+                assert env[key] == value
+        finally:
+            await cleanup()
+
+    @_posix_only
+    def test_ssh_answers_a_passphrase_through_the_trio_with_no_tty(self, tmp_path):
+        """The bug: ssh reads /dev/tty for a key passphrase and, with no tty and
+        no display, ignores SSH_ASKPASS — so a push over ssh from the backend
+        died with nothing to answer. With the trio, ssh-keygen (same
+        read_passphrase as ssh) asks the helper instead."""
+        import shutil
+        import subprocess
+
+        from agent_team_backend.osplat import _linux
+
+        if shutil.which("ssh-keygen") is None:
+            pytest.skip("no ssh-keygen on this machine")
+        key = tmp_path / "id_ed25519"
+        subprocess.run(
+            ["ssh-keygen", "-q", "-t", "ed25519", "-N", "pp-secret", "-f", str(key), "-C", "t"],
+            check=True, timeout=30,
+        )
+        helper = tmp_path / "ask.sh"
+        helper.write_text("#!/bin/sh\necho pp-secret\n")
+        helper.chmod(0o755)
+        base = {"PATH": os.environ.get("PATH", ""), "HOME": str(tmp_path)}
+
+        with_trio = subprocess.run(
+            ["ssh-keygen", "-y", "-f", str(key)],
+            env={**base, **_linux.paths.git_subprocess_env(str(helper))},
+            stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=30,
+        )
+        assert with_trio.returncode == 0, with_trio.stderr
+        assert with_trio.stdout.startswith("ssh-ed25519 ")
+
+        # GIT_ASKPASS alone (what the env used to carry): ssh never consults it.
+        # A new session so there is no controlling tty for ssh-keygen to fall
+        # back to — from a developer's terminal it would otherwise sit on
+        # /dev/tty waiting for someone to type.
+        without = subprocess.run(
+            ["ssh-keygen", "-y", "-f", str(key)],
+            env={**base, "GIT_ASKPASS": str(helper)},
+            stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=30,
+            start_new_session=True,
+        )
+        assert without.returncode != 0

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -445,10 +445,13 @@ def test_start_ollama_service_requires_ollama(monkeypatch: pytest.MonkeyPatch) -
     assert ob.start_ollama_service()["ok"] is False
 
 
-def test_local_bin_is_a_path_fallback() -> None:
+def test_local_bin_is_a_path_fallback(tmp_path) -> None:
     # aider / opencode / cursor / kimi install scripts land in ~/.local/bin and
     # export it from a shell rc file the 3s probe can miss.
-    assert any(p.endswith("/.local/bin") for p in ob._FALLBACK_PATH_DIRS)
+    from agent_team_backend.osplat import _darwin, _linux
+
+    for paths in (_darwin.paths, _linux.paths):
+        assert str(tmp_path / ".local" / "bin") in paths.login_path_fallbacks(tmp_path)
 
 
 # ── completion flag ───────────────────────────────────────────────────────────

--- a/backend/tests/test_onboarding_path_refresh.py
+++ b/backend/tests/test_onboarding_path_refresh.py
@@ -11,8 +11,11 @@ import subprocess
 import pytest
 
 # Import the private function directly for unit testing
+from pathlib import Path
+
 from agent_team_backend import osplat
 from agent_team_backend import onboarding_deps
+from agent_team_backend.osplat import _darwin, _linux, _posix_paths, _windows
 from agent_team_backend.onboarding_deps import (
     _path_probe_command,
     _refresh_path_from_login_shell,
@@ -36,11 +39,27 @@ def _reset_path_probe_cache(monkeypatch):
     monkeypatch.setattr(onboarding_deps, "_path_refreshed_at", None)
 
 
+MARKER = osplat.spec.LOGIN_PATH_MARKER
+
+
 def _make_run_result(stdout: str, returncode: int = 0) -> MagicMock:
     result = MagicMock()
     result.stdout = stdout
     result.returncode = returncode
     return result
+
+
+def _probe_output(path: str, *chatter: str) -> str:
+    """What the marker probe prints: rc-file chatter, then the marked PATH."""
+    return "".join(f"{line}\n" for line in chatter) + f"{MARKER}{path}\n"
+
+
+def _no_fallbacks(monkeypatch) -> None:
+    monkeypatch.setattr(osplat.paths, "login_path_fallbacks", lambda home: [])
+
+
+def _fallbacks(monkeypatch, *dirs) -> None:
+    monkeypatch.setattr(osplat.paths, "login_path_fallbacks", lambda home: list(dirs))
 
 
 # ── merge order ──────────────────────────────────────────────────────────────
@@ -51,7 +70,7 @@ def test_new_paths_prepended(monkeypatch):
     """Paths returned by the shell that are absent from PATH should be prepended."""
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     shell_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-    with patch("subprocess.run", return_value=_make_run_result(shell_path + "\n")):
+    with patch("subprocess.run", return_value=_make_run_result(_probe_output(shell_path))):
         _refresh_path_from_login_shell()
     parts = os.environ["PATH"].split(":")
     assert parts[0] == "/opt/homebrew/bin"
@@ -65,7 +84,7 @@ def test_existing_paths_not_duplicated(monkeypatch):
     """Paths already in PATH must not appear twice after refresh."""
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     shell_path = "/usr/bin:/bin"
-    with patch("subprocess.run", return_value=_make_run_result(shell_path + "\n")):
+    with patch("subprocess.run", return_value=_make_run_result(_probe_output(shell_path))):
         _refresh_path_from_login_shell()
     parts = os.environ["PATH"].split(":")
     assert parts.count("/usr/bin") == 1
@@ -80,7 +99,7 @@ def test_dedup_within_shell_output(monkeypatch):
     """Even if shell output contains duplicates, only first occurrence is added."""
     monkeypatch.setenv("PATH", "/usr/bin")
     shell_path = "/new/path:/new/path:/usr/bin"
-    with patch("subprocess.run", return_value=_make_run_result(shell_path + "\n")):
+    with patch("subprocess.run", return_value=_make_run_result(_probe_output(shell_path))):
         _refresh_path_from_login_shell()
     parts = os.environ["PATH"].split(":")
     assert parts.count("/new/path") == 1
@@ -91,7 +110,7 @@ def test_dedup_within_shell_output(monkeypatch):
 
 def test_timeout_swallowed(monkeypatch):
     """TimeoutExpired must not propagate; PATH unchanged (fallback disabled)."""
-    monkeypatch.setattr(onboarding_deps, "_FALLBACK_PATH_DIRS", ())
+    _no_fallbacks(monkeypatch)
     original = "/usr/bin:/bin"
     monkeypatch.setenv("PATH", original)
     with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="bash", timeout=3)):
@@ -101,7 +120,7 @@ def test_timeout_swallowed(monkeypatch):
 
 def test_oserror_swallowed(monkeypatch):
     """OSError (e.g. bash not found) must not propagate."""
-    monkeypatch.setattr(onboarding_deps, "_FALLBACK_PATH_DIRS", ())
+    _no_fallbacks(monkeypatch)
     original = "/usr/bin:/bin"
     monkeypatch.setenv("PATH", original)
     with patch("subprocess.run", side_effect=OSError("not found")):
@@ -109,19 +128,18 @@ def test_oserror_swallowed(monkeypatch):
     assert os.environ["PATH"] == original
 
 
-def test_garbage_output_no_crash(monkeypatch):
-    """Non-path garbage in stdout must not raise; PATH may be unchanged or extended."""
+def test_unmarked_output_adds_nothing(monkeypatch):
+    """Output with no marked line is chatter, not a PATH: nothing is merged."""
+    _no_fallbacks(monkeypatch)
     monkeypatch.setenv("PATH", "/usr/bin")
-    # Last non-empty line is used; if it has no valid paths nothing bad happens
-    with patch("subprocess.run", return_value=_make_run_result("some banner text\n\n")):
+    with patch("subprocess.run", return_value=_make_run_result("some banner text\n/looks/like/a/path\n")):
         _refresh_path_from_login_shell()
-    # Just assert it didn't raise and PATH is still set
-    assert "PATH" in os.environ
+    assert os.environ["PATH"] == "/usr/bin"
 
 
 def test_empty_stdout_no_crash(monkeypatch):
     """Empty stdout must not crash."""
-    monkeypatch.setattr(onboarding_deps, "_FALLBACK_PATH_DIRS", ())
+    _no_fallbacks(monkeypatch)
     original = "/usr/bin"
     monkeypatch.setenv("PATH", original)
     with patch("subprocess.run", return_value=_make_run_result("")):
@@ -137,7 +155,7 @@ def test_fallback_dirs_merged_when_probe_fails(monkeypatch, tmp_path):
     """Standard install prefixes are merged even when the login-shell probe fails."""
     fallback = tmp_path / "brew-bin"
     fallback.mkdir()
-    monkeypatch.setattr(onboarding_deps, "_FALLBACK_PATH_DIRS", (str(fallback),))
+    _fallbacks(monkeypatch, str(fallback))
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="zsh", timeout=3)):
         _refresh_path_from_login_shell()
@@ -146,7 +164,7 @@ def test_fallback_dirs_merged_when_probe_fails(monkeypatch, tmp_path):
 
 def test_fallback_dir_skipped_when_missing(monkeypatch, tmp_path):
     """A fallback prefix that does not exist on disk is not added."""
-    monkeypatch.setattr(onboarding_deps, "_FALLBACK_PATH_DIRS", (str(tmp_path / "nope"),))
+    _fallbacks(monkeypatch, str(tmp_path / "nope"))
     original = "/usr/bin:/bin"
     monkeypatch.setenv("PATH", original)
     with patch("subprocess.run", side_effect=OSError("not found")):
@@ -159,9 +177,9 @@ def test_shell_paths_ordered_before_fallback(monkeypatch, tmp_path):
     """Shell-derived paths are prepended ahead of fallback prefixes."""
     fallback = tmp_path / "fb"
     fallback.mkdir()
-    monkeypatch.setattr(onboarding_deps, "_FALLBACK_PATH_DIRS", (str(fallback),))
+    _fallbacks(monkeypatch, str(fallback))
     monkeypatch.setenv("PATH", "/usr/bin")
-    with patch("subprocess.run", return_value=_make_run_result("/shell/bin:/usr/bin\n")):
+    with patch("subprocess.run", return_value=_make_run_result(_probe_output("/shell/bin:/usr/bin"))):
         _refresh_path_from_login_shell()
     parts = os.environ["PATH"].split(":")
     assert parts[0] == "/shell/bin"
@@ -169,16 +187,22 @@ def test_shell_paths_ordered_before_fallback(monkeypatch, tmp_path):
 
 
 @_needs_login_shell_probe
-def test_last_line_used_when_banner_present(monkeypatch):
-    """When shell emits a banner, the last non-empty line is treated as PATH."""
+def test_marked_line_used_whatever_the_rc_files_print(monkeypatch):
+    """The marked line is the PATH even when chatter comes before AND after
+    it — an interactive bash on Linux prints its motd last, which is exactly
+    what taking "the last non-empty line" used to merge into PATH."""
+    _no_fallbacks(monkeypatch)
     monkeypatch.setenv("PATH", "/usr/bin")
-    banner_then_path = "Welcome to zsh!\n/opt/homebrew/bin:/usr/bin\n"
-    with patch("subprocess.run", return_value=_make_run_result(banner_then_path)):
+    output = _probe_output("/opt/homebrew/bin:/usr/bin", "Welcome to zsh!") + "motd: 3 updates\n"
+    with patch("subprocess.run", return_value=_make_run_result(output)):
         _refresh_path_from_login_shell()
-    assert "/opt/homebrew/bin" in os.environ["PATH"].split(":")
+    assert os.environ["PATH"].split(":") == ["/opt/homebrew/bin", "/usr/bin"]
 
 
 # ── probe command shape ───────────────────────────────────────────────────────
+
+
+SCRIPT = _posix_paths.LOGIN_PATH_PROBE_SCRIPT
 
 
 @_needs_login_shell_probe
@@ -186,19 +210,102 @@ def test_probe_uses_interactive_zsh(monkeypatch):
     """zsh reads ~/.zshrc only in interactive mode; installers (e.g. grok)
     write PATH exports there, so the probe must run zsh with -i."""
     monkeypatch.setenv("SHELL", "/bin/zsh")
-    assert _path_probe_command() == ["/bin/zsh", "-ilc", "echo $PATH"]
+    assert _path_probe_command() == ["/bin/zsh", "-ilc", SCRIPT]
 
 
-@_needs_login_shell_probe
-def test_probe_uses_login_shell_for_non_zsh(monkeypatch):
+def test_linux_probes_bash_interactively(monkeypatch):
+    """The stock Debian/Ubuntu ~/.bashrc — where nvm, bun and npm-global put
+    their PATH exports — returns at its first line unless the shell is
+    interactive, so `bash -lc` sees ~/.profile and nothing else."""
     monkeypatch.setenv("SHELL", "/bin/bash")
-    assert _path_probe_command() == ["/bin/bash", "-lc", "echo $PATH"]
+    assert _linux.paths.login_path_probe() == ["/bin/bash", "-ilc", SCRIPT]
+
+
+def test_macos_keeps_a_plain_login_bash(monkeypatch):
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    assert _darwin.paths.login_path_probe() == ["/bin/bash", "-lc", SCRIPT]
+
+
+def test_other_shells_get_a_plain_login_shell_everywhere(monkeypatch):
+    monkeypatch.setenv("SHELL", "/usr/bin/fish")
+    assert _linux.paths.login_path_probe() == ["/usr/bin/fish", "-lc", SCRIPT]
+    assert _darwin.paths.login_path_probe() == ["/usr/bin/fish", "-lc", SCRIPT]
 
 
 @_needs_login_shell_probe
 def test_probe_falls_back_to_bash_without_shell_env(monkeypatch):
     monkeypatch.delenv("SHELL", raising=False)
-    assert _path_probe_command() == ["/bin/bash", "-lc", "echo $PATH"]
+    assert _path_probe_command()[0] == "/bin/bash"
+    assert _path_probe_command()[-1] == SCRIPT
+
+
+def test_probe_script_marks_the_path_line():
+    """The script prints the marker and PATH on ONE line, so the parser can
+    pick it out of whatever the rc files printed around it."""
+    proc = subprocess.run(["/bin/sh", "-c", SCRIPT], capture_output=True, text=True,
+                          env={"PATH": "/a:/b"}, timeout=5)
+    assert proc.stdout == f"{MARKER}/a:/b\n"
+
+
+# ── fallback lists per platform ──────────────────────────────────────────────
+
+
+def test_linux_fallbacks_name_the_node_manager_and_toolchain_dirs(tmp_path):
+    """A .desktop-launched app on Linux gets the session PATH, which has none
+    of these; nvm's per-version bins come newest first."""
+    for v in ("v18.20.4", "v22.11.0", "v20.19.0"):
+        (tmp_path / ".nvm" / "versions" / "node" / v / "bin").mkdir(parents=True)
+    dirs = _linux.paths.login_path_fallbacks(tmp_path)
+    assert dirs == [
+        str(tmp_path / ".local" / "bin"),
+        str(tmp_path / ".local" / "share" / "pnpm"),
+        str(tmp_path / ".npm-global" / "bin"),
+        str(tmp_path / ".cargo" / "bin"),
+        str(tmp_path / ".bun" / "bin"),
+        str(tmp_path / ".nvm" / "versions" / "node" / "v22.11.0" / "bin"),
+        str(tmp_path / ".nvm" / "versions" / "node" / "v20.19.0" / "bin"),
+        str(tmp_path / ".nvm" / "versions" / "node" / "v18.20.4" / "bin"),
+        "/usr/local/bin",
+        "/snap/bin",
+    ]
+
+
+def test_linux_fallbacks_without_nvm(tmp_path):
+    dirs = _linux.paths.login_path_fallbacks(tmp_path)
+    assert not any(".nvm" in d for d in dirs)
+    assert "/snap/bin" in dirs
+
+
+def test_macos_fallbacks_are_the_homebrew_prefixes(tmp_path):
+    assert _darwin.paths.login_path_fallbacks(tmp_path) == [
+        str(tmp_path / ".local" / "bin"),
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+    ]
+
+
+def test_windows_has_no_fallbacks(tmp_path):
+    assert _windows.paths.login_path_fallbacks(tmp_path) == []
+
+
+def test_refresh_asks_the_platform_for_its_fallbacks(monkeypatch, tmp_path):
+    """The merge goes through the seam, not a module-level tuple."""
+    fallback = tmp_path / "platform-bin"
+    fallback.mkdir()
+    seen: list = []
+
+    def fallbacks(home):
+        seen.append(home)
+        return [str(fallback)]
+
+    monkeypatch.setattr(osplat.paths, "login_path_fallbacks", fallbacks)
+    monkeypatch.setattr(osplat.paths, "login_path_probe", lambda: ["/bin/sh", "-c", "true"])
+    monkeypatch.setenv("PATH", "/usr/bin")
+    with patch("subprocess.run", return_value=_make_run_result("")):
+        _refresh_path_from_login_shell()
+    assert seen == [Path.home()]
+    assert os.environ["PATH"].split(":")[0] == str(fallback)
 
 
 # ── non-POSIX no-op ───────────────────────────────────────────────────────────
@@ -248,7 +355,7 @@ def test_detection_missing_to_ok_after_refresh(monkeypatch, tmp_path):
     assert result_before["status"] == "missing"
 
     # Simulate login shell returning a PATH that includes tmp_path
-    shell_path_output = f"{tmp_path}:/usr/bin:/bin\n"
+    shell_path_output = _probe_output(f"{tmp_path}:/usr/bin:/bin")
     with patch("subprocess.run", return_value=_make_run_result(shell_path_output)):
         _refresh_path_from_login_shell()
 

--- a/backend/tests/test_onboarding_path_refresh.py
+++ b/backend/tests/test_onboarding_path_refresh.py
@@ -239,6 +239,7 @@ def test_probe_falls_back_to_bash_without_shell_env(monkeypatch):
     assert _path_probe_command()[-1] == SCRIPT
 
 
+@_needs_login_shell_probe
 def test_probe_script_marks_the_path_line():
     """The script prints the marker and PATH on ONE line, so the parser can
     pick it out of whatever the rc files printed around it."""
@@ -305,7 +306,7 @@ def test_refresh_asks_the_platform_for_its_fallbacks(monkeypatch, tmp_path):
     with patch("subprocess.run", return_value=_make_run_result("")):
         _refresh_path_from_login_shell()
     assert seen == [Path.home()]
-    assert os.environ["PATH"].split(":")[0] == str(fallback)
+    assert os.environ["PATH"].split(os.pathsep)[0] == str(fallback)
 
 
 # ── non-POSIX no-op ───────────────────────────────────────────────────────────

--- a/backend/tests/test_osplat_windows_discovery.py
+++ b/backend/tests/test_osplat_windows_discovery.py
@@ -51,7 +51,7 @@ class TestExecutableCandidates:
 class TestOtherDiscoveryAnswers:
     def test_no_login_shell_to_probe(self, win) -> None:
         assert win.login_path_probe() is None
-        assert _posix_paths.login_path_probe()[-1] == "echo $PATH"
+        assert _posix_paths.login_path_probe()[-1] == _posix_paths.LOGIN_PATH_PROBE_SCRIPT
 
     def test_backend_entry_gains_exe_unless_it_names_a_suffix(self, win) -> None:
         assert win.backend_entry_on_disk("backend/navide-plans") == "backend/navide-plans.exe"

--- a/src/main/backend-ws-token-parity.test.ts
+++ b/src/main/backend-ws-token-parity.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { posix, win32 } from 'node:path'
+
+// The invariant under test: the file main reads the ws token FROM is the file
+// the backend writes it TO. Both sides derive the path independently — TS in
+// resolveBackendDataDir, Python in applog/osplat — so the only honest check
+// runs the Python side for real and compares. A packaged Linux build shipped
+// with the two disagreeing (main: ~/.config, backend: ~/.local/share) and
+// every window was refused; a test that only pinned the TS string would have
+// been green the whole time.
+
+const HOME = { posix: '/home/parity', win32: 'C:\\Users\\parity' }
+
+const electron = vi.hoisted(() => ({
+  isPackaged: true,
+  platform: 'linux' as NodeJS.Platform,
+}))
+vi.mock('electron', () => ({
+  app: {
+    get isPackaged() {
+      return electron.isPackaged
+    },
+    getPath(name: string): string {
+      const p = electron.platform
+      if (name === 'home') return p === 'win32' ? HOME.win32 : HOME.posix
+      if (name === 'appData') {
+        // What Electron's app.getPath('appData') answers on each platform.
+        if (p === 'darwin') return posix.join(HOME.posix, 'Library', 'Application Support')
+        if (p === 'win32') return win32.join(HOME.win32, 'AppData', 'Roaming')
+        return posix.join(HOME.posix, '.config')
+      }
+      throw new Error(`unexpected app.getPath(${name})`)
+    },
+  },
+}))
+
+import { backendDataDir, wsTokenPath } from './backend'
+
+type Vars = Record<string, string | undefined>
+
+/**
+ * Ask the backend where it writes the ws token, with HOME and the XDG /
+ * Windows base variables pinned. `layout` selects an osplat implementation
+ * explicitly ('host' is whatever this machine selects — the packaged case).
+ */
+function pythonWsTokenPath(layout: 'host' | 'linux', vars: Vars): string {
+  const script = `
+import json, os, sys
+vars = json.loads(os.environ["NAVIDE_PARITY_VARS"])
+for key in ("AGENT_TEAM_DATA_DIR", "XDG_DATA_HOME", "APPDATA"):
+    os.environ.pop(key, None)
+os.environ["HOME"] = vars["HOME"]
+os.environ["USERPROFILE"] = vars["HOME"]
+for key, value in vars.items():
+    if key != "HOME" and value is not None:
+        os.environ[key] = value
+layout = ${JSON.stringify(layout)}
+if layout == "host":
+    from agent_team_backend import applog
+    print(applog.backend_ws_token_file())
+else:
+    from agent_team_backend.osplat import _linux
+    print(_linux.LinuxLayout().state_dir("Agent-Team") / "backend-ws-token")
+`
+  return execFileSync('uv', ['--project', 'backend', 'run', '--locked', 'python', '-'], {
+    input: script,
+    encoding: 'utf8',
+    env: { ...process.env, NAVIDE_PARITY_VARS: JSON.stringify(vars) },
+    timeout: 60_000,
+  }).trim()
+}
+
+function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const real = Object.getOwnPropertyDescriptor(process, 'platform')!
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+  electron.platform = platform
+  try {
+    return fn()
+  } finally {
+    Object.defineProperty(process, 'platform', real)
+    electron.platform = 'linux'
+  }
+}
+
+describe('ws token path parity (main reads where the backend writes)', () => {
+  afterEach(() => {
+    electron.isPackaged = true
+  })
+
+  it('agrees with the backend on this platform for a packaged app', () => {
+    const home = process.platform === 'win32' ? HOME.win32 : HOME.posix
+    const expected = pythonWsTokenPath('host', { HOME: home })
+    const actual = withPlatform(process.platform, () => wsTokenPath(backendDataDir({})))
+    expect(actual).toBe(expected)
+  })
+
+  it.skipIf(process.platform === 'win32')('agrees with the Linux layout, default XDG', () => {
+    const expected = pythonWsTokenPath('linux', { HOME: HOME.posix })
+    const actual = withPlatform('linux', () => wsTokenPath(backendDataDir({})))
+    expect(actual).toBe(expected)
+    // The bug this guards: main used to read under appData (~/.config).
+    expect(actual).not.toContain('/.config/')
+  })
+
+  it.skipIf(process.platform === 'win32')('agrees with the Linux layout when XDG_DATA_HOME is set', () => {
+    const xdg = '/mnt/state/xdg-data'
+    const expected = pythonWsTokenPath('linux', { HOME: HOME.posix, XDG_DATA_HOME: xdg })
+    const actual = withPlatform('linux', () => wsTokenPath(backendDataDir({ XDG_DATA_HOME: xdg })))
+    expect(actual).toBe(expected)
+  })
+
+  it('honours AGENT_TEAM_DATA_DIR on both sides (the dev-mode contract)', () => {
+    const override = process.platform === 'win32' ? 'C:\\navide-dev-state' : '/tmp/navide-dev-state'
+    const home = process.platform === 'win32' ? HOME.win32 : HOME.posix
+    const expected = pythonWsTokenPath('host', { HOME: home, AGENT_TEAM_DATA_DIR: override })
+    electron.isPackaged = false
+    const actual = withPlatform(process.platform, () =>
+      wsTokenPath(backendDataDir({ AGENT_TEAM_DATA_DIR: override }))
+    )
+    expect(actual).toBe(expected)
+  })
+})

--- a/src/main/backend.test.ts
+++ b/src/main/backend.test.ts
@@ -8,10 +8,14 @@ import type { ChildProcess } from 'node:child_process'
 const killProcessTree = vi.hoisted(() => vi.fn())
 vi.mock('./process-tree', () => ({ killProcessTree }))
 
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { normalizePlatformId, setPlatformId } from '../shared/osplat'
 import {
   bindBackendPluginActivationCatalog,
   handConfirmKey,
+  listNvmNodeBins,
   mergePathList,
   mintTrustConfirmation,
   pathEnvKey,
@@ -31,6 +35,29 @@ describe('backend plugin activation environment', () => {
       AGENT_TEAM_PLUGIN_ACTIVATION_CATALOG: '/state/catalog.json',
       AGENT_TEAM_PLUGIN_ACTIVATION_CATALOG_SHA256: 'a'.repeat(64),
     })
+  })
+})
+
+describe('listNvmNodeBins', () => {
+  let home: string
+  afterEach(() => rmSync(home, { recursive: true, force: true }))
+
+  it('lists every installed version bin, newest first, and nothing else', () => {
+    home = mkdtempSync(join(tmpdir(), 'nvm-home-'))
+    const node = join(home, '.nvm', 'versions', 'node')
+    for (const v of ['v18.20.4', 'v22.11.0', 'v20.19.0']) mkdirSync(join(node, v, 'bin'), { recursive: true })
+    mkdirSync(join(node, 'v16.0.0'), { recursive: true }) // no bin: half-installed
+    writeFileSync(join(node, '.DS_Store'), '')
+    expect(listNvmNodeBins(home)).toEqual([
+      join(node, 'v22.11.0', 'bin'),
+      join(node, 'v20.19.0', 'bin'),
+      join(node, 'v18.20.4', 'bin'),
+    ])
+  })
+
+  it('is empty without nvm', () => {
+    home = mkdtempSync(join(tmpdir(), 'nvm-home-'))
+    expect(listNvmNodeBins(home)).toEqual([])
   })
 })
 

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -1,6 +1,6 @@
 import { spawn, execFile, type ChildProcess } from 'node:child_process'
 import { createHmac, randomBytes, randomUUID } from 'node:crypto'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { homedir } from 'node:os'
 import { delimiter, join } from 'node:path'
@@ -18,6 +18,7 @@ import {
   writeBackendPluginActivationCatalog,
   type BackendPluginActivationCatalogFile,
 } from './plugins/pluginBackendActivationCatalog'
+import { resolveBackendDataDir } from './ui-settings-bootstrap'
 
 /**
  * The key that tells a person's own window apart from an agent driving the same
@@ -117,6 +118,45 @@ export function pathEnvKey(env: Record<string, string | undefined>): string {
 export function mergePathList(head: string[], existing: string | undefined): string {
   const tail = (existing ?? '').split(delimiter).filter(Boolean)
   return [...new Set([...head, ...tail])].join(delimiter)
+}
+
+/**
+ * Every `bin` nvm has installed under `home`, newest version first.
+ *
+ * nvm exports exactly one of these (its `default` alias) and only from the
+ * rc file the probe just failed to read, so which one the shell would have
+ * picked is unknowable here; a CLI installed with `npm install -g` lives
+ * under the node that installed it, so all of them go on PATH. Same rule as
+ * `nvm_node_bins` on the backend.
+ */
+export function listNvmNodeBins(home: string): string[] {
+  const versions = join(home, '.nvm', 'versions', 'node')
+  let names: string[]
+  try {
+    names = readdirSync(versions)
+  } catch {
+    return []
+  }
+  const key = (name: string): number[] =>
+    name.replace(/^v/, '').split('.').map((part) => (/^\d+$/.test(part) ? Number(part) : 0))
+  const compare = (a: string, b: string): number => {
+    const ka = key(a), kb = key(b)
+    for (let i = 0; i < Math.max(ka.length, kb.length); i++) {
+      const d = (kb[i] ?? 0) - (ka[i] ?? 0)
+      if (d !== 0) return d
+    }
+    return 0
+  }
+  return names
+    .filter((name) => {
+      try {
+        return statSync(join(versions, name, 'bin')).isDirectory()
+      } catch {
+        return false
+      }
+    })
+    .sort(compare)
+    .map((name) => join(versions, name, 'bin'))
 }
 
 /** Ask the user's login shell for its full PATH (captures nvm/fnm/volta etc.).
@@ -283,7 +323,7 @@ export async function startBackend(
       // Fallback: the platform's own conventional tool locations, which the
       // session PATH omits. ~/.local/bin is where Claude Code's installer
       // puts `claude` on both platforms, and where uv lands on Linux.
-      env[pathKey] = mergePathList(loginPathFallbacks(homedir()), env[pathKey])
+      env[pathKey] = mergePathList(loginPathFallbacks(homedir(), listNvmNodeBins(homedir())), env[pathKey])
     }
   }
   resolvedUserPath = env[pathKey] ?? null
@@ -357,7 +397,7 @@ export async function startBackend(
     port,
     shell: userShell,
     hostSessionToken,
-    dataDir: env.AGENT_TEAM_DATA_DIR ?? join(app.getPath('appData'), 'Agent-Team'),
+    dataDir: backendDataDir(env),
     proc,
     stop: () => stopBackendProcess(proc)
   }
@@ -386,6 +426,35 @@ export async function startBackend(
 
 
 /**
+ * Where the backend just spawned keeps its state, seen from `env` — the
+ * environment it was spawned with, so the dev override set above is honoured.
+ *
+ * Goes through the same resolver the ui_settings bootstrap uses instead of
+ * re-deriving the path here: an earlier copy fell back to
+ * `<appData>/Agent-Team`, which matches the backend's `state_dir` on macOS
+ * (~/Library/Application Support) and Windows (%APPDATA%) but not on Linux,
+ * where appData is ~/.config and the backend writes under
+ * $XDG_DATA_HOME (~/.local/share). A packaged Linux build then read its ws
+ * token from a directory nothing wrote to, and every window was refused.
+ */
+export function backendDataDir(env: NodeJS.ProcessEnv): string {
+  return resolveBackendDataDir({
+    envOverride: env.AGENT_TEAM_DATA_DIR,
+    isPackaged: app.isPackaged,
+    appDataPath: app.getPath('appData'),
+    platform: process.platform,
+    homeDir: app.getPath('home'),
+    xdgDataHome: env.XDG_DATA_HOME,
+    appData: env.APPDATA
+  })
+}
+
+/** The file the backend mints its `/ws` credential into, under `dataDir`. */
+export function wsTokenPath(dataDir: string): string {
+  return join(dataDir, 'backend-ws-token')
+}
+
+/**
  * The credential the backend requires on /ws, or '' if it is not there yet.
  *
  * Read from disk on every call rather than cached: the backend mints a new one
@@ -395,7 +464,7 @@ export async function startBackend(
  */
 export function readWsToken(handle: BackendHandle): string {
   try {
-    return readFileSync(join(handle.dataDir, 'backend-ws-token'), 'utf8').trim()
+    return readFileSync(wsTokenPath(handle.dataDir), 'utf8').trim()
   } catch {
     // Absent means the backend has not written it yet, or is an older build.
     // Callers pass '' through and the backend answers for itself.

--- a/src/shared/osplat.test.ts
+++ b/src/shared/osplat.test.ts
@@ -169,10 +169,31 @@ describe('loginPathFallbacks', () => {
       expect(loginPathFallbacks('/home/x')).toEqual([
         '/home/x/.local/bin',
         '/home/x/.local/share/pnpm',
+        '/home/x/.npm-global/bin',
+        '/home/x/.cargo/bin',
+        '/home/x/.bun/bin',
         '/usr/local/bin',
         '/snap/bin',
       ])
     })
+  })
+
+  // nvm is how most Linux users have node — and `claude`/`codex` with it —
+  // and it exports its bin only from ~/.bashrc, which is what the probe
+  // could not read when this fallback is the one in use.
+  it('slots the nvm bins the caller enumerated ahead of the system dirs on Linux', () => {
+    asPlatform('linux', () => {
+      const nvm = ['/home/x/.nvm/versions/node/v22.11.0/bin', '/home/x/.nvm/versions/node/v20.19.0/bin']
+      const dirs = loginPathFallbacks('/home/x', nvm)
+      expect(dirs.slice(5, 7)).toEqual(nvm)
+      expect(dirs.at(-2)).toBe('/usr/local/bin')
+    })
+  })
+
+  it('never adds nvm bins on macOS or Windows', () => {
+    const nvm = ['/Users/x/.nvm/versions/node/v22.11.0/bin']
+    asPlatform('darwin', () => expect(loginPathFallbacks('/Users/x', nvm)).not.toContain(nvm[0]))
+    asPlatform('win32', () => expect(loginPathFallbacks('C:\\Users\\x', nvm)).toEqual([]))
   })
 
   it('has nothing to add on Windows', () => {

--- a/src/shared/osplat.ts
+++ b/src/shared/osplat.ts
@@ -108,16 +108,31 @@ export function loginShellFlags(shell: string): string[] {
  * Prepended to PATH so a tool installed to one of these is found even when
  * the shell would not answer (a heavy rc file timing out, an exotic shell).
  * Each list is the platform's own convention: Homebrew's prefixes on macOS;
- * on Linux the XDG-adjacent dirs the pnpm and uv installers use, plus snap's
- * bin which most distributions do not put on the session PATH.
+ * on Linux the XDG-adjacent dirs the pnpm, uv and `npm config set prefix`
+ * installers use, the Rust and bun toolchains, nvm's per-version bins, and
+ * snap's bin which most distributions do not put on the session PATH.
+ *
+ * `nvmBins` is nvm's `~/.nvm/versions/node/<v>/bin` list, newest first —
+ * enumerated by the caller because this module has no `fs` (see
+ * listNvmNodeBins in main). Mirrors `Paths.login_path_fallbacks` on the
+ * backend; keep the two lists the same.
  */
-export function loginPathFallbacks(home: string): string[] {
+export function loginPathFallbacks(home: string, nvmBins: string[] = []): string[] {
   const local = `${home}/.local/bin`
   switch (platformId()) {
     case 'darwin':
       return [local, '/usr/local/bin', '/opt/homebrew/bin', '/opt/homebrew/sbin']
     case 'linux':
-      return [local, `${home}/.local/share/pnpm`, '/usr/local/bin', '/snap/bin']
+      return [
+        local,
+        `${home}/.local/share/pnpm`,
+        `${home}/.npm-global/bin`,
+        `${home}/.cargo/bin`,
+        `${home}/.bun/bin`,
+        ...nvmBins,
+        '/usr/local/bin',
+        '/snap/bin',
+      ]
     default:
       return []
   }


### PR DESCRIPTION
Three Linux path fixes from the read-only audit in `.agent-team/plans/linux-paths-audit_7c3e9a.html` (batch 1 of 2). Read-only findings first, then `跨平台支援` approved this scope.

## #1 — packaged Linux read the ws token from a directory nothing wrote to

`src/main/backend.ts` derived the backend's data dir by hand as `<appData>/Agent-Team`. On Linux `app.getPath('appData')` is `~/.config`, but the backend writes `backend-ws-token` under `osplat.paths.state_dir("Agent-Team")` = `$XDG_DATA_HOME`/`~/.local/share/Agent-Team`. `readWsToken` swallows ENOENT and returns `''`, `ws_auth` answers "missing or invalid token", and every window of a packaged AppImage/.deb sits reconnecting while the backend is healthy.

**Why it was never seen:** on macOS `appData/Agent-Team` *is* `~/Library/Application Support/Agent-Team`, and on Windows it *is* `%APPDATA%\Agent-Team` — the same directories the backend's `state_dir` answers there. The two hand-rolled derivations happen to agree on both shipped platforms and disagree only on Linux.

**Why CI never saw it:** `backend/linux_smoke.py` pins `AGENT_TEAM_DATA_DIR` at the top (for hook isolation), so the one Linux job we have never exercised the no-override path a packaged app takes. That pin is the coverage gap itself. The smoke now additionally pops the override and asserts the packaged data dir lands under `$XDG_DATA_HOME` and not under `$XDG_CONFIG_HOME`.

**The fix** reuses the resolver that already had the Linux arm right — `resolveBackendDataDir()` in `ui-settings-bootstrap.ts`, which `index.ts` was already using in two places — instead of writing a third copy. `backendDataDir(env)` / `wsTokenPath(dataDir)` are the two seams main now has for this.

**The invariant test** (`src/main/backend-ws-token-parity.test.ts`) does not compare a string literal on the TS side. It spawns `uv --project backend run python` and asks the Python side — `applog.backend_ws_token_file()` for the host platform, `_linux.LinuxLayout().state_dir()` for the Linux layout on any POSIX host — where the token is written, then asserts `wsTokenPath(backendDataDir(env))` is that path. Reverting the fix turns the two Linux cases red on macOS and the host case red on the ubuntu vitest job. It guards the structural problem (two sides deriving the same path independently), not just this instance. The three frontend CI jobs already run `uv --project backend sync --locked`, so the interpreter is there.

**Where it actually asserts, per runner** (so nobody reads "green on three platforms" as "the Linux invariant was checked three times"): the host-platform case and the `AGENT_TEAM_DATA_DIR` case run everywhere. The two that drive `_linux.LinuxLayout` explicitly run on Linux **and macOS** — the Linux layout is importable on any POSIX host, so the macOS job does check the Linux answer — and are skipped on Windows, where importing `_linux` pulls in `_posix` and its `termios`/`fcntl`/`pty`. CI first run: Linux `4 tests`, macOS `4 tests`, Windows `4 tests | 2 skipped`.

## #3 — the backend's login-shell PATH probe could not see `~/.bashrc` on Linux

`_posix_paths.login_path_probe()` ran bash as `bash -lc`. The stock Debian/Ubuntu `~/.bashrc` begins with `case $- in *i*) ;; *) return;; esac`, and nvm, bun and `npm config set prefix` all append their `PATH` exports there — so a `.desktop`-launched backend saw `~/.profile` and nothing else, while the Electron probe (`loginShellFlags`) already used `-il` for Linux bash. The two disagreed; a CLI installed after launch stayed "missing" until restart.

- Linux bash now probes interactively (`-ilc`); macOS bash keeps `-lc` (same split as `src/shared/osplat.ts`).
- Output is marker-wrapped (`printf "__NAVIDE_PATH__%s\n" "$PATH"`) and only the marked line is parsed — "last non-empty line" was a motd on an interactive bash.
- The macOS-flavoured module tuple `_FALLBACK_PATH_DIRS` becomes a seam, `Paths.login_path_fallbacks(home)`, with per-platform lists. Linux adds `~/.npm-global/bin`, `~/.cargo/bin`, `~/.bun/bin` and every `~/.nvm/versions/node/*/bin` (newest first — which version the shell would have picked is unknowable when the rc file could not be read). TS `loginPathFallbacks(home, nvmBins)` is kept in step, with `listNvmNodeBins` in main doing the enumeration `src/shared` cannot.

### Deliberate behaviour change, outside #1/#3/#7: macOS fallback order

The old backend tuple was `/opt/homebrew/bin, /usr/local/bin, ~/.local/bin`. The new `_darwin.login_path_fallbacks` is `~/.local/bin, /usr/local/bin, /opt/homebrew/bin, /opt/homebrew/sbin` — the order `src/shared/osplat.ts` already ships. That is the order a user actually gets: Electron resolves PATH first and the backend inherits it, so the backend's own fallback only ever fills gaps behind an order Electron already fixed; keeping a second, conflicting order in the backend would only matter in the case where both probes fail, and then the two sides would disagree about which `claude` wins. Aligning removes that disagreement. It is pinned by `test_macos_fallbacks_are_the_homebrew_prefixes` (exact list) and the existing `loginPathFallbacks` darwin test on the TS side.

## #7 — ssh prompts had nowhere to go from a tty-less backend

Git ran with `GIT_ASKPASS` only. That covers git's own HTTPS prompts; ssh reads `/dev/tty` for a key passphrase or host-key confirmation, and consults `SSH_ASKPASS` only under a display or with `SSH_ASKPASS_REQUIRE=force`. The backend has neither, so a push over ssh with a passphrase-protected key failed with nothing to answer — worse on Linux, where no Keychain-backed agent holds the passphrase by default.

New seam `Paths.git_subprocess_env(askpass)`: POSIX returns `GIT_ASKPASS`, `SSH_ASKPASS` (same launcher), `SSH_ASKPASS_REQUIRE=force`, `GIT_TERMINAL_PROMPT=0`; Windows keeps `GIT_ASKPASS` only (whether the bundled OpenSSH execs the `.cmd` launcher is unverified, and this PR does not change Windows behaviour). `test_ssh_answers_a_passphrase_through_the_trio_with_no_tty` runs a real `ssh-keygen -y` on a passphrase-protected key with `stdin=DEVNULL`: with the trio it answers through the helper; with `GIT_ASKPASS` alone it fails.

## Verification (bare runs, exit codes kept)

- `uv --project backend run --locked ruff check backend` — All checks passed!
- `uv --project backend run --locked pytest backend/tests` — `5390 passed, 9 skipped in 236.47s`, exit 0
- `pnpm typecheck` — exit 0
- `pnpm vitest run` on the six touched files — 140 passed
- Every fix was reverted once to confirm its test goes red, then restored.

Expect a rebase once #63 (Windows path seam, also touches `spec.py` / `_windows.py`) lands; I will rebase before merge rather than resolve blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
