### PR TITLE
fix(linux): desktop integration — terminals, editor paths, symlinked homes, orphan sweep, ps

### DIFF
--- a/backend/agent_team_backend/osplat/_linux.py
+++ b/backend/agent_team_backend/osplat/_linux.py
@@ -18,7 +18,8 @@ import os
 from collections.abc import Sequence
 from pathlib import Path
 
-from ._posix import process_tree, terminal_backend
+from . import _posix
+from ._posix import terminal_backend
 
 log = logging.getLogger(__name__)
 
@@ -174,9 +175,36 @@ class LinuxResourceProbe:
         return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
 
 
+#: What `/proc/<pid>/comm` reads as for the processes that adopt orphans on a
+#: Linux desktop besides init: the user's `systemd --user` (a child
+#: subreaper on every systemd desktop, so an orphan's ppid is it, not 1) and
+#: bubblewrap, which plays the same role inside a Flatpak.
+_SUBREAPER_COMMS = frozenset({"systemd", "bwrap"})
+
+
+def _read_comm(pid: int) -> str | None:
+    try:
+        return (_PROC / str(pid) / "comm").read_text().strip()
+    except OSError:
+        return None
+
+
+class LinuxProcessTree(_posix.PosixProcessTree):
+    def is_orphan_parent(self, ppid: int, me: int) -> bool:
+        # The POSIX answer (init or this backend), plus the subreapers: a
+        # CLI this backend spawned can only end up under `systemd --user`
+        # by the backend dying, which is exactly the orphan `reap_stale`
+        # is looking for. `terminals` still checks the process's identity
+        # (ps lstart) before killing anything this says yes to.
+        if super().is_orphan_parent(ppid, me):
+            return True
+        return _read_comm(ppid) in _SUBREAPER_COMMS
+
+
 paths = LinuxPaths()
 resource_probe = LinuxResourceProbe()
-# PTY and process-group handling are plain POSIX; see `_posix`.
+process_tree = LinuxProcessTree()
+# PTY handling is plain POSIX; see `_posix`.
 __all__ = ["paths", "process_tree", "resource_probe", "terminal_backend"]
 
 

--- a/backend/tests/test_osplat.py
+++ b/backend/tests/test_osplat.py
@@ -466,6 +466,33 @@ class TestOrphanParent:
         assert not tree.is_orphan_parent(0, 500)
         assert not tree.is_orphan_parent(42, 500)
 
+    # systemd desktops: `systemd --user` is a child subreaper, so a CLI whose
+    # backend died gets ppid = that manager, never 1 — and the sweep skipped
+    # every leaked CLI after a backend crash.
+    def test_linux_also_accepts_the_session_subreapers(self, monkeypatch):
+        from agent_team_backend.osplat import _linux
+
+        comms = {1234: "systemd", 5678: "bwrap", 42: "bash"}
+        monkeypatch.setattr(_linux, "_read_comm", lambda pid: comms.get(pid))
+        tree = _linux.process_tree
+        assert tree.is_orphan_parent(1, 500)
+        assert tree.is_orphan_parent(500, 500)
+        assert tree.is_orphan_parent(1234, 500)
+        assert tree.is_orphan_parent(5678, 500)
+        assert not tree.is_orphan_parent(42, 500)
+        # A parent /proc cannot describe (gone, or hidepid) is not called an orphan.
+        assert not tree.is_orphan_parent(9999, 500)
+
+    def test_linux_reads_comm_from_proc(self, tmp_path, monkeypatch):
+        from agent_team_backend.osplat import _linux
+
+        (tmp_path / "77").mkdir()
+        (tmp_path / "77" / "comm").write_text("systemd\n")
+        monkeypatch.setattr(_linux, "_PROC", tmp_path)
+        assert _linux._read_comm(77) == "systemd"
+        assert _linux._read_comm(78) is None
+        assert _linux.process_tree.is_orphan_parent(77, 500)
+
     def test_windows_is_the_normalised_zero_or_this_process(self):
         from agent_team_backend.osplat import _windows
 

--- a/src/main/editors.test.ts
+++ b/src/main/editors.test.ts
@@ -279,9 +279,40 @@ describe('resolveEditorCommand', () => {
   it('falls back to the .app-bundled CLI when PATH has no hit', () => {
     // The common macOS case: VS Code is installed but its shell command was
     // never added to PATH (that is a separate opt-in step).
-    const bundled = '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
-    const hit = resolveEditorCommand(vscode, usrBin, (p) => p === bundled, always)
-    expect(hit).toBe(bundled)
+    setPlatformId('darwin')
+    try {
+      const bundled = '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+      const hit = resolveEditorCommand(vscode, usrBin, (p) => p === bundled, always)
+      expect(hit).toBe(bundled)
+    } finally {
+      setPlatformId(normalizePlatformId(process.platform))
+    }
+  })
+
+  // The Linux shapes: a deb/rpm whose /usr/bin/code symlink is missing, a
+  // snap on a distribution that does not put /snap/bin on PATH, and a Flatpak
+  // — whose exported launcher is named after the app id, so no lookup for
+  // `code` can ever find it.
+  it.each([
+    '/usr/share/code/bin/code',
+    '/snap/bin/code',
+    '/var/lib/flatpak/exports/bin/com.visualstudio.code',
+  ])('falls back to %s on Linux', (bundled) => {
+    setPlatformId('linux')
+    try {
+      expect(resolveEditorCommand(vscode, usrBin, (p) => p === bundled, always)).toBe(bundled)
+    } finally {
+      setPlatformId(normalizePlatformId(process.platform))
+    }
+  })
+
+  it('does not look for the macOS bundle on Linux', () => {
+    setPlatformId('linux')
+    try {
+      expect(vscode.bundledPaths().some((p) => p.includes('/Applications/'))).toBe(false)
+    } finally {
+      setPlatformId(normalizePlatformId(process.platform))
+    }
   })
 
   it('returns null when the editor is not installed at all', () => {

--- a/src/main/editors.ts
+++ b/src/main/editors.ts
@@ -1,7 +1,8 @@
 import { accessSync, constants, existsSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { delimiter, extname, isAbsolute, join } from 'node:path'
 
-import { isWindows } from '../shared/osplat'
+import { editorBundledPaths, isWindows, type EditorInstallHints } from '../shared/osplat'
 
 // Default-editor routing. Every "open this file" in the app funnels through
 // window:openEditor, so this module decides — per request — whether it goes to
@@ -20,23 +21,22 @@ export interface EditorDefinition {
   kind: EditorKind
   /** Executable names looked up on PATH, in order. */
   commands: string[]
-  /** Absolute paths tried when PATH has no hit (macOS ships the CLI inside
-   *  the .app, and installing it onto PATH is a manual opt-in most users skip). */
-  bundledPaths: string[]
+  /** Absolute paths tried when PATH has no hit — the platform's own idea of
+   *  where an installed editor keeps a CLI that never made it onto PATH
+   *  (see editorBundledPaths). A function so the platform is asked at
+   *  resolution time, not at module load. */
+  bundledPaths: () => string[]
   /** Argv after the executable for a file open. */
   fileArgs: (file: string, line?: number) => string[]
   /** Argv after the executable for a folder open. */
   folderArgs: (dir: string) => string[]
 }
 
-const vscodeLike = (id: string, command: string, appName: string): EditorDefinition => ({
+const vscodeLike = (id: string, hints: EditorInstallHints): EditorDefinition => ({
   id,
   kind: 'external',
-  commands: [command],
-  bundledPaths: [
-    `/Applications/${appName}.app/Contents/Resources/app/bin/${command}`,
-    `${process.env.HOME ?? ''}/Applications/${appName}.app/Contents/Resources/app/bin/${command}`,
-  ],
+  commands: [hints.command],
+  bundledPaths: () => editorBundledPaths(homedir(), hints),
   // -g is the goto form: without it the file:line suffix is taken literally as
   // part of the filename.
   fileArgs: (file, line) => (line && line > 0 ? ['-g', `${file}:${line}`] : [file]),
@@ -47,8 +47,16 @@ const vscodeLike = (id: string, command: string, appName: string): EditorDefinit
  *  are handled by the host (plugin view / shell.openPath) and so carry no
  *  command; `custom` is driven entirely by the user's template. */
 export const BUILT_IN_EDITORS: EditorDefinition[] = [
-  vscodeLike('vscode', 'code', 'Visual Studio Code'),
-  vscodeLike('cursor', 'cursor', 'Cursor'),
+  vscodeLike('vscode', {
+    command: 'code',
+    macApp: 'Visual Studio Code',
+    // deb/rpm from Microsoft, and the Arch AUR package, respectively.
+    linuxPrefixes: ['/usr/share/code', '/opt/visual-studio-code'],
+    flatpakId: 'com.visualstudio.code',
+  }),
+  // Cursor on Linux ships as an AppImage with no fixed prefix and no
+  // Flatpak; only a `cursor` the user put on PATH themselves is found.
+  vscodeLike('cursor', { command: 'cursor', macApp: 'Cursor' }),
 ]
 
 /** Editor ids that need no detection because the host implements them. */
@@ -260,7 +268,7 @@ export function resolveEditorCommand(
     const hit = whichIn(name, pathEnv, exists, executable)
     if (hit) return hit
   }
-  for (const path of def.bundledPaths) {
+  for (const path of def.bundledPaths()) {
     if (path && exists(path) && executable(path)) return path
   }
   return null

--- a/src/main/external-terminal.test.ts
+++ b/src/main/external-terminal.test.ts
@@ -20,13 +20,16 @@ type FakeChild = EventEmitter & { unref: ReturnType<typeof vi.fn> }
 // Created at spawn() time, never ahead of it: the event fires on a microtask,
 // and a child built while setting up a mock chain would emit before the
 // code under test has attached its listeners.
-function fakeChild(outcome: 'spawn' | 'error' | { close: number }): FakeChild {
+function fakeChild(outcome: 'spawn' | 'error' | { close: number } | { exit: number }): FakeChild {
   const child = new EventEmitter() as FakeChild
   child.unref = vi.fn()
   queueMicrotask(() => {
     if (outcome === 'spawn') child.emit('spawn')
     else if (outcome === 'error') child.emit('error', new Error('spawn ENOENT'))
-    else child.emit('close', outcome.close)
+    else if ('exit' in outcome) {
+      child.emit('spawn')
+      child.emit('exit', outcome.exit)
+    } else child.emit('close', outcome.close)
   })
   return child
 }
@@ -146,11 +149,18 @@ describe('openInExternalTerminal', () => {
   })
 
   describe('on Linux', () => {
+    // A display and a short failure window: the real one (800ms) would make
+    // every success case wait that long, and the window is what is under test
+    // only where a test says so.
+    const display = { DISPLAY: ':0' }
+    const open = (command: string, path: string | undefined, env: NodeJS.ProcessEnv = display) =>
+      terminal.openInExternalTerminal(command, path, { env, failureWindowMs: 5 })
+
     // The bug this fixes: every needs_terminal install (fourteen agent CLIs
     // plus Ollama) went through osascript, which does not exist on Linux.
     it('never touches osascript', async () => {
       on('linux')
-      await terminal.openInExternalTerminal('x', binDirWith())
+      await open('x', binDirWith())
       for (const call of spawnMock.mock.calls) expect(call[0]).not.toBe('osascript')
     })
 
@@ -161,7 +171,7 @@ describe('openInExternalTerminal', () => {
       spawnMock.mockImplementation(() => fakeChild('spawn'))
 
       const command = 'curl -fsSL https://ollama.com/install.sh | sh'
-      await expect(terminal.openInExternalTerminal(command, bin)).resolves.toEqual({ ok: true })
+      await expect(open(command, bin)).resolves.toEqual({ ok: true })
 
       const [exe, argv, opts] = spawnMock.mock.calls[0]
       expect(exe).toBe(join(bin, 'gnome-terminal'))
@@ -176,7 +186,7 @@ describe('openInExternalTerminal', () => {
       on('linux')
       const bin = binDirWith('x-terminal-emulator', 'gnome-terminal', 'konsole')
       spawnMock.mockImplementation(() => fakeChild('spawn'))
-      await terminal.openInExternalTerminal('x', bin)
+      await open('x', bin)
       expect(spawnMock.mock.calls[0][0]).toBe(join(bin, 'x-terminal-emulator'))
     })
 
@@ -184,7 +194,7 @@ describe('openInExternalTerminal', () => {
       on('linux')
       let child!: FakeChild
       spawnMock.mockImplementation(() => (child = fakeChild('spawn')))
-      await terminal.openInExternalTerminal('sleep 600', binDirWith('xterm'))
+      await open('sleep 600', binDirWith('xterm'))
       expect(child.unref).toHaveBeenCalledTimes(1)
     })
 
@@ -194,7 +204,7 @@ describe('openInExternalTerminal', () => {
       spawnMock
         .mockImplementationOnce(() => fakeChild('error'))
         .mockImplementationOnce(() => fakeChild('spawn'))
-      await expect(terminal.openInExternalTerminal('x', bin)).resolves.toEqual({ ok: true })
+      await expect(open('x', bin)).resolves.toEqual({ ok: true })
       expect(spawnMock.mock.calls.map((c) => c[0])).toEqual([
         join(bin, 'x-terminal-emulator'),
         join(bin, 'konsole'),
@@ -203,13 +213,106 @@ describe('openInExternalTerminal', () => {
 
     it('names every emulator it tried when none is available', async () => {
       on('linux')
-      const result = await terminal.openInExternalTerminal('x', binDirWith())
+      const result = await open('x', binDirWith())
       expect(result.ok).toBe(false)
-      expect(result.error).toContain('x-terminal-emulator')
-      expect(result.error).toContain('gnome-terminal')
-      expect(result.error).toContain('konsole')
-      expect(result.error).toContain('xterm')
+      for (const name of ['xdg-terminal-exec', 'x-terminal-emulator', 'gnome-terminal', 'ptyxis', 'konsole', 'xfce4-terminal', 'kitty', 'alacritty', 'foot', 'xterm']) {
+        expect(result.error).toContain(name)
+      }
       expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    // The lie this closes: gnome-terminal is a D-Bus client that forks fine
+    // and only then exits 1 with no session bus or display; resolving on the
+    // 'spawn' event reported success over a headless SSH session.
+    it('refuses without a display instead of reporting a window that never opened', async () => {
+      on('linux')
+      const result = await open('x', binDirWith('gnome-terminal'), { HOME: '/home/x' })
+      expect(result).toEqual({ ok: false, error: expect.stringContaining('DISPLAY') })
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('accepts WAYLAND_DISPLAY alone as a display', async () => {
+      on('linux')
+      spawnMock.mockImplementation(() => fakeChild('spawn'))
+      await expect(open('x', binDirWith('foot'), { WAYLAND_DISPLAY: 'wayland-0' })).resolves.toEqual({ ok: true })
+    })
+
+    it('treats a non-zero exit inside the failure window as "could not open", and moves on', async () => {
+      on('linux')
+      const bin = binDirWith('gnome-terminal', 'xterm')
+      spawnMock
+        .mockImplementationOnce(() => fakeChild({ exit: 1 }))
+        .mockImplementationOnce(() => fakeChild('spawn'))
+      await expect(open('x', bin)).resolves.toEqual({ ok: true })
+      expect(spawnMock.mock.calls.map((c) => c[0])).toEqual([join(bin, 'gnome-terminal'), join(bin, 'xterm')])
+    })
+
+    it('reports every emulator that started and died when none stays up', async () => {
+      on('linux')
+      const bin = binDirWith('gnome-terminal', 'xterm')
+      spawnMock.mockImplementation(() => fakeChild({ exit: 1 }))
+      const result = await open('x', bin)
+      expect(result.ok).toBe(false)
+      expect(result.error).toContain('gnome-terminal exited 1')
+      expect(result.error).toContain('xterm exited 1')
+    })
+
+    it('counts an immediate exit 0 as opened — a hand-off to a running instance', async () => {
+      on('linux')
+      spawnMock.mockImplementation(() => fakeChild({ exit: 0 }))
+      await expect(open('x', binDirWith('gnome-terminal'))).resolves.toEqual({ ok: true })
+    })
+
+    it('honours $TERMINAL first, with its own argv form when the table knows it', async () => {
+      on('linux')
+      const bin = binDirWith('x-terminal-emulator', 'kitty')
+      spawnMock.mockImplementation(() => fakeChild('spawn'))
+      await open('x', bin, { ...display, TERMINAL: 'kitty' })
+      const [exe, argv] = spawnMock.mock.calls[0]
+      expect(exe).toBe(join(bin, 'kitty'))
+      expect(argv.slice(0, 2)).toEqual(['bash', '-c'])
+    })
+
+    it('gives an unknown $TERMINAL the common -e form', async () => {
+      on('linux')
+      const bin = binDirWith('my-term')
+      spawnMock.mockImplementation(() => fakeChild('spawn'))
+      await open('x', bin, { ...display, TERMINAL: 'my-term' })
+      expect(spawnMock.mock.calls[0][1].slice(0, 3)).toEqual(['-e', 'bash', '-c'])
+    })
+
+    it('asks xdg-terminal-exec before guessing from the table', async () => {
+      on('linux')
+      const bin = binDirWith('xdg-terminal-exec', 'x-terminal-emulator')
+      spawnMock.mockImplementation(() => fakeChild('spawn'))
+      await open('x', bin)
+      expect(spawnMock.mock.calls[0][0]).toBe(join(bin, 'xdg-terminal-exec'))
+    })
+
+    // Fedora 41+ ships ptyxis and no gnome-terminal; XFCE and the Wayland
+    // tiling set were "no terminal emulator found" with the four-entry table.
+    it.each([
+      ['ptyxis', ['--', 'bash', '-c']],
+      ['xfce4-terminal', ['-x', 'bash', '-c']],
+      ['alacritty', ['-e', 'bash', '-c']],
+      ['wezterm', ['start', '--', 'bash', '-c']],
+      ['foot', ['bash', '-c']],
+    ])('finds %s and passes the command as argv', async (name, prefix) => {
+      on('linux')
+      const bin = binDirWith(name)
+      spawnMock.mockImplementation(() => fakeChild('spawn'))
+      await expect(open('x', bin)).resolves.toEqual({ ok: true })
+      const [exe, argv] = spawnMock.mock.calls[0]
+      expect(exe).toBe(join(bin, name))
+      expect(argv.slice(0, prefix.length)).toEqual(prefix)
+    })
+
+    it('hands the emulator the resolved PATH so the install can find nvm-provided npm', async () => {
+      on('linux')
+      const bin = binDirWith('xterm')
+      spawnMock.mockImplementation(() => fakeChild('spawn'))
+      await open('npm install -g @openai/codex', bin)
+      expect(spawnMock.mock.calls[0][2]).toMatchObject({ env: { DISPLAY: ':0', PATH: bin } })
     })
   })
 

--- a/src/main/external-terminal.ts
+++ b/src/main/external-terminal.ts
@@ -13,7 +13,7 @@
 
 import { spawn, type SpawnOptions } from 'node:child_process'
 import { accessSync, constants } from 'node:fs'
-import { delimiter, join } from 'node:path'
+import { basename, delimiter, join } from 'node:path'
 
 import { isLinux, isMac, isWindows } from '../shared/osplat'
 
@@ -22,23 +22,79 @@ export interface OpenTerminalResult {
   error?: string
 }
 
+type TerminalEntry = { bin: string; argv: (script: string) => string[] }
+
+/** `-e`/`-x`-style: the rest of argv is the command. */
+const rest = (flag: string) => (s: string): string[] => [flag, 'bash', '-c', s]
+/** kitty/foot-style: argv after the binary is the command, no flag at all. */
+const bare = (s: string): string[] => ['bash', '-c', s]
+
 /**
- * Terminal emulators tried in order on Linux.
+ * Terminal emulators tried in order on Linux, after `$TERMINAL` and
+ * `xdg-terminal-exec` (see linuxTerminalCandidates).
  *
  * Every entry takes the command as argv after its own separator, so the
- * command reaches `bash -c` verbatim with no quoting layer of ours in between.
+ * command reaches `bash -c` verbatim with no quoting layer of ours in between
+ * — which is why emulators whose only form is a single `-e "string"`
+ * (tilix, lxterminal, qterminal) are not listed: they would need one.
  * `x-terminal-emulator` goes first: it is Debian's alternatives symlink to
  * whatever the user picked, which beats guessing their desktop environment.
+ * The rest are one per desktop (GNOME old and new, KDE, XFCE, MATE) and the
+ * Wayland-native set a tiling-WM user is likely to have instead.
  */
-const LINUX_TERMINALS: ReadonlyArray<{
-  bin: string
-  argv: (script: string) => string[]
-}> = [
-  { bin: 'x-terminal-emulator', argv: (s) => ['-e', 'bash', '-c', s] },
-  { bin: 'gnome-terminal', argv: (s) => ['--', 'bash', '-c', s] },
-  { bin: 'konsole', argv: (s) => ['-e', 'bash', '-c', s] },
-  { bin: 'xterm', argv: (s) => ['-e', 'bash', '-c', s] },
+const LINUX_TERMINALS: ReadonlyArray<TerminalEntry> = [
+  { bin: 'x-terminal-emulator', argv: rest('-e') },
+  { bin: 'gnome-terminal', argv: rest('--') },
+  { bin: 'ptyxis', argv: rest('--') },
+  { bin: 'konsole', argv: rest('-e') },
+  { bin: 'xfce4-terminal', argv: rest('-x') },
+  { bin: 'mate-terminal', argv: rest('-x') },
+  { bin: 'terminator', argv: rest('-x') },
+  { bin: 'kitty', argv: bare },
+  { bin: 'alacritty', argv: rest('-e') },
+  { bin: 'wezterm', argv: (s) => ['start', '--', 'bash', '-c', s] },
+  { bin: 'foot', argv: bare },
+  { bin: 'xterm', argv: rest('-e') },
 ]
+
+/**
+ * The order Linux emulators are tried, given the user's environment.
+ *
+ * `$TERMINAL` first — it is the user naming their emulator outright, and its
+ * argv form is looked up by basename in the table (an unknown one gets the
+ * common `-e`). Then `xdg-terminal-exec`, the freedesktop resolver that reads
+ * the desktop's own default. Then the table, so a machine with none of the
+ * hints still gets whatever is installed.
+ */
+export function linuxTerminalCandidates(env: NodeJS.ProcessEnv): TerminalEntry[] {
+  const candidates: TerminalEntry[] = []
+  const preferred = env.TERMINAL?.trim()
+  if (preferred) {
+    const known = LINUX_TERMINALS.find((t) => t.bin === basename(preferred))
+    candidates.push({ bin: preferred, argv: known?.argv ?? rest('-e') })
+  }
+  candidates.push({ bin: 'xdg-terminal-exec', argv: bare })
+  for (const entry of LINUX_TERMINALS) {
+    if (entry.bin !== preferred && basename(preferred ?? '') !== entry.bin) candidates.push(entry)
+  }
+  return candidates
+}
+
+/**
+ * How long a freshly started emulator gets to fail before it counts as
+ * opened. The `'spawn'` event alone is not evidence: gnome-terminal and its
+ * kin are D-Bus clients that fork fine and only then exit non-zero when
+ * there is no session bus or display, and xterm dies the same way on
+ * "Can't open display" — so resolving on spawn reported success over a
+ * headless SSH session while nothing opened. Same window as the editors.
+ */
+export const LINUX_TERMINAL_FAILURE_WINDOW_MS = 800
+
+/** Options a caller (or a test) can pin instead of the machine's own. */
+export interface OpenTerminalOptions {
+  env?: NodeJS.ProcessEnv
+  failureWindowMs?: number
+}
 
 /**
  * The suffixes Windows will run a bare command name under. `code` on PATH is
@@ -103,27 +159,75 @@ function launch(bin: string, argv: string[], extra: SpawnOptions = {}): Promise<
   })
 }
 
+/**
+ * Start an emulator and report whether it stayed up.
+ *
+ * Unlike `launch`, success is "no non-zero exit inside the failure window":
+ * an emulator that hands off to a running instance exits 0 at once and is
+ * fine; one that exits non-zero could not open anything.
+ */
+function launchWatched(
+  bin: string,
+  argv: string[],
+  extra: SpawnOptions,
+  failureWindowMs: number
+): Promise<OpenTerminalResult> {
+  return new Promise((resolve) => {
+    const child = spawn(bin, argv, { detached: true, stdio: 'ignore', ...extra })
+    let settled = false
+    const settle = (result: OpenTerminalResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(result)
+    }
+    const timer = setTimeout(() => {
+      child.unref()
+      settle({ ok: true })
+    }, failureWindowMs)
+    child.on('error', (err) => settle({ ok: false, error: String(err) }))
+    child.on('exit', (code) => {
+      if (code !== 0) settle({ ok: false, error: `${basename(bin)} exited ${code}` })
+    })
+  })
+}
+
 async function openWithLinuxTerminal(
   command: string,
-  path: string | undefined
+  path: string | undefined,
+  { env = process.env, failureWindowMs = LINUX_TERMINAL_FAILURE_WINDOW_MS }: OpenTerminalOptions
 ): Promise<OpenTerminalResult> {
+  // No display, no window: every emulator would fork and then die, and the
+  // watched launch below would report each one — say so up front instead,
+  // and the wizard shows the command for the user's own terminal.
+  if (!env.DISPLAY && !env.WAYLAND_DISPLAY) {
+    return { ok: false, error: 'no display (DISPLAY and WAYLAND_DISPLAY are unset)' }
+  }
   // `; exec bash` mirrors Terminal.app: the window stays open with a shell
   // once the command finishes, so its output (or its sudo prompt) is not
   // gone the instant it returns.
   const script = `${command}; exec bash`
+  // The emulator, and the bash inside it, get the login-shell PATH the
+  // caller resolved: an `npm install -g` here has to find the nvm-provided
+  // npm the session PATH omits.
+  const childEnv = path === undefined ? env : { ...env, PATH: path }
   const tried: string[] = []
-  for (const terminal of LINUX_TERMINALS) {
+  const failures: string[] = []
+  for (const terminal of linuxTerminalCandidates(env)) {
     tried.push(terminal.bin)
     const bin = findOnPath(terminal.bin, path)
     if (!bin) continue
-    const result = await launch(bin, terminal.argv(script))
+    const result = await launchWatched(bin, terminal.argv(script), { env: childEnv }, failureWindowMs)
     if (result.ok) return result
     // Present on PATH but would not start — try the next one rather than
     // reporting a broken emulator as "no terminal".
+    failures.push(result.error ?? terminal.bin)
   }
   return {
     ok: false,
-    error: `no terminal emulator found (tried ${tried.join(', ')})`,
+    error: failures.length > 0
+      ? `no terminal emulator could open a window (${failures.join('; ')})`
+      : `no terminal emulator found (tried ${tried.join(', ')})`,
   }
 }
 
@@ -159,9 +263,10 @@ async function openWithWindowsTerminal(
  */
 export function openInExternalTerminal(
   command: string,
-  path: string | undefined = process.env.PATH
+  path: string | undefined = process.env.PATH,
+  options: OpenTerminalOptions = {}
 ): Promise<OpenTerminalResult> {
   if (isMac()) return openWithTerminalApp(command)
-  if (isLinux()) return openWithLinuxTerminal(command, path)
+  if (isLinux()) return openWithLinuxTerminal(command, path, options)
   return openWithWindowsTerminal(command, path)
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3282,8 +3282,10 @@ ipcMain.handle('shell:openTerminal', async (event, command: string) => {
   if (!command || typeof command !== 'string') return { ok: false, error: 'invalid command' }
   // Run the install command in a visible terminal (sudo / OAuth prompts need
   // a real TTY). Which terminal is the platform's business — see
-  // external-terminal.ts; this used to be AppleScript only.
-  return await openInExternalTerminal(command)
+  // external-terminal.ts; this used to be AppleScript only. The login-shell
+  // PATH, not this process's: a Linux .desktop launch has no nvm on PATH,
+  // and `npm install -g` in the terminal has to find npm.
+  return await openInExternalTerminal(command, getResolvedUserPath())
 })
 
 // macOS TCC permissions (onboarding wizard). Requests are user-initiated only —

--- a/src/main/plugins/pluginBackendHost.test.ts
+++ b/src/main/plugins/pluginBackendHost.test.ts
@@ -1,10 +1,10 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { PluginBackendHost, type PluginBackendHostOptions } from './pluginBackendHost'
+import { PluginBackendHost, canonicalBackendPackageDir, type PluginBackendHostOptions } from './pluginBackendHost'
 import type {
   BackendPluginLaunchSpec,
   PluginBackendSupervisorOptions,
@@ -468,6 +468,30 @@ describe('PluginBackendHost', () => {
         ...activation,
         packageDir: symlink,
       })).toThrowError(expect.objectContaining({ code: 'INVALID_ACTIVATION' }))
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  // Fedora Silverblue's /home → var/home, a stow-managed ~/.config, a home on
+  // another disk: every plugin lives under a symlinked ancestor there, and the
+  // root used to be refused for not equalling its own realpath.
+  it('accepts a real package root reached through a symlinked ancestor', () => {
+    const root = mkdtempSync(join(tmpdir(), 'navide-backend-root-'))
+    try {
+      const real = join(root, 'real-home', 'plugins')
+      mkdirSync(join(real, 'pkg'), { recursive: true })
+      symlinkSync(join(root, 'real-home'), join(root, 'home-link'))
+      const viaLink = join(root, 'home-link', 'plugins', 'pkg')
+
+      const canonical = canonicalBackendPackageDir(viaLink)
+      expect(canonical).toBe(realpathSync(join(real, 'pkg')))
+      // Same canonical answer whichever spelling reaches it, so descriptor and
+      // activation compare equal across the two.
+      expect(canonicalBackendPackageDir(join(real, 'pkg'))).toBe(canonical)
+      // The root itself being a link is still refused.
+      symlinkSync(join(real, 'pkg'), join(real, 'pkg-link'))
+      expect(canonicalBackendPackageDir(join(real, 'pkg-link'))).toBeNull()
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/src/main/plugins/pluginBackendHost.ts
+++ b/src/main/plugins/pluginBackendHost.ts
@@ -33,7 +33,7 @@ import {
 } from './workspacePathPolicy'
 import { lstatSync, realpathSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 
 export interface PlanRootResolverInput {
   readonly runtime: BackendRuntimeContext
@@ -97,6 +97,14 @@ function nonEmptyString(value: unknown): value is string {
  * Resolve the package root that the Host owns for an activation or descriptor.
  * A package root must be an existing, real directory; accepting a symlink here
  * would let a later target change silently alter which descriptor is bound.
+ *
+ * Only the root itself has to be real. Its ancestors may be symlinks and on
+ * Linux often are — `/home` → `var/home` on Fedora Silverblue, a stow- or
+ * chezmoi-managed `~/.config`, a home on a second disk — and the plugins root
+ * under `userData` is never realpath'd before it gets here, so requiring the
+ * whole path to equal its realpath refused every plugin backend on such a
+ * machine with no plugin-specific error. (macOS's `/var` → `/private/var`
+ * is the same shape; `/Users` being real is why it never showed there.)
  */
 export function canonicalBackendPackageDir(packageDir: unknown): string | null {
   if (!nonEmptyString(packageDir)) return null
@@ -105,7 +113,9 @@ export function canonicalBackendPackageDir(packageDir: unknown): string | null {
     const entry = lstatSync(resolved)
     if (!entry.isDirectory() || entry.isSymbolicLink()) return null
     const canonical = realpathSync(resolved)
-    if (canonical !== resolved) return null
+    // The last component must survive canonicalisation unchanged: a link
+    // swapped in between the lstat above and the realpath would not.
+    if (canonical !== join(realpathSync(dirname(resolved)), basename(resolved))) return null
     const canonicalEntry = lstatSync(canonical)
     if (!canonicalEntry.isDirectory() || canonicalEntry.isSymbolicLink()) return null
     return canonical

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -77,6 +77,14 @@ describe('killProcessTree', () => {
     expect(kill.mock.calls.every((c) => c[1] === 'SIGKILL')).toBe(true)
   })
 
+  it('looks ps up on PATH rather than pinning /bin/ps', () => {
+    // NixOS/Guix keep no /bin/ps; the absolute path there meant no snapshot
+    // and a kill that reached only the handle.
+    killProcessTree(4102, 'SIGKILL')
+    expect(execFileSync.mock.calls[0][0]).toBe('ps')
+    expect(execFileSync.mock.calls[0][1]).toEqual(['-Ao', 'pid=,ppid='])
+  })
+
   it('carries on when a process died between the snapshot and the signal', () => {
     kill.mockImplementation((pid) => {
       if (pid === 4200) throw new Error('ESRCH')

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -75,7 +75,10 @@ export function killProcessTree(pid: number | undefined, signal: NodeJS.Signals)
 
   let targets = [pid]
   try {
-    const snapshot = execFileSync('/bin/ps', ['-Ao', 'pid=,ppid='], {
+    // `ps` by name, not `/bin/ps`: NixOS and Guix have no /bin beyond sh, and
+    // the absolute path there meant no snapshot — so a SIGKILL took only the
+    // bootloader and left the Python backend and its PTYs running.
+    const snapshot = execFileSync('ps', ['-Ao', 'pid=,ppid='], {
       encoding: 'utf8',
       timeout: 2_000
     })

--- a/src/shared/osplat.test.ts
+++ b/src/shared/osplat.test.ts
@@ -4,6 +4,7 @@ import {
   isLinux,
   isMac,
   isWindows,
+  editorBundledPaths,
   loginPathFallbacks,
   loginShellFlags,
   needsDrawnWindowControls,
@@ -259,5 +260,38 @@ describe('shellCommandArgv', () => {
     asPlatform('linux', () => {
       expect(shellCommandArgv('powershell.exe', 'x')).toEqual(['powershell.exe', '-lc', 'x'])
     })
+  })
+})
+
+describe('editorBundledPaths', () => {
+  const hints = {
+    command: 'code',
+    macApp: 'Visual Studio Code',
+    linuxPrefixes: ['/usr/share/code'],
+    flatpakId: 'com.visualstudio.code',
+  }
+
+  it('names the .app-bundled CLI on macOS', () => {
+    asPlatform('darwin', () => {
+      expect(editorBundledPaths('/Users/x', hints)).toEqual([
+        '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
+        '/Users/x/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
+      ])
+    })
+  })
+
+  it('names the package prefix, snap and Flatpak launchers on Linux', () => {
+    asPlatform('linux', () => {
+      expect(editorBundledPaths('/home/x', hints)).toEqual([
+        '/usr/share/code/bin/code',
+        '/snap/bin/code',
+        '/var/lib/flatpak/exports/bin/com.visualstudio.code',
+        '/home/x/.local/share/flatpak/exports/bin/com.visualstudio.code',
+      ])
+    })
+  })
+
+  it('has nothing to add on Windows', () => {
+    asPlatform('win32', () => expect(editorBundledPaths('C:\\Users\\x', hints)).toEqual([]))
   })
 })

--- a/src/shared/osplat.ts
+++ b/src/shared/osplat.ts
@@ -138,6 +138,50 @@ export function loginPathFallbacks(home: string, nvmBins: string[] = []): string
   }
 }
 
+/** Where an editor's CLI lives when it is installed but not on PATH. */
+export interface EditorInstallHints {
+  /** The CLI's name: `code`, `cursor`. */
+  command: string
+  /** The macOS bundle name under /Applications: `Visual Studio Code`. */
+  macApp: string
+  /** Linux package prefixes that carry `bin/<command>`: `/usr/share/code`. */
+  linuxPrefixes?: string[]
+  /** The Flatpak app id, whose exported launcher is named after it, not the CLI. */
+  flatpakId?: string
+}
+
+/**
+ * Absolute paths tried for an editor's CLI when PATH has no hit.
+ *
+ * macOS ships the CLI inside the .app and putting it on PATH is a manual
+ * opt-in most users skip. On Linux the deb/rpm has it under the package
+ * prefix (the `/usr/bin` symlink is not always there), snap exports it to
+ * `/snap/bin` (on PATH on Ubuntu, not elsewhere), and Flatpak exports a
+ * launcher named after the app id — `com.visualstudio.code`, never `code` —
+ * so a PATH lookup for the CLI's name can never find it. Windows has no
+ * entry yet: `code.cmd` lands on PATH from the installer there.
+ */
+export function editorBundledPaths(home: string, hints: EditorInstallHints): string[] {
+  const { command, macApp, linuxPrefixes = [], flatpakId } = hints
+  switch (platformId()) {
+    case 'darwin':
+      return [
+        `/Applications/${macApp}.app/Contents/Resources/app/bin/${command}`,
+        `${home}/Applications/${macApp}.app/Contents/Resources/app/bin/${command}`,
+      ]
+    case 'linux':
+      return [
+        ...linuxPrefixes.map((prefix) => `${prefix}/bin/${command}`),
+        `/snap/bin/${command}`,
+        ...(flatpakId
+          ? [`/var/lib/flatpak/exports/bin/${flatpakId}`, `${home}/.local/share/flatpak/exports/bin/${flatpakId}`]
+          : []),
+      ]
+    default:
+      return []
+  }
+}
+
 export function defaultShell(env: Record<string, string | undefined> = {}): string {
   const declared = env.SHELL
   if (declared && declared.length > 0) return declared


### PR DESCRIPTION
Batch 2 of the Linux path audit (`.agent-team/plans/linux-paths-audit_7c3e9a.html`): the desktop-integration items #4, #6, #8, #9, #11.

Rebased onto `801edc1b` (main, including #65/batch 1). The two batches both touch `osplat/_linux.py` but at different points — #65 edits the `LinuxLayout` method tail, this one the `LinuxProcessTree` block above it — so the rebase was conflict-free; verified by rebasing on a throwaway branch and running both batches' tests there before touching this one.

## #4 — external terminal on Linux (`src/main/external-terminal.ts`)

Four things were wrong for the onboarding wizard's "run this install in a terminal":

1. **It lied when headless.** `launch()` resolved `ok: true` on the child's `'spawn'` event. gnome-terminal (and ptyxis, konsole…) is a D-Bus client that forks fine and only then exits 1 with no session bus or display; xterm dies on "Can't open display". Over SSH the wizard reported success and nothing opened. Now: if neither `DISPLAY` nor `WAYLAND_DISPLAY` is set it refuses up front with that reason; otherwise an emulator counts as opened only if it does not exit non-zero inside an 800ms window (`LINUX_TERMINAL_FAILURE_WINDOW_MS`, the same rule `editors.ts` uses — an exit 0 is a hand-off to a running instance and is fine). Every emulator that started and died is named in the error.
2. **Four emulators.** Fedora 41+ ships ptyxis and no gnome-terminal; XFCE/MATE/LXQt spins and Wayland tiling setups had none of the four. Order is now `$TERMINAL` (the user naming it; argv form looked up by basename, unknown ones get `-e`) → `xdg-terminal-exec` (the freedesktop resolver) → x-terminal-emulator, gnome-terminal, ptyxis, konsole, xfce4-terminal, mate-terminal, terminator, kitty, alacritty, wezterm, foot, xterm. Only argv-form emulators are listed so the command still reaches `bash -c` verbatim; tilix/lxterminal/qterminal take a single `-e "string"` and would need a quoting layer.
3. **Wrong PATH.** The IPC handler passed nothing, so `process.env.PATH` — the session PATH of a `.desktop` launch, no nvm — was searched for emulators, and the bash inside inherited it, so `npm install -g …` said `npm: command not found` for nvm users. `index.ts` now passes `getResolvedUserPath()` and the emulator's env carries it.
4. Tests: 18 Linux cases including the headless refusal, non-zero-exit fallthrough, the `$TERMINAL`/`xdg-terminal-exec` order, one per new emulator's argv shape, and the PATH hand-off. Reverting the display guard and the watched launch turns 4 red.

## #6 — editor CLI discovery on Linux (`editors.ts`, `shared/osplat.ts`)

`bundledPaths` were two macOS `.app` strings baked at module load. New `editorBundledPaths(home, hints)` in `shared/osplat.ts` answers per platform: Linux gets the deb/rpm prefix (`/usr/share/code/bin/code` — the `/usr/bin/code` symlink is not always there), the Arch prefix, `/snap/bin/<cmd>` (on PATH on Ubuntu only), and Flatpak's exported launcher, which is named after the app id (`com.visualstudio.code`) so no PATH lookup for `code` can find it. Cursor gets no Linux entries on purpose: it ships as an AppImage with no fixed prefix and no Flatpak — flagged as (c) needs-real-Linux in the audit. Windows returns `[]`, which is what the mac strings amounted to there.

## #8 — plugin backends refused under a symlinked home (`pluginBackendHost.ts`)

`canonicalBackendPackageDir` required `realpathSync(dir) === dir`. The plugins root (`userData/plugins`) is never realpath'd, so on Fedora Silverblue (`/home → var/home`), with a stow/chezmoi-managed `~/.config`, or a home on a second disk, every plugin backend was refused with no plugin-specific error. Only the root's last component must be real now (its ancestors may be links); the root itself being a symlink is still rejected, and a link swapped in between lstat and realpath still fails the check.

## #9 — orphan sweep never found orphans on systemd desktops (`osplat/_linux.py`)

`is_orphan_parent` accepted `ppid in (1, me)`. On a systemd desktop `systemd --user` is a child subreaper, so a CLI whose backend crashed gets `ppid = <systemd --user>`, never 1 — `reap_stale` skipped every leaked CLI. New `LinuxProcessTree` also accepts a parent whose `/proc/<ppid>/comm` is `systemd` or `bwrap` (Flatpak). `terminals` still checks the process's `ps lstart` identity before killing anything this says yes to; a parent `/proc` cannot describe is not called an orphan.

## #11 — `/bin/ps` (`process-tree.ts`)

NixOS/Guix have no `/bin/ps`; the absolute path there meant no snapshot and a SIGKILL that reached only the bootloader, leaving the Python backend and its PTYs alive. `ps` is now looked up on PATH.

## Verification (bare runs, exit codes kept)

- `uv --project backend run --locked ruff check backend` — All checks passed!
- `uv --project backend run --locked pytest backend/tests` — `5380 passed, 9 skipped in 212.14s`, exit 0
- `pnpm typecheck` — exit 0
- `pnpm vitest run` on the six touched files — 171 passed, 4 skipped (pre-existing packaged-fixture gate)
- Each of #4, #6, #8, #9, #11 was reverted once to confirm its tests go red, then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
