### PR TITLE
test(plans): click a review-note control only once it is enabled

### DIFF
--- a/tests/integration/plansPackagedRoundtrip.test.ts
+++ b/tests/integration/plansPackagedRoundtrip.test.ts
@@ -1531,15 +1531,30 @@ describe('Plans packaged backend composition', () => {
         expect(mountedApp.findAll('.prt-panel .prt-note')).toHaveLength(1)
 
         // Drive the controls rather than exposed component methods. A rendered
-        // button is not evidence that its edit or confirmation UI is usable.
-        await mountedApp.get('[data-test="edit-n1"]').trigger('click')
+        // button is not evidence that its edit or confirmation UI is usable —
+        // nor is a rendered NOTE evidence that its buttons are: the toolbar
+        // keeps them `:disabled` until the write and its follow-up re-read
+        // both settle, while the note itself shows as soon as the write
+        // returns (PlansApp pushes into the meta object the toolbar renders).
+        // VTU's trigger() silently skips a disabled element, so a click in
+        // that window does nothing and the edit input never appears. Wait for
+        // the control to be enabled, which is what a user sees before clicking.
+        const clickWhenEnabled = async (selector: string): Promise<void> => {
+          // The wait spans a real round trip through the packaged child, so
+          // it gets more than waitFor's 1s default on a slow runner.
+          await vi.waitFor(() => {
+            expect(mountedApp.get(selector).attributes('disabled')).toBeUndefined()
+          }, { timeout: 5_000 })
+          await mountedApp.get(selector).trigger('click')
+        }
+        await clickWhenEnabled('[data-test="edit-n1"]')
         const editInput = mountedApp.get('[data-test="review-note-edit-input"]')
         expect(editInput.attributes('disabled')).toBeUndefined()
         expect.soft(document.activeElement, 'Edit must focus its input').toBe(editInput.element)
         await editInput.setValue('Edited through the UI')
         await mountedApp.get('[data-test="review-note-edit-save"]').trigger('click')
         await vi.waitFor(() => expect(mountedApp.text()).toContain('Edited through the UI'))
-        await mountedApp.get('[data-test="delete-n1"]').trigger('click')
+        await clickWhenEnabled('[data-test="delete-n1"]')
         await flushPromises()
         expect.soft(document.querySelector('.modal .card.confirm'), 'Delete must render the application confirmation').not.toBeNull()
         expect(readFileSync(planFile, 'utf8')).toContain('Edited through the UI')
@@ -1547,7 +1562,7 @@ describe('Plans packaged backend composition', () => {
         // an unresolved confirmation leaking into the rest of the suite.
         useNotify().resolveDialog(false)
         await flushPromises()
-        await mountedApp.get('[data-test="edit-n1"]').trigger('click')
+        await clickWhenEnabled('[data-test="edit-n1"]')
         await mountedApp.get('[data-test="review-note-edit-input"]').setValue('Draft text')
         await mountedApp.get('[data-test="review-note-edit-save"]').trigger('click')
         await vi.waitFor(() => expect(mountedApp.text()).toContain('Draft text'))


### PR DESCRIPTION
## Symptom

`Packaged Plans checks (macOS)` failed roughly one run in ten, unrelated to the change under test (one red run's commit only changed quotes in another test file):

```
FAIL tests/integration/plansPackagedRoundtrip.test.ts > Plans packaged backend composition
     > mounts the real PlansApp window and persists Review Notes through the packaged child
Error: Unable to get [data-test="review-note-edit-input"] within: <!--teleport start-->
```

## Reproduced, then read from the artifact

Built the packaged fixtures the way the job does (`build:plans:v2` / `build:plans:fixture` / `build:plans:backend`, Go 1.27 via `GOTOOLCHAIN`) and ran the file in a loop with the job's env: **3 failures in 30 runs**, same message as CI. The DOM dump vue-test-utils attaches to the failure shows the cause directly — every failing run has

```html
<button class="prt-ghost" disabled="" title="Edit" data-test="edit-n1">
<button class="prt-ghost prt-ghost--danger" disabled="" title="Delete" data-test="delete-n1">
```

at the moment of the click. The edit button was rendered, but disabled.

## Mechanism (verified in code, not inferred from the log)

1. `PlanReviewToolbar.writeNote` sets `saving = true`, awaits the mutation, **then awaits a second round trip** (`store.readMeta`) before `finally { saving = false }`. Every note button is `:disabled="saving"`.
2. `PlansApp.applyToolbarMetadata` does `selected.value.meta = meta` — the parent adopts the toolbar's own meta object, so both render the same `reviewNotes` array.
3. `PlansApp.addReviewNote` does `reviewNotes.push(note)` as soon as the RPC returns. The note is therefore **visible during the `readMeta` window, while `saving` is still true.**
4. The test's loop broke on "a `.prt-note` exists" and clicked `edit-n1`. `DOMWrapper.trigger()` in vue-test-utils is `if (this.element && !this.isDisabled()) dispatch…` — a click on a disabled element is silently dropped. No `startEditNote`, no edit input, `get()` throws.

Whether the second round trip finished before the loop's next 20 ms tick decided pass or fail; on a loaded macOS runner it lost more often.

**The part most likely to bite the next person:** vue-test-utils' `trigger()` does not throw on a disabled element — it returns normally having dispatched nothing. The test *looks* like it clicked, and the error surfaces one statement later at an unrelated selector. Any `trigger('click')` on a control that can be `:disabled` needs an enabled-check in front of it, or its failure will point at the wrong line.

The same window sits in front of `delete-n1` one line later (`editReviewNote` mutates the shared note in place before its `readMeta`), which would have surfaced as the `expect.soft('Delete must render the application confirmation')` message instead. **This PR closes both: the flake that fired today (`edit-n1`) and a same-origin one that had not yet (`delete-n1`).** The helper is applied to every post-write click in the case — `edit-n1` (twice) and `delete-n1`.

## Test or product?

Test. A disabled button during a save is the toolbar's intended in-flight guard (a user sees a greyed control for one IPC round trip and cannot click it); "the note is visible" was never the right precondition for "the edit control is usable" — the test's own comment already said a rendered button is not evidence its UI is usable. The fix makes the test wait for what a user waits for: the control being enabled.

`clickWhenEnabled(selector)` — `vi.waitFor` until the element has no `disabled` attribute (5 s budget, since it spans a real round trip through the packaged child), then `trigger('click')`. Applied to the three post-write clicks (`edit-n1` ×2, `delete-n1`). No product code changed.

## Running this job locally

The file is skipped without `NAVIDE_TEST_PACKAGED_PLANS=1 NAVIDE_TEST_PRODUCTION_PLANS_BACKEND=1` and needs the packaged fixtures built first: `pnpm run build:plans:v2 && pnpm run build:plans:fixture && pnpm run build:plans:backend`. `scripts/build-plans-backend.mjs` hard-requires Go 1.27.x and refuses Homebrew's 1.25; `GOTOOLCHAIN=go1.27.0` in front of the build commands makes Go fetch and use 1.27 without changing anything on the machine. Each run is a fresh vitest process of ~10–17 s.

## Verification

- `NAVIDE_TEST_PACKAGED_PLANS=1 NAVIDE_TEST_PRODUCTION_PLANS_BACKEND=1 pnpm vitest run tests/integration/plansPackagedRoundtrip.test.ts` in a shell loop (vitest has no CLI repeat; each iteration is a fresh process like CI):
  - before: **27 pass / 3 fail** in 30 runs
  - after: **60 pass / 0 fail**, then after widening the `waitFor` budget to 5 s: **20 pass / 0 fail** — 80/80 on the fix
- `pnpm run typecheck:integration` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

