### PR TITLE
Build the permissions cache path the way the module does

### DIFF
--- a/src/main/permissions.test.ts
+++ b/src/main/permissions.test.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // permissions.ts caches the last prompt result on disk because macOS exposes no
@@ -6,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // shows a real notification and records the result, and every path degrades to
 // a status string instead of throwing.
 
+const USER_DATA = join('/tmp', 'navide-permissions-test')
 const files = new Map<string, string>()
 const notifications: Array<{ title: string; body: string }> = []
 let notificationsSupported = true
@@ -13,7 +16,7 @@ let showThrows = false
 const openExternal = vi.fn(() => Promise.resolve())
 
 vi.mock('electron', () => ({
-  app: { getPath: () => '/tmp/navide-permissions-test' },
+  app: { getPath: () => USER_DATA },
   Notification: class {
     static isSupported(): boolean { return notificationsSupported }
     constructor(private readonly opts: { title: string; body: string }) {}
@@ -43,7 +46,10 @@ vi.mock('node:fs/promises', () => ({
 
 vi.mock('node:child_process', () => ({ execFile: vi.fn() }))
 
-const CACHE = '/tmp/navide-permissions-test/permissions.json'
+// join(), not a literal: the module builds the path the same way, and on
+// Windows that is a backslash — a literal would key the fake filesystem
+// differently from the code under test and every cached read would miss.
+const CACHE = join(USER_DATA, 'permissions.json')
 
 function setPlatform(p: string): void {
   Object.defineProperty(process, 'platform', { value: p, configurable: true })


### PR DESCRIPTION
main's `Frontend checks and build (Windows)` job is red: four `permissions.test.ts` cases read `unknown` where they had just written `denied`.

The fake filesystem is a `Map` keyed by path. `permissions.ts` builds its cache path with `join(app.getPath('userData'), 'permissions.json')` — a backslash on Windows — while the test held a forward-slash literal, so every cached read missed. Both sides now build it the same way.

Verified: `vitest run src/main/permissions.test.ts` → 9 passed; `typecheck:node` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)