### PR TITLE
Let a slow Windows runner start powershell before the hook test gives up

### DIFF
--- a/backend/tests/test_claude_hooks.py
+++ b/backend/tests/test_claude_hooks.py
@@ -76,18 +76,19 @@ def _run_hook(tmp_path, event_kind: str, body: bytes, endpoint: str = "claude"):
 
     server = HTTPServer(("127.0.0.1", 0), Handler)
     # Room for powershell.exe to start on a busy Windows runner — sh returns
-    # long before any of these — but not so much room that a hook which hangs
-    # keeps the suite (and the runner) busy for a minute.
-    server.timeout = 20
+    # long before any of these. The cap was kept short while a hung hook could
+    # leave its curl behind and stall the whole job; _run_to_completion takes
+    # the tree down now, so a slow start no longer has to look like a failure.
+    server.timeout = 45
     thread = threading.Thread(target=server.handle_request)
     thread.start()
     port_file.write_text(str(server.server_port), encoding="utf-8")
     payload = '{"hook_event_name":"Stop","session_id":"session-1"}'
 
     try:
-        result = _run_to_completion(argv, payload, timeout=20)
+        result = _run_to_completion(argv, payload, timeout=45)
     finally:
-        thread.join(timeout=21)
+        thread.join(timeout=46)
         server.server_close()
 
     assert received == [payload.encode()]


### PR DESCRIPTION
`test_stop_hook_puts_the_response_on_stdout_where_the_cli_reads_decisions` timed out again on a Windows runner that took 12 minutes for the suite where it usually takes 9.

The 20 s cap was chosen while a hung hook could leave its `curl` behind and stall the whole job — that was the failure mode that cost a run its log. The harness takes the hook's whole process tree down on a timeout now, so a generous cap costs one slow test and nothing else, and `sh` still returns long before any of these numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)