### PR TITLE
feat(windows): spawn a pane on the node script behind an npm shim, not on cmd.exe

### DIFF
--- a/backend/agent_team_backend/osplat/_darwin.py
+++ b/backend/agent_team_backend/osplat/_darwin.py
@@ -124,8 +124,10 @@ class DarwinLayout(DarwinPaths):
     def launch_argv(self, program: str, args: Sequence[str] = ()) -> list[str]:
         return _posix_paths.launch_argv(program, args)
 
-    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
-        return _posix_paths.pty_launch_parts(program, args)
+    def pty_launch_parts(
+        self, program: str, args: Sequence[str] = (), *, path: str | None = None
+    ) -> tuple[str, list[str]]:
+        return _posix_paths.pty_launch_parts(program, args, path=path)
 
 
 paths = DarwinLayout()

--- a/backend/agent_team_backend/osplat/_linux.py
+++ b/backend/agent_team_backend/osplat/_linux.py
@@ -294,8 +294,10 @@ class LinuxLayout(LinuxPaths):
     def launch_argv(self, program: str, args: Sequence[str] = ()) -> list[str]:
         return _posix_paths.launch_argv(program, args)
 
-    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
-        return _posix_paths.pty_launch_parts(program, args)
+    def pty_launch_parts(
+        self, program: str, args: Sequence[str] = (), *, path: str | None = None
+    ) -> tuple[str, list[str]]:
+        return _posix_paths.pty_launch_parts(program, args, path=path)
 
 
 paths = LinuxLayout()

--- a/backend/agent_team_backend/osplat/_posix_paths.py
+++ b/backend/agent_team_backend/osplat/_posix_paths.py
@@ -180,7 +180,9 @@ def launch_argv(program: str, args: Sequence[str] = ()) -> list[str]:
     return [program, *args]
 
 
-def pty_launch_parts(program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+def pty_launch_parts(
+    program: str, args: Sequence[str] = (), *, path: str | None = None
+) -> tuple[str, list[str]]:
     return program, list(args)
 
 

--- a/backend/agent_team_backend/osplat/_windows.py
+++ b/backend/agent_team_backend/osplat/_windows.py
@@ -36,6 +36,7 @@ import codecs
 import ctypes
 import logging
 import os
+import re
 import shutil
 import subprocess
 import threading
@@ -806,14 +807,16 @@ class WindowsTerminalBackend:
         if not words:
             raise ValueError("command is empty")
         # PATHEXT lookup: `claude` resolves to npm's `claude.cmd` shim. The
-        # application name is left NULL at CreateProcess (winpty-rs puts it at
-        # the head of the command line instead), which is what makes Windows
-        # run a .cmd through the interpreter at all.
+        # launch seam decides what actually starts: the `node.exe <script>`
+        # behind a recognised shim, else cmd.exe on the shim (a .cmd is not
+        # an image CreateProcess can run). winpty-rs puts `appname` at the
+        # head of the command line and leaves lpApplicationName NULL.
         exe = shutil.which(words[0], path=env.get("PATH") or None)
         if not exe:
             raise FileNotFoundError(f"executable not found: {words[0]}")
-        appname = subprocess.list2cmdline([exe])
-        cmdline = subprocess.list2cmdline(words[1:]) or None
+        head, tail = paths.pty_launch_parts(exe, words[1:], path=env.get("PATH") or None)
+        appname = subprocess.list2cmdline([head])
+        cmdline = subprocess.list2cmdline(tail) or None
         env_block = "\0".join(f"{k}={v}" for k, v in env.items()) + "\0"
         try:
             import winpty
@@ -1229,9 +1232,101 @@ class WindowsDiscoveryLayout(WindowsLayout):
             ]
         return [program, *args]
 
-    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+    def pty_launch_parts(
+        self, program: str, args: Sequence[str] = (), *, path: str | None = None
+    ) -> tuple[str, list[str]]:
+        if self.launch_kind(program) == "cmd":
+            unwrapped = _unwrap_node_shim(program, path=path)
+            if unwrapped is not None:
+                node, script = unwrapped
+                return node, [script, *args]
         argv = self.launch_argv(program, args)
         return argv[0], argv[1:]
+
+
+#: Largest file still read as a shim. Every generator's output is well under
+#: 1 KiB; anything bigger is a real batch file and is left to cmd.exe.
+_SHIM_MAX_BYTES = 4096
+
+# The lines a generated node shim may consist of, one pattern per line shape,
+# matched whole against each stripped line (batch is case-insensitive). The
+# set is the union of what npm's cmd-shim (2.x through 8.x), yarn classic's
+# @zkochan/cmd-shim and pnpm's @pnpm/cmd-shim write when they wrap a node
+# script with no extra arguments and no environment of their own. A shim is
+# accepted only when every one of its lines is here or is the invocation
+# below; a line that sets NODE_PATH or PATH, or anything unknown, makes the
+# whole file unrecognised — it is matched, never interpreted.
+_SHIM_LINE_RES = [
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"@?ECHO off$",
+        r"GOTO start$",
+        r":find_dp0$",
+        r":start$",
+        r"SET dp0=%~dp0$",
+        r"EXIT /b$",
+        r"@?SETLOCAL$",
+        r"@?ENDLOCAL$",
+        r"CALL :find_dp0$",
+        r'@?IF EXIST "(?:%~dp0|%dp0%)\\node\.exe" \($',
+        r'@?SET "_prog=(?:%~dp0|%dp0%)\\node\.exe"$',
+        r'@?SET "_prog=node"$',
+        r"\) ELSE \($",
+        r"\)$",
+        r"@?SET PATHEXT=%PATHEXT:;\.JS;=;%$",
+    )
+]
+#: The line that runs the script: node (next to the shim, or from PATH), the
+#: script relative to the shim's directory, and `%*` — nothing in between.
+_SHIM_INVOKE_RE = re.compile(
+    r"^(?:endLocal & goto #_undefined_# 2>NUL \|\| title %COMSPEC% & )?@?"
+    r'(?:"%_prog%"|"(?:%~dp0|%dp0%)\\node\.exe"|node)\s+'
+    r'"(?:%~dp0|%dp0%)\\(?P<target>[^"]+)"\s+%\*$',
+    re.IGNORECASE,
+)
+
+
+def _unwrap_node_shim(program: str, *, path: str | None) -> tuple[str, str] | None:
+    """`(node.exe, script)` for a generated node shim at `program`, else None.
+
+    None means "run it through cmd.exe as before": the file is not a shim
+    of a known shape, its script is not on disk, or no `node.exe` can be
+    found where the shim would have looked (next to it, then on `path`).
+    """
+    try:
+        if os.path.getsize(program) > _SHIM_MAX_BYTES:
+            return None
+        text = Path(program).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    targets: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        invoke = _SHIM_INVOKE_RE.match(line)
+        if invoke:
+            targets.add(invoke.group("target"))
+            continue
+        if not any(pattern.match(line) for pattern in _SHIM_LINE_RES):
+            return None
+    if len(targets) != 1:
+        return None
+    shim_dir = os.path.dirname(os.path.abspath(program))
+    # `%~dp0` ends in a backslash, so the target is shim-relative; it is
+    # written with backslashes whatever the host, hence the split.
+    script = os.path.normpath(os.path.join(shim_dir, *targets.pop().split("\\")))
+    if not os.path.isfile(script):
+        return None
+    node = os.path.join(shim_dir, "node.exe")
+    if not os.path.isfile(node):
+        node = shutil.which("node.exe", path=path)
+        if not node:
+            return None
+    # The pane's reported binary stays the shim (that is what resolved); this
+    # line is where a log shows which process the pane actually holds.
+    log.info("node shim %s runs %s on %s", program, node, script)
+    return node, script
 
 
 class WindowsScheduler:

--- a/backend/agent_team_backend/osplat/spec.py
+++ b/backend/agent_team_backend/osplat/spec.py
@@ -267,18 +267,27 @@ class Paths(Protocol):
         """
         ...
 
-    def pty_launch_parts(self, program: str, args: Sequence[str] = ()) -> tuple[str, list[str]]:
+    def pty_launch_parts(
+        self, program: str, args: Sequence[str] = (), *, path: str | None = None
+    ) -> tuple[str, list[str]]:
         """`launch_argv` split the way a pseudo-terminal spawn wants it.
 
         ConPTY (through winpty-rs) takes the application name and the rest of
         the command line separately rather than one argv, so the terminal
-        backend needs the head and the tail apart. Same decision as
-        `launch_argv` otherwise: POSIX hands back `program` and its args
-        untouched, Windows the cmd.exe wrapping.
+        backend needs the head and the tail apart. POSIX hands back `program`
+        and its args untouched.
 
-        Note what the Windows shape costs a pane: a shell sits between the
-        terminal and the CLI, so Ctrl-C reaches cmd.exe first, the exit code
-        is cmd.exe's, and the job object holds one process more.
+        Windows looks through an npm-style `.cmd` shim first: when the file is
+        recognisably one of the generated forms (npm's cmd-shim, yarn
+        classic's, pnpm's) and does nothing but start `node.exe` on a script,
+        the answer is that `node.exe` and script directly, so the pane holds
+        the CLI itself — Ctrl-C reaches it and not a batch interpreter, the
+        exit code is its own, and the job holds one process fewer. A shim
+        that is anything else — an environment it sets, arguments it adds, a
+        line the parser does not know — falls back to the cmd.exe wrapping of
+        `launch_argv`; the shim is never interpreted, only matched. `path`
+        is the PATH the pane will run with, searched for `node.exe` the way
+        the shim would search for `node`.
         """
         ...
 

--- a/backend/tests/test_osplat.py
+++ b/backend/tests/test_osplat.py
@@ -353,6 +353,192 @@ class TestLaunching:
         assert _posix.terminal_backend.parse_command(text) == shlex.split(text)
 
 
+# What the shim generators actually write, verbatim (CRLF as on disk):
+# npm's cmd-shim 8.0.0 (bundled with npm 10/11), the cmd-shim 2.x template
+# npm 6 shipped, yarn classic's @zkochan/cmd-shim 3.1.0, and pnpm 10's
+# @pnpm/cmd-shim — the last one with the NODE_PATH block pnpm adds for a
+# hoisted global install and once without it.
+_CLI_JS = r"node_modules\@anthropic-ai\claude-code\cli.js"
+
+_NPM_SHIM = (
+    "@ECHO off\r\n"
+    "GOTO start\r\n"
+    ":find_dp0\r\n"
+    "SET dp0=%~dp0\r\n"
+    "EXIT /b\r\n"
+    ":start\r\n"
+    "SETLOCAL\r\n"
+    "CALL :find_dp0\r\n"
+    "\r\n"
+    'IF EXIST "%dp0%\\node.exe" (\r\n'
+    '  SET "_prog=%dp0%\\node.exe"\r\n'
+    ") ELSE (\r\n"
+    '  SET "_prog=node"\r\n'
+    "  SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+    ")\r\n"
+    "\r\n"
+    "endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "
+    f'"%_prog%"  "%dp0%\\{_CLI_JS}" %*\r\n'
+)
+
+_NPM6_SHIM = (
+    "@SETLOCAL\r\n"
+    "\r\n"
+    '@IF EXIST "%~dp0\\node.exe" (\r\n'
+    '  @SET "_prog=%~dp0\\node.exe"\r\n'
+    ") ELSE (\r\n"
+    '  @SET "_prog=node"\r\n'
+    "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+    ")\r\n"
+    "\r\n"
+    f'"%_prog%"  "%~dp0\\{_CLI_JS}" %*\r\n'
+    "@ENDLOCAL\r\n"
+)
+
+_YARN_SHIM = (
+    '@IF EXIST "%~dp0\\node.exe" (\r\n'
+    f'  "%~dp0\\node.exe"  "%~dp0\\{_CLI_JS}" %*\r\n'
+    ") ELSE (\r\n"
+    "  @SETLOCAL\r\n"
+    "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+    f'  node  "%~dp0\\{_CLI_JS}" %*\r\n'
+    ")\r\n"
+)
+
+_PNPM_TARGET = r"..\global\5\node_modules\@anthropic-ai\claude-code\cli.js"
+
+_PNPM_SHIM = (
+    "@SETLOCAL\r\n"
+    '@IF EXIST "%~dp0\\node.exe" (\r\n'
+    f'  "%~dp0\\node.exe"  "%~dp0\\{_PNPM_TARGET}" %*\r\n'
+    ") ELSE (\r\n"
+    "  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+    f'  node  "%~dp0\\{_PNPM_TARGET}" %*\r\n'
+    ")\r\n"
+)
+
+_PNPM_NODE_PATH_SHIM = (
+    "@SETLOCAL\r\n"
+    "@IF NOT DEFINED NODE_PATH (\r\n"
+    '  @SET "NODE_PATH=C:\\Users\\u\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\node_modules"\r\n'
+    ") ELSE (\r\n"
+    '  @SET "NODE_PATH=C:\\Users\\u\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\node_modules;%NODE_PATH%"\r\n'
+    ")\r\n"
+    + _PNPM_SHIM[len("@SETLOCAL\r\n"):]
+)
+
+
+def _write_shim(root: Path, text: str, *, target: str = _CLI_JS, node_beside: bool = False) -> Path:
+    """A shim under `root/bin` with its script on disk where `%~dp0\<target>`
+    points; the shim-relative target is spelled with backslashes as the
+    generators write it, whatever the host."""
+    bin_dir = root / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    script = bin_dir.joinpath(*target.split("\\")).resolve()
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("#!/usr/bin/env node\n")
+    if node_beside:
+        (bin_dir / "node.exe").write_text("")
+    shim = bin_dir / "claude.CMD"
+    shim.write_bytes(text.encode("utf-8"))
+    return shim
+
+
+def _node_on_path(root: Path) -> tuple[str, str]:
+    """A `node.exe` in its own directory, and that directory as a PATH."""
+    node_dir = root / "nodejs"
+    node_dir.mkdir()
+    node = node_dir / "node.exe"
+    node.write_text("")
+    node.chmod(0o755)
+    return str(node), str(node_dir)
+
+
+class TestShimPassthrough:
+    """The ConPTY spawn looks through a generated node shim to the `node.exe
+    <script>` it would run, so the pane holds the CLI and not cmd.exe. Only
+    a shim of a known generator's exact shape qualifies; everything else keeps
+    the cmd.exe wrapping."""
+
+    @pytest.mark.parametrize(
+        "text", [_NPM_SHIM, _NPM6_SHIM, _YARN_SHIM], ids=["npm", "npm6", "yarn-classic"]
+    )
+    def test_a_generated_shim_becomes_node_on_its_script(self, tmp_path, text):
+        from agent_team_backend.osplat import _windows
+
+        shim = _write_shim(tmp_path, text)
+        node, node_dir = _node_on_path(tmp_path)
+        script = str((tmp_path / "bin").joinpath(*_CLI_JS.split("\\")).resolve())
+        assert _windows.paths.pty_launch_parts(
+            str(shim), ["--resume", "abc def"], path=node_dir
+        ) == (node, [script, "--resume", "abc def"])
+
+    def test_pnpm_shim_resolves_its_parent_relative_script(self, tmp_path):
+        from agent_team_backend.osplat import _windows
+
+        shim = _write_shim(tmp_path, _PNPM_SHIM, target=_PNPM_TARGET)
+        node, node_dir = _node_on_path(tmp_path)
+        script = str((tmp_path / "bin").joinpath(*_PNPM_TARGET.split("\\")).resolve())
+        assert _windows.paths.pty_launch_parts(str(shim), path=node_dir) == (node, [script])
+
+    def test_node_beside_the_shim_wins_over_path(self, tmp_path):
+        from agent_team_backend.osplat import _windows
+
+        shim = _write_shim(tmp_path, _NPM_SHIM, node_beside=True)
+        _node, node_dir = _node_on_path(tmp_path)
+        head, _tail = _windows.paths.pty_launch_parts(str(shim), path=node_dir)
+        assert head == str(tmp_path / "bin" / "node.exe")
+
+    def _falls_back(self, shim: Path, args=(), *, path=None) -> None:
+        from agent_team_backend.osplat import _windows
+
+        assert _windows.paths.pty_launch_parts(str(shim), args, path=path) == (
+            "cmd.exe", ["/d", "/c", str(shim), *args],
+        )
+
+    def test_a_shim_that_sets_node_path_keeps_cmd_exe(self, tmp_path):
+        # pnpm's hoisted global layout needs NODE_PATH; the shim is the only
+        # thing that sets it, so running node directly would break module
+        # resolution. Environment is not carried — the shim stays in charge.
+        shim = _write_shim(tmp_path, _PNPM_NODE_PATH_SHIM, target=_PNPM_TARGET)
+        _node, node_dir = _node_on_path(tmp_path)
+        self._falls_back(shim, ["--version"], path=node_dir)
+
+    def test_a_shim_with_node_arguments_or_unknown_lines_keeps_cmd_exe(self, tmp_path):
+        _node, node_dir = _node_on_path(tmp_path)
+        with_args = _NPM_SHIM.replace('"%_prog%"  "%dp0%', '"%_prog%" --harmony "%dp0%')
+        self._falls_back(_write_shim(tmp_path, with_args), path=node_dir)
+        extra_line = _NPM_SHIM.replace("SETLOCAL\r\n", "SETLOCAL\r\nSET DEBUG=1\r\n", 1)
+        self._falls_back(_write_shim(tmp_path, extra_line), path=node_dir)
+        two_scripts = _YARN_SHIM.replace(f'node  "%~dp0\\{_CLI_JS}"', 'node  "%~dp0\\other.js"')
+        self._falls_back(_write_shim(tmp_path, two_scripts), path=node_dir)
+        self._falls_back(_write_shim(tmp_path, "@echo hello\r\n"), path=node_dir)
+
+    def test_a_shim_whose_pieces_are_missing_keeps_cmd_exe(self, tmp_path):
+        _node, node_dir = _node_on_path(tmp_path)
+        shim = _write_shim(tmp_path, _NPM_SHIM)
+        (tmp_path / "bin").joinpath(*_CLI_JS.split("\\")).unlink()  # script gone
+        self._falls_back(shim, path=node_dir)
+        shim = _write_shim(tmp_path, _NPM_SHIM)
+        self._falls_back(shim, path=str(tmp_path / "empty"))  # no node anywhere
+        big = _write_shim(tmp_path, _NPM_SHIM + "REM " + "x" * 5000 + "\r\n")
+        self._falls_back(big, path=node_dir)  # not a generated shim by size alone
+        self._falls_back(tmp_path / "bin" / "absent.cmd", path=node_dir)  # unreadable
+
+    def test_only_a_cmd_program_is_looked_into(self, tmp_path):
+        from agent_team_backend.osplat import _windows
+
+        exe = tmp_path / "claude.exe"
+        exe.write_bytes(_NPM_SHIM.encode())  # same bytes, wrong extension
+        assert _windows.paths.pty_launch_parts(str(exe), ["x"]) == (str(exe), ["x"])
+
+    def test_posix_ignores_the_path_argument(self):
+        from agent_team_backend.osplat import _darwin, _linux
+
+        for paths in (_darwin.paths, _linux.paths):
+            assert paths.pty_launch_parts("/bin/zsh", ("-l",), path="/nowhere") == ("/bin/zsh", ["-l"])
+
+
 #: What git_service hands the seam: this build's own executable plus the entry
 #: mode that answers a prompt. Never the bare name `python`.
 _LAUNCH_ARGV = ["/opt/navide/agent_team_backend", "--askpass-helper"]

--- a/backend/tests/test_osplat_windows_terminal.py
+++ b/backend/tests/test_osplat_windows_terminal.py
@@ -10,6 +10,7 @@ Windows box; CI runs the same suite there against the real modules.
 from __future__ import annotations
 
 import asyncio
+import shutil
 import subprocess
 import sys
 import types
@@ -163,11 +164,12 @@ class TestSpawn:
         pty = _FakePTY.last
         assert pty is not None
         assert pty.size == (100, 30)
-        # The shim path goes first on the command line (winpty-rs prepends
-        # `appname` and leaves lpApplicationName NULL — which is exactly what
-        # lets CreateProcess run a .cmd); the rest is list2cmdline-quoted.
+        # `C:\npm\claude.cmd` is not on disk, so the launch seam cannot look
+        # through it: cmd.exe goes first on the command line (winpty-rs
+        # prepends `appname` and leaves lpApplicationName NULL) with the shim
+        # and the list2cmdline-quoted arguments behind `/d /c`.
         assert pty.spawn_args == (
-            r"C:\npm\claude.cmd", '--resume "abc def"', r"C:\ws",
+            "cmd.exe", r'/d /c C:\npm\claude.cmd --resume "abc def"', r"C:\ws",
             "PATH=x\0TERM=xterm-256color\0",
         )
         assert handle.pid == 4242
@@ -208,13 +210,49 @@ class TestSpawn:
             'claude -p "hi there"', cwd="C:\\", env={}, rows=1, cols=1
         )
         assert seen == ['claude -p "hi there"']
-        assert _FakePTY.last.spawn_args[:2] == (r"C:\npm\claude.cmd", '-p "hi there"')
+        assert _FakePTY.last.spawn_args[:2] == (
+            "cmd.exe", r'/d /c C:\npm\claude.cmd -p "hi there"',
+        )
 
     def test_a_bare_executable_passes_no_command_line(
-        self, kernel32, winpty, which_cmd_shim
+        self, kernel32, winpty, monkeypatch
     ):
+        monkeypatch.setattr(
+            _windows.shutil, "which",
+            lambda name, path=None: r"C:\tools\claude.exe" if name == "claude" else None,
+        )
         _windows.terminal_backend.spawn(["claude"], cwd="C:\\", env={}, rows=1, cols=1)
-        assert _FakePTY.last.spawn_args[1] is None
+        assert _FakePTY.last.spawn_args[:2] == (r"C:\tools\claude.exe", None)
+
+    # A real npm shim on disk is looked through: the pane's child is node on
+    # the CLI's script, not cmd.exe on the shim — the same pid the job, the
+    # exit watcher and the registry then follow, so a Ctrl-C reaches the CLI
+    # and the exit code is the CLI's own.
+    def test_a_generated_shim_spawns_node_on_the_script(
+        self, kernel32, winpty, monkeypatch, tmp_path
+    ):
+        from .test_osplat import _CLI_JS, _NPM_SHIM, _node_on_path, _write_shim
+
+        shim = _write_shim(tmp_path, _NPM_SHIM)
+        node, node_dir = _node_on_path(tmp_path)
+        script = str((tmp_path / "bin").joinpath(*_CLI_JS.split("\\")).resolve())
+        real_which = shutil.which
+        monkeypatch.setattr(
+            _windows.shutil, "which",
+            lambda name, path=None: str(shim) if name == "claude" else real_which(name, path=path),
+        )
+        handle = _windows.terminal_backend.spawn(
+            ["claude", "--resume", "abc def"],
+            cwd=r"C:\ws", env={"PATH": node_dir}, rows=30, cols=100,
+        )
+        assert _FakePTY.last.spawn_args[:2] == (
+            node, subprocess.list2cmdline([script, "--resume", "abc def"]),
+        )
+        # The job table keys on pid + start-time identity, and the pid it holds
+        # is node's — the look-through changed which process the pane tracks,
+        # not how the job is owned.
+        assert handle.pid == 4242
+        assert _windows._jobs == {4242: (kernel32.calls[1][1], "T4242")}
 
     def test_missing_executable_raises_before_any_pty_exists(
         self, kernel32, winpty, monkeypatch


### PR DESCRIPTION
## Why

An npm-installed CLI on Windows is a `.cmd` shim, so a pane's tracked process was the `cmd.exe` running that batch and the CLI (node) sat one level below it. That layer is where two whole classes of pane symptoms come from:

- **A console control event that reaches cmd.exe before node has taken raw mode ends the batch with `0xC000013A` (STATUS_CONTROL_C_EXIT).** The first ~1s after spawn is exactly the shim's own batch lines plus node startup — the window in which the Windows pane in #64's report died, 1047ms after spawn.
- **After the CLI has exited, a cmd.exe that saw a CTRL_C stops at `Terminate batch job (Y/N)?` and never exits.** The pane waits on cmd.exe's process handle, so it never sees an exit: the "pane is stuck and won't end" symptom, for which nothing in Navide could be at fault because nothing in Navide was running any more.

Both go away when the pane's child is node itself. This PR makes the ConPTY spawn look through a generated npm shim to the `node.exe <script>` it would run and start that directly — only when it can be certain, never by interpreting the batch.

## What

`osplat.paths.pty_launch_parts(program, args, *, path=None)` (the seam #63 added for the ConPTY spawn) gains the look-through on Windows, and `WindowsTerminalBackend.spawn` is routed through it.

`_unwrap_node_shim(program, path)` in `osplat/_windows.py`:

- refuses any file over 4 KiB (every generator's output is under 1 KiB);
- strips each line and requires it to be one of 15 whitelisted line shapes (`@ECHO off`, `GOTO start`, `:find_dp0`, `SET dp0=%~dp0`, `EXIT /b`, `SETLOCAL`/`ENDLOCAL`, `CALL :find_dp0`, `IF EXIST "%~dp0\node.exe" (`, `SET "_prog=…"`, `) ELSE (`, `)`, `SET PATHEXT=%PATHEXT:;.JS;=;%`) or the one invocation line: `node` | `"%_prog%"` | `"%~dp0\node.exe"`, then `"%~dp0\<target>"`, then `%*`, nothing in between (npm 8's `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% &` prefix optional). **Any other line makes the whole file unrecognised** — a `NODE_PATH` or `PATH` the shim sets, arguments it adds to node, anything unknown. The shim is matched, never interpreted;
- requires exactly one distinct target across the invocation lines, resolves it under the shim's directory (backslash-split, `normpath`, so pnpm's `..\` works), and requires it to be a file;
- takes `node.exe` beside the shim if present, else `shutil.which("node.exe", path=<the pane's PATH>)` — where the batch itself would have looked; none → refuse;
- on success logs `node shim %s runs %s on %s`. The pane's reported `binary_path` stays the shim (that is what resolved); the log line is where the actual child shows.

Refusal returns `None` and `pty_launch_parts` falls back to `launch_argv`'s `cmd.exe /d /c <shim> <args>`.

The seam takes `path` because the spawn already searches the pane's env PATH for the program and node must come from the same PATH; `spec`, `_posix_paths`, `_darwin`, `_linux` gain the keyword and ignore it.

### A deliberate behaviour change in the fallback: explicit `cmd.exe /d /c`

Before, spawn put the `.cmd` itself at the head of the command line and relied on CreateProcess implicitly running it through `%COMSPEC% /c`. Now the fallback is #63's explicit `cmd.exe /d /c <shim> <args>`. Functionally the same interpreter, with one difference that matters: **`/d` skips cmd's AutoRun.** Without it, a command a user (or an installer) has put under `HKCU\Software\Microsoft\Command Processor\AutoRun` runs once inside every pane that opens — with the pane's cwd and environment, before the CLI starts. That is not something Navide wants to execute on the user's behalf, and `/d` is how `shell_command` already avoids it for one-shot commands.

## Who the pane tracks now, and why every pid path is still right

Name matching (`app.py`'s `_names_a_known_command` at the override, alias and probe sites) operates on the **pane's command text** (`claude …`, or an override path) before `TerminalService.create`; the look-through happens last, inside `WindowsTerminalBackend.spawn`, after `shutil.which` has produced the shim. The command text, `session.command`, `pane.command` and `startup_probe.binary_path` all still say `claude`/`claude.cmd`; the name checks never see `node.exe`. Name matching answers "what did the user ask for"; the pid answers "what did the OS actually start". Only the latter changes, and to the truer answer.

| Path | Before (root = cmd.exe) | Now (root = node.exe) |
|---|---|---|
| `kill()` / `kill_all()` | `kill_group(group_of(pid))` → `kill_tree` → `TerminateJobObject`; job held cmd.exe + node + MCP children | same job, same kill; job holds node + MCP. The no-job fallback walks a shallower tree whose root is the CLI itself |
| `_watch_exit` / exit code | waited on cmd.exe's handle: cmd exits only after node and the batch's tail; after a CTRL_C it parks at `Terminate batch job (Y/N)?` and **never exits — the pane never sees an exit** | waits on node's handle; the exit code is the CLI's own |
| `_reap_exit_orphans` | descendants snapshot = {node, MCP…}; when the batch was terminated cmd.exe died first and a still-live node was swept as an orphan | descendants = {MCP…}; same `is_orphan_parent` + start-time identity (#64) verdict; no intermediate state in which the CLI itself is the orphan |
| `pty_registry` | root pid = cmd.exe with its create_time | root pid = node; `argv0` stays `claude` (diagnostic only); `reap_stale` on the next start does the same `kill_tree`. A backend crash still takes the whole tree via `KILL_ON_JOB_CLOSE`, regardless of root |
| `interrupt()` (`\x03`) | in cooked mode ConPTY raised CTRL_C_EVENT to cmd.exe and node; cmd terminated its batch (0xC000013A) or later parked at the Y/N prompt | the console holds node (and conhost) only: nothing to terminate but the CLI's own turn; in raw mode it is one byte, as on macOS |
| startup probe (`claude --version`) | `launch_argv` → `cmd.exe /d /c shim` | unchanged — a one-shot subprocess is not harmed by the cmd.exe layer, and `probe_command` keeps reporting what #63 defined |

## Deliberately not done

- A shim that sets `NODE_PATH` or `PATH` (pnpm's hoisted global layout) keeps cmd.exe: the environment it sets is what makes module resolution work, the seam carries no environment, and it is not carried "on the side" either.
- A shim that passes arguments to node (cmd-shim's `progArgs`, e.g. a `node --harmony` shebang) keeps cmd.exe.
- `launch_argv` (one-shot subprocesses) does not look through shims.
- volta/fnm `.exe` shims are `direct` already and never enter this path.

## Fixtures — where each shim text comes from

The tests carry the generators' actual output, CRLF included, because the whitelist is only as right as these samples; anyone judging later whether the parser still matches reality needs the provenance:

- `_NPM_SHIM`: **npm's `cmd-shim` 8.0.0** (the copy bundled with npm 10/11 at `$(npm root -g)/npm/node_modules/cmd-shim`), produced on this machine by calling `cmdShim()` on `node_modules/@anthropic-ai/claude-code/cli.js`, copied byte for byte.
- `_NPM6_SHIM`: the **`cmd-shim` 2.1.0** template npm 6 shipped, rendered from the package source (`index.js` lines 119–129).
- `_YARN_SHIM`: yarn classic 1.22.22's dependency **`@zkochan/cmd-shim` 3.1.0**, rendered from its source (`index.js` lines 117–127).
- `_PNPM_SHIM` / `_PNPM_NODE_PATH_SHIM`: **pnpm 10.0.0**'s bundled `@pnpm/cmd-shim` (`dist/pnpm.cjs`, `generateCmdShim`), rendered once without and once with the `@IF NOT DEFINED NODE_PATH (…)` block pnpm adds for a hoisted global install, with pnpm's `..\global\5\node_modules\…` target shape.

## Tests

`backend/tests/test_osplat.py::TestShimPassthrough` and `test_osplat_windows_terminal.py::TestSpawn`.

Look-through: npm / npm6 / yarn-classic each become `(node, [script, "--resume", "abc def"])`; pnpm's `..\` target resolves; `node.exe` beside the shim wins over PATH; at spawn level, `test_a_generated_shim_spawns_node_on_the_script` runs the real npm shim file through `terminal_backend.spawn` and asserts `spawn_args == (node, list2cmdline([script, …]))` with pid and job unchanged.

Fallback — the safety of this change: `_falls_back` asserts the result is exactly `("cmd.exe", ["/d", "/c", <shim>, *args])` for a pnpm shim with `NODE_PATH`; an invocation line with `--harmony`; an extra `SET DEBUG=1` line; two invocation lines naming different scripts; a file that is not a shim at all; a script missing from disk; no `node.exe` beside or on PATH; a file over 4 KiB; a file that does not exist. A `.exe` containing shim text is not looked into; POSIX ignores `path`.

On what "red on the old code" proves: stashing the production files turns 12 tests red, but the fallback tests among them fail with `TypeError` (the `path` keyword did not exist), not because the fallback shape differs — that shape is `launch_argv`'s and is unchanged. The evidence those tests carry is on the new code: a refused shim yields exactly the `launch_argv` shape. The two pre-existing spawn tests were red for the real reason (implicit `.cmd` head → explicit `cmd.exe /d /c`) and had their assertions and comments updated; `test_a_bare_executable_passes_no_command_line` now uses a `.exe` so it still tests what its name says.

## What `merge-tree` could not see

This branch and #64 changed `osplat/_windows.py` in different places — #64 the job table, the pump and the kills, this one `pty_launch_parts`, the new `_unwrap_node_shim` and three lines of `spawn` — and `git merge-tree` on top of main reported zero conflicts for the pair. Rebasing onto the merged main and running the suite found a failure anyway: #64 changed the job table from `pid -> job` to `pid -> (job, start_time)`, and this branch's spawn test asserted the old shape.

The lesson is worth more than the one-line fix: **no conflict at the patch level is not semantic compatibility.** `merge-tree` compares hunks; it cannot know whether one side's *assertions* still hold once the other side's data structure has changed. Whether two branches can go in together is answered by rebasing onto the merged tree and running the tests, not by a clean three-way merge.

The product needed no change — the look-through ran (`node shim … runs …/node.exe on …/cli.js` in the captured log) and the `spawn_args` assertion passed; only the job-table assertion was stale. It now reads `{4242: (job, "T4242")}`, with the reason in place: the look-through changed which process the pane tracks, not how the job is owned.

## Verification

- `uv --project backend run --locked ruff check backend` → All checks passed!
- `uv --project backend run --locked pytest backend/tests` → 5516 passed, 9 skipped (macOS, 0 failed; rebased onto main @ 54749cfb, which carries #64 and #66)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
