### PR TITLE
test: ratchet the test tree against POSIX-shaped tests that bypass a seam

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,8 +147,45 @@ test UI changes manually. To reproduce the build check locally, run `pnpm build`
   integration is two vendor spec files plus registration — never an
   `if agent_key == "<yours>"` branch in a shared module.
 
+**Tests that have to pass on macOS, Linux and Windows**
+
+CI runs both suites on all three. Most tests that fail on only one platform
+are correct code plus a test that answered a platform question itself instead
+of asking the seam the code under test asks. Two rules keep that out:
+
+- *Do not build a platform-dependent value by a different route than the
+  module under test.* If the module gets a path from `join()`, a PATH from
+  `os.pathsep`, a shell from `osplat.paths.shell_command()`, or kills through
+  `osplat.process_tree.kill()`, the test uses the same call — never a
+  `'/tmp/…'` literal as a fake-fs key, a `.split(":")`, a bare `/bin/sh`, or a
+  stub of `os.kill` under that module. The two spellings agree on the platform
+  you wrote the test on and disagree on exactly one other; and a stub that
+  lands under the seam does something worse than fail there — on Windows
+  `os.kill` is never reached, the real call raises an equivalent error, and
+  the test passes while executing none of what it claims. Stub the seam for
+  *which* pids are signalled; only a test about *how* (the signal itself) may
+  stub `os.kill`, gated on the capability (`skipif(not hasattr(signal,
+  "SIGKILL"))` — say what you need, not which OS you think you are on). A
+  literal that is a spec constant (`STATUS_CONTROL_C_EXIT`) or a value the test
+  itself set is fine to assert; a value the current platform decides (an OS
+  error message) is not. `backend/tests/test_cross_platform_test_hygiene.py`
+  and `src/main/crossPlatformTestHygiene.test.ts` ratchet the shapes that can be
+  matched statically; the rest is this paragraph.
+- *Take the platform as an input; do not ask the host.* Code that computes
+  another platform's paths should take the platform as a parameter and pick
+  `path.win32`/`path.posix` (or the osplat layout class) from it, the way
+  `resolveBackendDataDir` in `src/main/ui-settings-bootstrap.ts` does. Then a
+  test can assert all three answers on any runner — the fastest one, minutes
+  before the Windows job reports. `src/main/backend-ws-token-parity.test.ts`
+  does exactly this: the macOS runner asserts the Linux answer by driving
+  `_linux.LinuxLayout` directly and comparing with the Python side.
+
 > 請與現有程式碼風格保持一致。Python 提交前請執行完整 backend tests。
 > 新增 CLI 整合請依 `docs/adding-a-cli-vendor.md`，一家一檔，不要在共用模組加分支。
+> 測試要在三個平台都過：不要繞過被測程式用的 seam 自己造路徑／平台答案
+> （`join()`、`os.pathsep`、`osplat.*`——被測程式怎麼拿，測試就怎麼拿；stub 停在 seam，
+> 不停在 seam 底下的 `os.kill`）；算別的平台的路徑時把 platform 當參數傳、不要問 host，
+> 這樣三個平台的答案在任何 runner 都能斷言。
 
 ---
 

--- a/backend/tests/test_cross_platform_test_hygiene.py
+++ b/backend/tests/test_cross_platform_test_hygiene.py
@@ -1,0 +1,245 @@
+"""Ratchets over the test tree itself: a test may not answer a platform
+question the module under test asks a seam for.
+
+`test_osplat.py` keeps three ratchets over `agent_team_backend/` — no scattered
+`sys.platform` branches, secrets through `osplat.secret_files`, ported modules
+POSIX-free. Those protect the product. This file points the same shape at
+`backend/tests/`, because the day the Windows job joined the gate it caught
+four tests in one afternoon that were correct code plus a POSIX-shaped test:
+a `/bin/sh` handed straight to `subprocess`, a PATH split on `":"`, and a
+`terminals.os.kill` stub on a module that kills through
+`osplat.process_tree.kill`. The common shape is not "forward slashes" — a
+blanket ban on POSIX literals would touch 66 test files to catch one bug — it
+is a test constructing a platform-dependent value by a different route than
+the code under test, so the two disagree on exactly one platform.
+
+The `os.kill` case is the one worth the most: it did not go red on Windows,
+it went *green*. The stub was never called (Windows kills through psutil), the
+real kill raised an equivalent error, and the test passed while executing
+none of what it claimed to test. CI is silent about that kind forever; only a
+ratchet or a reader notices.
+
+Each rule is a regex, an allowlist of today's offenders, and two tests: new
+offenders fail with the seam to use named in the message, and an allowlist
+entry that has become clean fails too — the ratchet only tightens. A third
+test per rule pins the regex against a known-bad snippet so a broken pattern
+cannot pass by matching nothing (the shape `test_osplat.py` calls
+`test_the_seam_itself_still_makes_those_calls`).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parent
+
+
+def _feature_test_files() -> list[Path]:
+    """Every test module except this file. R1 and R2 apply to all of them —
+    a seam's own tests have no better reason to hard-code `/bin/sh` than
+    anyone else. R5 exempts a stub by its *target* (a module under `osplat/`),
+    not by file name: `test_terminals_exit_orphan_reap.py` stubs
+    `_posix.subprocess.run` and is a test of the seam despite its name."""
+    return sorted(
+        p for p in TESTS_ROOT.rglob("test_*.py") if p.name != Path(__file__).name
+    )
+
+
+#: A module that opts out of Windows up front with `pytest.importorskip` on
+#: one of the POSIX-only stdlib modules — the gate `92650ea6` put on the ten
+#: real-PTY test modules. Such a file is skipped wholesale where the primitive
+#: does not exist, so nothing in it can be an UNGATED POSIX assumption; the
+#: rules below leave it alone. A per-test `skipif` is not recognised here (it
+#: cannot be attributed to one stub statically) — a test gated that way is
+#: allowlisted with the gate as its reason.
+_MODULE_GATE_RE = re.compile(r"pytest\.importorskip\(\s*[\"'](?:fcntl|pty|termios)[\"']")
+
+
+def _is_module_gated(text: str) -> bool:
+    return bool(_MODULE_GATE_RE.search(text))
+
+
+def _offenders(pattern: re.Pattern[str], files: list[Path]) -> set[str]:
+    offenders: set[str] = set()
+    for p in files:
+        text = p.read_text(encoding="utf-8")
+        if _is_module_gated(text):
+            continue
+        if pattern.search(text):
+            offenders.add(p.relative_to(TESTS_ROOT).as_posix())
+    return offenders
+
+
+def _stale(pattern: re.Pattern[str], allowlist: set[str]) -> set[str]:
+    return {
+        name
+        for name in allowlist
+        if not pattern.search((TESTS_ROOT / name).read_text(encoding="utf-8"))
+    }
+
+
+# ── R1: no absolute POSIX interpreter handed straight to subprocess ─────────
+
+#: A POSIX path as the program of a `subprocess.*` call. Not a ban on
+#: `/bin/sh` — a ban on an UNGATED `/bin/sh`: on Windows the file does not
+#: exist and the test dies with FileNotFoundError before asserting anything.
+#: A test that needs a shell asks `osplat.paths.shell_command(cmd)`; a test
+#: that needs an interpreter uses `sys.executable`; a test that is about
+#: one platform's binary gates itself with a capability `skipif` and lands
+#: in the allowlist with that reason.
+_POSIX_PROGRAM_RE = re.compile(
+    r"subprocess\.(?:run|Popen|call|check_output|check_call)\(\s*\[?\s*['\"]/(?:bin|usr|etc|opt|sbin)/"
+)
+#: Offenders today, each with the gate that makes it acceptable. Empty: the
+#: one there was (`/bin/sh -c` in the PATH-probe test) now asks the seam.
+POSIX_PROGRAM_ALLOWLIST: set[str] = set()
+
+
+class TestNoUngatedPosixProgramInTests:
+    def test_only_allowlisted_tests_exec_a_posix_path(self):
+        new = _offenders(_POSIX_PROGRAM_RE, _feature_test_files()) - POSIX_PROGRAM_ALLOWLIST
+        assert not new, (
+            "these tests hand an absolute POSIX path to subprocess, which does not "
+            "exist on Windows. This is not a ban on /bin/sh — it is a ban on an "
+            "UNGATED /bin/sh. Ask osplat.paths.shell_command(cmd) for a shell, use "
+            "sys.executable for an interpreter, or gate the test with a capability "
+            f"skipif and allowlist it with that reason: {sorted(new)}"
+        )
+
+    def test_the_allowlist_has_no_stale_entries(self):
+        stale = _stale(_POSIX_PROGRAM_RE, POSIX_PROGRAM_ALLOWLIST)
+        assert not stale, f"already clean, drop from the allowlist: {sorted(stale)}"
+
+    def test_the_pattern_still_matches_the_shape_it_guards(self):
+        assert _POSIX_PROGRAM_RE.search('subprocess.run(["/bin/sh", "-c", script])')
+        assert _POSIX_PROGRAM_RE.search("subprocess.Popen('/usr/bin/env', ...)")
+        # The seam form, and an interpreter by name, are what the rule asks for.
+        assert not _POSIX_PROGRAM_RE.search("subprocess.run(osplat.paths.shell_command(s))")
+        assert not _POSIX_PROGRAM_RE.search("subprocess.run([sys.executable, '-c', s])")
+
+
+# ── R2: PATH is split on os.pathsep, never on ":" ───────────────────────────
+
+#: `.split(":")` on something PATH-shaped. Windows separates PATH with `;`,
+#: so `"C:\\Users\\x".split(":")` yields `["C", "\\Users\\x"]` and the
+#: assertion compares against `"C"`. The operand filter keeps the rule off
+#: the `pid:pgid:sid` markers and `key:value` strings that also split on a
+#: colon and are not paths.
+_COLON_SPLIT_PATH_RE = re.compile(
+    r"(?:PATH|[Pp]ath|_dirs|_bins?)\b[^\n]*?\.split\(\s*[\"']:[\"']\s*\)"
+)
+COLON_SPLIT_PATH_ALLOWLIST: set[str] = set()
+
+
+class TestPathSplitsOnPathsep:
+    def test_only_allowlisted_tests_split_a_path_on_colon(self):
+        new = _offenders(_COLON_SPLIT_PATH_RE, _feature_test_files()) - COLON_SPLIT_PATH_ALLOWLIST
+        assert not new, (
+            "these tests split a PATH on ':' — Windows separates PATH with ';', so "
+            "the first entry there is the drive letter. Split on os.pathsep: "
+            f"{sorted(new)}"
+        )
+
+    def test_the_allowlist_has_no_stale_entries(self):
+        stale = _stale(_COLON_SPLIT_PATH_RE, COLON_SPLIT_PATH_ALLOWLIST)
+        assert not stale, f"already clean, drop from the allowlist: {sorted(stale)}"
+
+    def test_the_pattern_still_matches_the_shape_it_guards(self):
+        assert _COLON_SPLIT_PATH_RE.search('parts = os.environ["PATH"].split(":")')
+        assert _COLON_SPLIT_PATH_RE.search("shell_path.split(':')[0]")
+        assert _COLON_SPLIT_PATH_RE.search("fallback_dirs.split(':')")
+        assert not _COLON_SPLIT_PATH_RE.search('os.environ["PATH"].split(os.pathsep)')
+        # Not paths: a `pid:pgid:sid` marker line, a dedup key, an ACL ACE.
+        assert not _COLON_SPLIT_PATH_RE.search('marker[0].split(":")')
+        assert not _COLON_SPLIT_PATH_RE.search('e.dedup_key.split(":")[-1]')
+
+
+# ── R5: a feature test stubs the seam, not the primitive under it ───────────
+
+#: A stub of `os.kill` / `os.killpg` on a module that signals through
+#: `osplat.process_tree.kill` / `kill_group`. On POSIX the seam calls
+#: `os.kill`, so the stub sees every signal; on Windows the seam calls
+#: psutil, the stub is never called, and the test either goes red
+#: (`assert [] == [11]`) or — worse — stays green while exercising none of
+#: what it claims, because psutil raised an equivalent error for a dead pid.
+#: Stub the seam for "which pids get signalled"; stub `os.kill` only in a test
+#: that is about the signal itself, gated on the capability, and allowlisted.
+#: A stub whose target module lives under `osplat/` is exempt — that is a test
+#: of the seam, which has nothing above it to stub.
+_OS_KILL_STUB_RE = re.compile(
+    r"setattr\(\s*(?P<target>[A-Za-z_][\w.]*)\.os\s*,\s*[\"'](?:kill|killpg)[\"']"
+)
+#: `test_terminals_breakaway_kill.py::test_kill_breakaway_sigkills_each_pid`
+#: is about SIGKILL itself — there is no platform-neutral spelling of "the
+#: signal was SIGKILL" — and gates on `hasattr(signal, "SIGKILL")`, a
+#: capability check rather than a platform name, so it stays correct on a
+#: platform nobody has ported to yet.
+OS_KILL_STUB_ALLOWLIST: set[str] = {"test_terminals_breakaway_kill.py"}
+
+
+#: Stub targets that ARE the seam: a test of `_posix` has nothing above
+#: `os.kill` left to stub.
+_SEAM_MODULES = ("_posix", "_linux", "_darwin", "_windows", "osplat")
+
+
+def _os_kill_stub_offenders(files: list[Path], root: Path = TESTS_ROOT) -> set[str]:
+    offenders: set[str] = set()
+    for p in files:
+        text = p.read_text(encoding="utf-8")
+        if _is_module_gated(text):
+            continue
+        for m in _OS_KILL_STUB_RE.finditer(text):
+            if m.group("target").startswith(_SEAM_MODULES):
+                continue
+            offenders.add(p.relative_to(root).as_posix())
+    return offenders
+
+
+class TestFeatureTestsStubTheSeamNotOsKill:
+    def test_only_allowlisted_tests_stub_os_kill(self):
+        new = _os_kill_stub_offenders(_feature_test_files()) - OS_KILL_STUB_ALLOWLIST
+        assert not new, (
+            "these tests stub os.kill/os.killpg under a module that signals through "
+            "osplat.process_tree — on Windows that seam calls psutil, the stub is never "
+            "reached, and the test goes red or (worse) silently tests nothing. Stub "
+            "osplat.process_tree.kill / kill_group for 'which pids'; stub os.kill only "
+            "in a test about the signal itself, gated with skipif(not hasattr(signal, "
+            f"'SIGKILL')) and allowlisted with that reason: {sorted(new)}"
+        )
+
+    def test_the_allowlist_has_no_stale_entries(self):
+        stale = {
+            name for name in OS_KILL_STUB_ALLOWLIST
+            if not _os_kill_stub_offenders([TESTS_ROOT / name])
+        }
+        assert not stale, f"already clean, drop from the allowlist: {sorted(stale)}"
+
+    def test_the_pattern_still_matches_the_shape_it_guards(self):
+        assert _OS_KILL_STUB_RE.search('monkeypatch.setattr(terminals.os, "kill", fake)')
+        assert _OS_KILL_STUB_RE.search("monkeypatch.setattr(app.os, 'killpg', fake)")
+        # Stubbing the seam is the rule's own advice.
+        assert not _OS_KILL_STUB_RE.search('monkeypatch.setattr(terminals.osplat.process_tree, "kill", fake)')
+
+    def test_a_module_gated_with_importorskip_is_exempt(self, tmp_path):
+        # `test_terminal_create_cancellation.py` stubs `terminals_module.os.killpg`
+        # but opens with `pytest.importorskip("fcntl")`: skipped wholesale on
+        # Windows, so the stub is never an ungated assumption there.
+        gated = tmp_path / "test_gated.py"
+        gated.write_text(
+            'pytest.importorskip("fcntl")\n'
+            'monkeypatch.setattr(\n    terminals_module.os, "killpg", fake\n)\n',
+            encoding="utf-8",
+        )
+        ungated = tmp_path / "test_ungated.py"
+        ungated.write_text('monkeypatch.setattr(terminals.os, "killpg", fake)\n', encoding="utf-8")
+        assert _os_kill_stub_offenders([gated, ungated], root=tmp_path) == {"test_ungated.py"}
+
+    def test_the_seams_own_tests_are_exempt(self, tmp_path):
+        # A test of `_posix` has nothing above `os.kill` to stub.
+        seam_test = tmp_path / "test_x.py"
+        seam_test.write_text('monkeypatch.setattr(_posix.os, "kill", fake)\n', encoding="utf-8")
+        feature_test = tmp_path / "test_y.py"
+        feature_test.write_text('monkeypatch.setattr(terminals.os, "kill", fake)\n', encoding="utf-8")
+        # Both match the regex; only the feature test is an offender.
+        assert _os_kill_stub_offenders([seam_test, feature_test], root=tmp_path) == {"test_y.py"}

--- a/backend/tests/test_onboarding_path_refresh.py
+++ b/backend/tests/test_onboarding_path_refresh.py
@@ -80,8 +80,15 @@ def test_new_paths_prepended(monkeypatch):
     assert "/bin" in parts
 
 
+@_needs_login_shell_probe
 def test_existing_paths_not_duplicated(monkeypatch):
-    """Paths already in PATH must not appear twice after refresh."""
+    """Paths already in PATH must not appear twice after refresh.
+
+    Gated like its siblings: on Windows there is no login shell to probe, the
+    refresh returns before touching PATH, and this test used to pass there
+    only because its ":"-joined fixture was split on ":" — asserting "no
+    duplicates" on a PATH the function never touched. Splitting on
+    os.pathsep (";" there) made that visible."""
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     shell_path = "/usr/bin:/bin"
     with patch("subprocess.run", return_value=_make_run_result(_probe_output(shell_path))):

--- a/backend/tests/test_onboarding_path_refresh.py
+++ b/backend/tests/test_onboarding_path_refresh.py
@@ -72,7 +72,7 @@ def test_new_paths_prepended(monkeypatch):
     shell_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
     with patch("subprocess.run", return_value=_make_run_result(_probe_output(shell_path))):
         _refresh_path_from_login_shell()
-    parts = os.environ["PATH"].split(":")
+    parts = os.environ["PATH"].split(os.pathsep)
     assert parts[0] == "/opt/homebrew/bin"
     assert parts[1] == "/usr/local/bin"
     # original paths preserved after new ones
@@ -86,7 +86,7 @@ def test_existing_paths_not_duplicated(monkeypatch):
     shell_path = "/usr/bin:/bin"
     with patch("subprocess.run", return_value=_make_run_result(_probe_output(shell_path))):
         _refresh_path_from_login_shell()
-    parts = os.environ["PATH"].split(":")
+    parts = os.environ["PATH"].split(os.pathsep)
     assert parts.count("/usr/bin") == 1
     assert parts.count("/bin") == 1
 
@@ -101,7 +101,7 @@ def test_dedup_within_shell_output(monkeypatch):
     shell_path = "/new/path:/new/path:/usr/bin"
     with patch("subprocess.run", return_value=_make_run_result(_probe_output(shell_path))):
         _refresh_path_from_login_shell()
-    parts = os.environ["PATH"].split(":")
+    parts = os.environ["PATH"].split(os.pathsep)
     assert parts.count("/new/path") == 1
 
 
@@ -159,7 +159,7 @@ def test_fallback_dirs_merged_when_probe_fails(monkeypatch, tmp_path):
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="zsh", timeout=3)):
         _refresh_path_from_login_shell()
-    assert os.environ["PATH"].split(":")[0] == str(fallback)
+    assert os.environ["PATH"].split(os.pathsep)[0] == str(fallback)
 
 
 def test_fallback_dir_skipped_when_missing(monkeypatch, tmp_path):
@@ -181,7 +181,7 @@ def test_shell_paths_ordered_before_fallback(monkeypatch, tmp_path):
     monkeypatch.setenv("PATH", "/usr/bin")
     with patch("subprocess.run", return_value=_make_run_result(_probe_output("/shell/bin:/usr/bin"))):
         _refresh_path_from_login_shell()
-    parts = os.environ["PATH"].split(":")
+    parts = os.environ["PATH"].split(os.pathsep)
     assert parts[0] == "/shell/bin"
     assert parts[1] == str(fallback)
 
@@ -196,7 +196,7 @@ def test_marked_line_used_whatever_the_rc_files_print(monkeypatch):
     output = _probe_output("/opt/homebrew/bin:/usr/bin", "Welcome to zsh!") + "motd: 3 updates\n"
     with patch("subprocess.run", return_value=_make_run_result(output)):
         _refresh_path_from_login_shell()
-    assert os.environ["PATH"].split(":") == ["/opt/homebrew/bin", "/usr/bin"]
+    assert os.environ["PATH"].split(os.pathsep) == ["/opt/homebrew/bin", "/usr/bin"]
 
 
 # ── probe command shape ───────────────────────────────────────────────────────
@@ -243,7 +243,7 @@ def test_probe_falls_back_to_bash_without_shell_env(monkeypatch):
 def test_probe_script_marks_the_path_line():
     """The script prints the marker and PATH on ONE line, so the parser can
     pick it out of whatever the rc files printed around it."""
-    proc = subprocess.run(["/bin/sh", "-c", SCRIPT], capture_output=True, text=True,
+    proc = subprocess.run(osplat.paths.shell_command(SCRIPT), capture_output=True, text=True,
                           env={"PATH": "/a:/b"}, timeout=5)
     assert proc.stdout == f"{MARKER}/a:/b\n"
 
@@ -361,7 +361,7 @@ def test_detection_missing_to_ok_after_refresh(monkeypatch, tmp_path):
         _refresh_path_from_login_shell()
 
     # After refresh: tmp_path is now in os.environ["PATH"]
-    assert str(tmp_path) in os.environ["PATH"].split(":")
+    assert str(tmp_path) in os.environ["PATH"].split(os.pathsep)
 
     # detect_dep uses shutil.which which reads os.environ["PATH"]
     assert shutil.which("mytool") is not None

--- a/src/main/crossPlatformTestHygiene.test.ts
+++ b/src/main/crossPlatformTestHygiene.test.ts
@@ -1,0 +1,132 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// A ratchet over the TS test tree, the shape backend/tests/test_osplat.py
+// keeps over the product: a regex, an allowlist of today's offenders, a test
+// that fails on new ones with the fix named, and a test that fails when an
+// allowlist entry has become clean so the list can only shrink.
+//
+// The bug it guards: a test that mocks `node:fs` seeds its fake filesystem
+// with a path written as a POSIX literal while the module under test builds
+// the same path with `join()`. On macOS and Linux the two spellings agree; on
+// Windows `join()` produces backslashes and the literal never matches, so the
+// module reads an empty cache and the assertions fail — which is how
+// `permissions.test.ts` went red on the Windows job the day it joined the
+// gate (fixed in #69). Not a ban on forward slashes: a POSIX literal handed to
+// a pure function, or used as inert fixture text, is fine and there are
+// hundreds of those. The rule fires only on the shapes that become a fake-fs
+// key — a declared path constant, or a literal returned from a mock such as
+// `app.getPath` — inside a file that mocks `node:fs`.
+
+const REPO_ROOT = resolve(__dirname, '..', '..')
+
+// The vitest include globs, as directories to walk.
+const TEST_DIRS = [
+  'src',
+  'packages/plugin-sdk/src',
+  'packages/plugin-ui/src',
+  'plugins/navide-git/src',
+  'plugins/navide-git/tests',
+  'plugins/navide-plans/src',
+  'plugins/navide-plans/tests',
+  'tests',
+]
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'out', 'dist-plugins', '.git'])
+
+function testFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string): void => {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const name of entries) {
+      if (SKIP_DIRS.has(name)) continue
+      const full = join(dir, name)
+      if (statSync(full).isDirectory()) walk(full)
+      // This file quotes the shapes it bans; it is not a fake-fs test.
+      else if (/\.(test|spec)\.tsx?$/.test(name) && full !== __filename) found.push(full)
+    }
+  }
+  for (const dir of TEST_DIRS) walk(join(REPO_ROOT, dir))
+  return found.sort()
+}
+
+/** Files whose fake filesystem is a `vi.mock('node:fs…')` factory. */
+const MOCKS_FS_RE = /vi\.mock\(\s*['"]node:fs(?:\/promises)?['"]/
+
+const POSIX_ROOTS = '(?:tmp|usr|bin|etc|opt|var|home|Users|private|Applications)'
+/**
+ * The shapes that turn a POSIX literal into a fake-fs key:
+ *  - a declared constant: `const CACHE = '/tmp/x/permissions.json'`
+ *  - a literal returned from a mock: `getPath: () => '/tmp/x'`
+ *  - a literal used directly as a Map key: `files.set('/tmp/x', …)`
+ */
+export const FAKE_FS_LITERAL_KEY_RE = new RegExp(
+  [
+    `\\b(?:const|let|var)\\s+\\w+(?:\\s*:\\s*[^=\\n]+)?\\s*=\\s*['"\`]/${POSIX_ROOTS}/`,
+    `=>\\s*['"\`]/${POSIX_ROOTS}/`,
+    `\\.(?:set|get|has|delete)\\(\\s*['"\`]/${POSIX_ROOTS}/`,
+  ].join('|')
+)
+
+/** Offenders today, each with why it is acceptable. Empty: the one there
+ *  was, `src/main/permissions.test.ts`, now builds its key with `join()`. */
+export const FAKE_FS_LITERAL_KEY_ALLOWLIST: ReadonlySet<string> = new Set()
+
+function offenders(files: string[]): Set<string> {
+  const out = new Set<string>()
+  for (const file of files) {
+    const text = readFileSync(file, 'utf8')
+    if (!MOCKS_FS_RE.test(text)) continue
+    if (FAKE_FS_LITERAL_KEY_RE.test(text)) out.add(relative(REPO_ROOT, file).split('\\').join('/'))
+  }
+  return out
+}
+
+describe('cross-platform test hygiene: fake-fs keys are built the way the module builds them', () => {
+  it('only allowlisted tests declare a POSIX literal as a fake-fs key', () => {
+    const fresh = [...offenders(testFiles())].filter((f) => !FAKE_FS_LITERAL_KEY_ALLOWLIST.has(f))
+    expect(
+      fresh,
+      'these tests mock node:fs and write a fake-fs path as a POSIX literal; the ' +
+        'module under test builds that path with join(), which produces backslashes ' +
+        'on Windows, so the literal never matches and the test reads an empty fake ' +
+        'filesystem there. Build the key the way the module does — ' +
+        "join(tmpdir(), …) or join(app.getPath('userData'), …) — and let the same " +
+        'expression seed the fake fs and drive the assertion'
+    ).toEqual([])
+  })
+
+  it('has no stale allowlist entries', () => {
+    const stale = [...FAKE_FS_LITERAL_KEY_ALLOWLIST].filter((f) => {
+      const text = readFileSync(join(REPO_ROOT, f), 'utf8')
+      return !(MOCKS_FS_RE.test(text) && FAKE_FS_LITERAL_KEY_RE.test(text))
+    })
+    expect(stale, 'already clean, drop from the allowlist').toEqual([])
+  })
+
+  it('still matches the shape it guards', () => {
+    // The two lines from permissions.test.ts before #69, verbatim.
+    expect(FAKE_FS_LITERAL_KEY_RE.test("const CACHE = '/tmp/navide-permissions-test/permissions.json'")).toBe(true)
+    expect(FAKE_FS_LITERAL_KEY_RE.test("  app: { getPath: () => '/tmp/navide-permissions-test' },")).toBe(true)
+    expect(FAKE_FS_LITERAL_KEY_RE.test("files.set('/tmp/x/settings.json', '{}')")).toBe(true)
+    // What the rule asks for instead.
+    expect(FAKE_FS_LITERAL_KEY_RE.test("const CACHE = join(userData, 'permissions.json')")).toBe(false)
+    expect(FAKE_FS_LITERAL_KEY_RE.test("const root = mkdtempSync(join(tmpdir(), 'navide-'))")).toBe(false)
+    // Inert POSIX literals that are not keys: an argument to a pure predicate,
+    // a computed template key, fixture text.
+    expect(FAKE_FS_LITERAL_KEY_RE.test("expect(isAllowedPlanDocumentPath('/etc/passwd', ws)).toBe(false)")).toBe(false)
+    expect(FAKE_FS_LITERAL_KEY_RE.test('selections[`/tmp/navide-source-${index}`] = {}')).toBe(false)
+    expect(FAKE_FS_LITERAL_KEY_RE.test("writeFileSync(file, '#!/bin/sh\\n')")).toBe(false)
+  })
+
+  it('scopes itself to files that mock node:fs', () => {
+    expect(MOCKS_FS_RE.test("vi.mock('node:fs', () => ({}))")).toBe(true)
+    expect(MOCKS_FS_RE.test("vi.mock('node:fs/promises', () => ({}))")).toBe(true)
+    expect(MOCKS_FS_RE.test("vi.mock('node:child_process', () => ({}))")).toBe(false)
+  })
+})


### PR DESCRIPTION
Implements the approved proposal in `.agent-team/plans/cross-platform-test-hygiene_4b9d21.html`: R1 + R2 + R3 + R5 as ratchet tests, plus two CONTRIBUTING guidelines. R4 (`setPlatformId` consistency) was cut in review as consistency-only; two broader candidate rules were rejected on measured false-positive rates (155 files / 1 true positive; 40 files / ~0).

**Depends on #69**: R3's allowlist is empty because #69 already rewrote the one offender (`permissions.test.ts`). The stale-entry test is therefore live from day one.

## Why ratchets and not lint

- ESLint does not exist in this repo (0 config files), so any TS lint rule carries the cost of introducing a linter and wiring it into CI.
- Ruff deliberately selects only `ASYNC` + `F821` ("Guardrail, not a style linter") and already exempts `tests/**` from `ASYNC`.
- `backend/tests/test_osplat.py` already keeps three ratchets of exactly this shape over the product. This PR points the same shape at the test tree — 2 new test files, no new dependencies, <2s.

## What each rule catches, and what it points at instead

Each rule is: a regex → an allowlist of today's offenders → a test that fails on new ones **naming the seam to use** → a test that fails when an allowlist entry has become clean → a pin of the regex against the known-bad snippet so a broken pattern cannot pass by matching nothing.

| Rule | Shape | Says instead | Allowlist today |
|---|---|---|---|
| **R1** (py) | absolute POSIX path as the program of `subprocess.*` | `osplat.paths.shell_command(cmd)` / `sys.executable` / gate on a capability and allowlist with that reason | empty — the one `/bin/sh -c` there was now asks the seam |
| **R2** (py) | `.split(":")` on a PATH-shaped operand | `os.pathsep` | empty — the 7 sites in `test_onboarding_path_refresh.py` are fixed here |
| **R3** (ts) | in a file that mocks `node:fs*`: a POSIX literal declared as a constant, returned from a mock (`getPath: () => '/tmp/…'`), or used as a Map key | `join(tmpdir(), …)` / `join(app.getPath(…), …)`, same expression seeding the fake fs and driving the assertion | empty (#69) |
| **R5** (py) | `setattr(<module>.os, "kill"\|"killpg", …)` in a feature test | stub `osplat.process_tree.kill` / `kill_group` for *which* pids; only a test about the signal itself stubs `os.kill`, gated on `hasattr(signal, "SIGKILL")` | 1: `test_terminals_breakaway_kill.py` (that test) |

Exemptions built into the scanners rather than the allowlists: a stub whose **target module is under `osplat/`** (`_posix.os`, …) is a test of the seam and has nothing above it to stub — by target, not by file name, since `test_terminals_exit_orphan_reap.py` stubs `_posix.subprocess.run` and is a seam test despite its name; and a module gated with `pytest.importorskip("fcntl"|"pty"|"termios")` (the gate `92650ea6` put on the ten real-PTY modules) is skipped wholesale on Windows, so nothing in it is an *ungated* assumption. R5 found one such gated stub the earlier survey missed (`test_terminal_create_cancellation.py` stubs `terminals_module.os.killpg` across a line break); it is exempt by the gate and untouched here — converting it to stub the seam would let it run on Windows too, which is a separate change.

The "ungated" wording is the rule: it is not a ban on `/bin/sh` or on stubbing `os.kill`, it is a ban on doing so without saying what capability the test needs.

## What R2 caught in this PR's own CI

Changing the seven `.split(":")` to `os.pathsep` did not just fix a spelling — it exposed a test that had been empty on Windows all along. `test_existing_paths_not_duplicated` was the one PATH test in that file without `@_needs_login_shell_probe`. On Windows `login_path_probe()` is `None`, so `_refresh_path_from_login_shell` returns before touching PATH; the test passed there only because its `":"`-joined fixture was split on `":"` — self-consistent, and asserting "no duplicates" on a PATH the function never touched. Reproduced locally by installing the Windows answer:

```
osplat.paths.login_path_probe = lambda: None    # what Windows answers
PATH = "/usr/bin:/bin"
_refresh_path_from_login_shell()
→ subprocess.run called: False                  # early return, PATH untouched
→ PATH.split(";") = ['/usr/bin:/bin'] → count('/usr/bin') = 0   # os.pathsep: red
→ PATH.split(":") = ['/usr/bin', '/bin'] → count = 1            # the old test: green
```

Fix (`8cfc2f83`): gate it like its five siblings — the subject, merging a login-shell PATH, does not exist on Windows. That is the same shape R5 guards (a test green while executing nothing it claims), surfaced by R2 rather than R5. A rule is easiest to defend by what it has caught; this one caught something in the PR that introduced it.

## Why R5 matters more than the other three

R1–R3 catch tests that go **red** on the wrong platform; CI reports those eventually. R5 catches a test that went **green** on Windows while executing none of what it claimed: the `os.kill` stub was never reached (the seam calls psutil there), psutil raised an equivalent error for a dead pid, and the assertion "does not raise" held. CI is silent about that kind forever. PR #64 confirmed the mechanism on a real Windows runner: the same test, stubbed at `os.kill`, went red (`assert [] == [11]`); stubbed at `process_tree.kill`, both platforms tested the same thing.

## Product-side follow-up recorded, deliberately not done here

Rejecting the broad version of R5 (any `subprocess.run`/`shutil.which` stub) surfaced that `onboarding_deps.py` is mixed: `:339` goes through `osplat.paths.resolve_program()` while `:410`/`:727`/`:891` call `shutil.which` directly. Not a bug (`shutil.which` handles PATHEXT on Windows), but the three remaining entry points if "find a program" is ever consolidated on one seam. Recorded in the plan as `followup-which`; untouched here.

## Verification (bare runs, exit codes kept)

- `uv --project backend run --locked ruff check backend` — exit 0
- `uv --project backend run --locked pytest backend/tests` — `5527 passed, 9 skipped in 229.17s`, exit 0
- `pnpm typecheck` — exit 0
- `pnpm vitest run src/main/crossPlatformTestHygiene.test.ts src/main/permissions.test.ts` — 13 passed
- Windows CI, first run: `1 failed, 5394 passed, 97 skipped` — the empty test above, now gated.
- Revert-to-red, each rule: R1 reintroduce `/bin/sh` → red; R2 reintroduce one `":"` → red; R3 restore pre-#69 `permissions.test.ts` → red; R5 drop the allowlist entry → red; stale-entry check: allowlist a clean file → red. All restored to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
