### PR TITLE
fix: onboarding lookups through the seam, cancellation test stubs the seam, positioning docs refreshed

### DIFF
--- a/backend/agent_team_backend/onboarding_deps.py
+++ b/backend/agent_team_backend/onboarding_deps.py
@@ -19,7 +19,6 @@ import hashlib
 import logging
 import os
 import re
-import shutil
 import signal
 import sqlite3
 import subprocess
@@ -407,7 +406,7 @@ def detect_dep(dep: Dep, quick: bool = False) -> dict[str, Any]:
         # "Homebrew is missing" during its check step instead of only after the
         # install command has already failed.
         "requirements": [
-            {"name": name, "ok": shutil.which(name) is not None}
+            {"name": name, "ok": osplat.paths.resolve_program(name) is not None}
             # Read the resolved install, not the Dep: the platform port moved
             # the foundation deps' brew requirement into install_cmds, which
             # left this list empty on macOS and the wizard no longer pulled
@@ -724,7 +723,7 @@ def detect_ollama_status() -> dict[str, Any]:
     from "no models installed" if only the parsed list is returned, which left
     the wizard telling users to pull a model that could never succeed.
     """
-    if shutil.which("ollama") is None:
+    if osplat.paths.resolve_program("ollama") is None:
         return {"models": [], "reachable": False, "detail": "ollama not installed"}
     try:
         proc = subprocess.run(
@@ -888,7 +887,7 @@ def missing_requirements(dep: Dep) -> list[str]:
     the macOS install of `uv` needs Homebrew, the Linux one needs curl.
     """
     install = dep.install_for(osplat.platform_id)
-    return [name for name in install.requires_binaries if shutil.which(name) is None]
+    return [name for name in install.requires_binaries if osplat.paths.resolve_program(name) is None]
 
 
 def _terminate_process_group(proc: subprocess.Popen[str]) -> None:
@@ -1013,7 +1012,7 @@ def pull_model(model: str) -> dict[str, Any]:
     name = model or ""
     if not _MODEL_NAME_RE.fullmatch(name) or ".." in name:
         return {"ok": False, "error": "invalid model name"}
-    if shutil.which("ollama") is None:
+    if osplat.paths.resolve_program("ollama") is None:
         return {"ok": False, "error": "ollama not installed"}
     if not ollama_reachable():
         return {
@@ -1032,9 +1031,9 @@ OLLAMA_SERVICE_CMD = "brew services start ollama"
 
 def start_ollama_service() -> dict[str, Any]:
     """Hand the official service-start command to an external Terminal."""
-    if shutil.which("ollama") is None:
+    if osplat.paths.resolve_program("ollama") is None:
         return {"ok": False, "error": "ollama not installed"}
-    if shutil.which("brew") is None:
+    if osplat.paths.resolve_program("brew") is None:
         return {"ok": False, "error": "brew is required to manage the ollama service"}
     return {"ok": True, "needs_terminal": True, "command": OLLAMA_SERVICE_CMD}
 

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -113,7 +113,7 @@ def test_detect_dep_requirements_come_from_the_resolved_install(monkeypatch: pyt
               min_version="22.0.0",
               install_cmds={"darwin": PlatformInstall("brew install node", ("brew",))})
     monkeypatch.setattr(ob.osplat, "platform_id", "darwin")
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)  # the requirement probe
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: None)  # the requirement probe
     _resolves_to(monkeypatch, None)
     r = ob.detect_dep(dep)
     assert r["requirements"] == [{"name": "brew", "ok": False}]
@@ -273,7 +273,7 @@ def _fake_popen(returncode: int, stdout: str = "", stderr: str = "", *, timeout:
 def _brew_present(monkeypatch: pytest.MonkeyPatch) -> None:
     # A Homebrew install only exists on the darwin roster.
     monkeypatch.setattr(ob.osplat, "platform_id", "darwin")
-    monkeypatch.setattr(ob.shutil, "which", lambda name: f"/opt/homebrew/bin/{name}")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda name, *, path=None: f"/opt/homebrew/bin/{name}")
 
 
 def test_install_failure_surfaces_output_as_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -311,7 +311,7 @@ def test_install_blocked_when_bootstrap_binary_missing(
     # Fresh Mac without Homebrew: `brew install node` only ever produced a bare
     # exit 127, so the wizard has to name the real blocker instead of running it.
     monkeypatch.setattr(ob.osplat, "platform_id", "darwin")
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: None)
 
     def boom(*_a: object, **_k: object) -> None:
         raise AssertionError("must not shell out when a requirement is missing")
@@ -328,7 +328,7 @@ def test_install_bootstrap_gate_precedes_the_terminal_handoff(
 ) -> None:
     # claude is needs_terminal: without the gate the app reported success while
     # the terminal it opened just printed "npm: command not found".
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: None)
     r = ob.install_dep("claude")
     assert r["ok"] is False
     assert r["missing_requirements"] == ["npm"]
@@ -376,7 +376,7 @@ def test_ollama_status_separates_service_down_from_no_models(
 ) -> None:
     # `ollama list` fails when the daemon is down, which used to be reported
     # identically to "no models installed".
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/opt/homebrew/bin/ollama")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: "/opt/homebrew/bin/ollama")
     monkeypatch.setattr(
         ob.subprocess, "run", _ollama_list(1, "", "could not connect to ollama app")
     )
@@ -386,7 +386,7 @@ def test_ollama_status_separates_service_down_from_no_models(
 
 
 def test_ollama_status_lists_models_when_reachable(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/opt/homebrew/bin/ollama")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: "/opt/homebrew/bin/ollama")
     monkeypatch.setattr(
         ob.subprocess, "run", _ollama_list(0, "NAME\tID\nqwen2.5-coder:7b\tabc\n")
     )
@@ -404,7 +404,7 @@ def test_gate_reports_analyzer_blocked_when_service_is_down() -> None:
 
 
 def test_pull_model_allows_namespaced_names(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/opt/homebrew/bin/ollama")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: "/opt/homebrew/bin/ollama")
     monkeypatch.setattr(ob, "ollama_reachable", lambda: True)
     r = ob.pull_model("hf.co/user/repo:q4")
     assert r["ok"] is True and r["command"].endswith("hf.co/user/repo:q4")
@@ -413,7 +413,7 @@ def test_pull_model_allows_namespaced_names(monkeypatch: pytest.MonkeyPatch) -> 
 def test_pull_model_rejects_traversal_flags_and_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/opt/homebrew/bin/ollama")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: "/opt/homebrew/bin/ollama")
     monkeypatch.setattr(ob, "ollama_reachable", lambda: True)
     assert ob.pull_model("../../etc/passwd")["ok"] is False
     assert ob.pull_model("-rf")["ok"] is False
@@ -423,7 +423,7 @@ def test_pull_model_rejects_traversal_flags_and_empty(
 def test_pull_model_blocked_while_the_service_is_down(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/opt/homebrew/bin/ollama")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: "/opt/homebrew/bin/ollama")
     monkeypatch.setattr(ob, "ollama_reachable", lambda: False)
     r = ob.pull_model("qwen2.5-coder:7b")
     assert r["ok"] is False and r["needs_service"] is True
@@ -432,7 +432,7 @@ def test_pull_model_blocked_while_the_service_is_down(
 def test_start_ollama_service_hands_back_the_official_command(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda name: f"/opt/homebrew/bin/{name}")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda name, *, path=None: f"/opt/homebrew/bin/{name}")
     assert ob.start_ollama_service() == {
         "ok": True,
         "needs_terminal": True,
@@ -441,8 +441,19 @@ def test_start_ollama_service_hands_back_the_official_command(
 
 
 def test_start_ollama_service_requires_ollama(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: None)
     assert ob.start_ollama_service()["ok"] is False
+
+
+def test_every_program_lookup_goes_through_the_seam() -> None:
+    # `resolve_executable` asked the seam while six sibling checks (install
+    # requirements, ollama, brew) still called shutil.which directly. Same
+    # question — "is this program on this machine" — so the same answer:
+    # on Windows the seam is what knows a bare `npm` is `npm.cmd`, and a
+    # presence check that disagrees with the launch that follows it is a
+    # wizard that says "installed" and then cannot run the thing.
+    source = Path(ob.__file__).read_text(encoding="utf-8")
+    assert "shutil.which(" not in source, "ask osplat.paths.resolve_program instead"
 
 
 def test_local_bin_is_a_path_fallback(tmp_path) -> None:

--- a/backend/tests/test_onboarding_install_flow.py
+++ b/backend/tests/test_onboarding_install_flow.py
@@ -162,7 +162,7 @@ def test_spawn_probe_accepts_the_legacy_binary(monkeypatch: pytest.MonkeyPatch) 
 def test_install_result_names_the_dep(monkeypatch: pytest.MonkeyPatch) -> None:
     # The dialog renders label + docs link from the result itself, so every
     # branch has to carry them — including the ones that fail.
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: "/opt/homebrew/bin/brew")
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: "/opt/homebrew/bin/brew")
     result = ob.install_dep("claude")
     assert result["label"] == "Claude Code"
     assert result["docs_url"] == ob.DEPS_BY_ID["claude"].docs_url
@@ -170,7 +170,7 @@ def test_install_result_names_the_dep(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_missing_bootstrap_result_still_names_the_dep(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ob.shutil, "which", lambda _x: None)
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda _x, *, path=None: None)
     result = ob.install_dep("claude")
     assert result["ok"] is False
     assert result["missing_requirements"] == ["npm"]

--- a/backend/tests/test_terminal_create_cancellation.py
+++ b/backend/tests/test_terminal_create_cancellation.py
@@ -362,16 +362,23 @@ async def test_terminal_service_create_rolls_back_post_popen_setup_failure(
 
     registered = threading.Event()
     unregistered = threading.Event()
-    killed: list[tuple[int, int]] = []
+    killed: list[tuple[int, bool]] = []
 
     monkeypatch.setattr(_posix.pty, "openpty", recording_openpty)
     monkeypatch.setattr(terminals_module.shutil, "which", lambda _cmd: "/bin/bash")
     monkeypatch.setattr(terminals_module.subprocess, "Popen", lambda *_a, **_kw: process)
     monkeypatch.setattr(terminals_module.pty_registry, "register", lambda *_a: registered.set())
     monkeypatch.setattr(terminals_module.pty_registry, "unregister", lambda *_a: unregistered.set())
-    monkeypatch.setattr(terminals_module.os, "getpgid", lambda pid: pid)
+    # Stub the seam, not the os primitives under it: the rollback asks
+    # `process_tree.group_of` / `kill_group`, and which group gets killed is
+    # the platform-neutral fact this test is about (the signal is
+    # `_posix`'s business). The module stays gated on fcntl regardless —
+    # the real PTY above is POSIX — so this does not unlock Windows.
+    monkeypatch.setattr(terminals_module.osplat.process_tree, "group_of", lambda pid: pid)
     monkeypatch.setattr(
-        terminals_module.os, "killpg", lambda pgid, sig: killed.append((pgid, sig))
+        terminals_module.osplat.process_tree,
+        "kill_group",
+        lambda pgid, *, force: killed.append((pgid, force)),
     )
 
     def fail_add_reader(*_args: Any) -> None:
@@ -386,6 +393,6 @@ async def test_terminal_service_create_rolls_back_post_popen_setup_failure(
     assert await asyncio.to_thread(unregistered.wait, 2)
     assert service._sessions == {}
     assert process.returncode == -9
-    assert killed == [(9876, terminals_module.signal.SIGKILL)]
+    assert killed == [(9876, True)]
     with pytest.raises(OSError):
         os.fstat(opened[0])

--- a/docs/en-US/product-positioning.md
+++ b/docs/en-US/product-positioning.md
@@ -107,7 +107,7 @@ Founder dogfooding must never be described as customer validation. Future direct
 - Workspace-scoped state, run events, handoffs, and compatible token summaries are stored under `.agent-team/`.
 - Navide provides editor, Diff, terminal, diagnostics, Git, test, and review surfaces.
 - Navide is local-first and does not require a Navide account.
-- Navide supports macOS 13+ on Apple silicon and provides a clearly labeled unsigned v0.1.47 preview download alongside source installation.
+- Navide supports macOS 13+ on Apple silicon, Linux x64, and Windows x64. The v0.2.1 release provides macOS downloads signed with a Developer ID certificate and notarized by Apple, alongside source installation; Linux and Windows installers are built by release CI and ship from the next release, and the Windows build is not code-signed.
 - Navide's founder uses it as the primary environment for developing Navide.
 
 ## Directional claims that require a label
@@ -122,7 +122,7 @@ Use `product direction`, `long-term direction`, `destination`, or equivalent lan
 
 ## Claims that are not currently supportable
 
-- A signed or notarized public download is available.
+- A signed or notarized download is available for every supported platform (the Windows build is not code-signed, and the Linux and Windows installers have not shipped yet).
 - Navide provides a complete workspace sandbox.
 - Navide is universally offline.
 - Navide makes an engineer a specific multiple faster.

--- a/docs/ja-JP/product-positioning.md
+++ b/docs/ja-JP/product-positioning.md
@@ -107,7 +107,7 @@ Founder Dogfooding を Customer Validation と表現してはなりません。F
 - Workspace ごとの State、Run Event、Handoff、対応する Token Summary は `.agent-team/` に保存されます。
 - Navide は Editor、Diff、Terminal、Diagnostics、Git、Test、Review Surface を提供します。
 - Navide は Local-first で、Navide Account を必要としません。
-- Navide は Apple silicon 上の macOS 13+ をサポートし、明確に未署名と表示した v0.1.47 Preview Download と Source Installation を提供します。
+- Navide は Apple silicon 上の macOS 13+、Linux x64、Windows x64 をサポートします。v0.2.1 では Developer ID 証明書で署名し Apple の Notarization を受けた macOS 向けダウンロードと Source Installation を提供します。Linux と Windows のインストーラーは Release CI でビルドされ、次のリリースから配布されます。Windows ビルドはまだコード署名されていません。
 - Navide の創設者は Navide 開発の主要環境として利用しています。
 
 ## ラベルが必要な方向性の主張
@@ -122,7 +122,7 @@ Founder Dogfooding を Customer Validation と表現してはなりません。F
 
 ## 現在は裏付けられない主張
 
-- 署名済みまたは Notarization 済みの Public Download がある。
+- すべての対応プラットフォームで署名済みまたは Notarization 済みのダウンロードがある（Windows ビルドは未署名で、Linux と Windows のインストーラーはまだ配布されていない）。
 - Navide は完全な Workspace Sandbox を提供する。
 - Navide は常に完全オフラインである。
 - Navide によりエンジニアが特定倍率で速くなる。

--- a/docs/zh-TW/product-positioning.md
+++ b/docs/zh-TW/product-positioning.md
@@ -107,7 +107,7 @@ Navide
 - Workspace 狀態、Run Event、Handoff 與相容 Token 摘要儲存在 `.agent-team/`。
 - Navide 提供 Editor、Diff、Terminal、Diagnostics、Git、Tests 與 Review 介面。
 - Navide 採用 Local-first，而且不要求建立 Navide 帳號。
-- Navide 支援配備 Apple 晶片且執行 macOS 13 以上版本的 Mac，並提供清楚標示為未簽章的 v0.1.47 Preview 下載及原始碼安裝方式。
+- Navide 支援 Apple 晶片的 macOS 13 以上、Linux x64 與 Windows x64。v0.2.1 提供以 Developer ID 憑證簽章並經 Apple 公證的 macOS 下載版本及原始碼安裝方式；Linux 與 Windows 安裝檔由 Release CI 產出、自下一個版本起發布，Windows 版尚未程式碼簽章。
 - Navide 創辦人使用它作為開發 Navide 的主要環境。
 
 ## 必須標示為方向的主張
@@ -122,7 +122,7 @@ Navide
 
 ## 目前無法支持的主張
 
-- 已提供正式簽章或 Notarized 公開下載版本。
+- 所有支援平台都已提供簽章或 Notarized 的下載版本（Windows 版尚未程式碼簽章，Linux 與 Windows 安裝檔尚未發布）。
 - Navide 已提供完整 Workspace Sandbox。
 - Navide 在所有情況下都完全離線。
 - Navide 讓工程師提升特定倍數的速度。


### PR DESCRIPTION
Three deferred follow-ups from the Linux audit line (`followup-which`, `followup-cancellation-stub` in `.agent-team/plans/cross-platform-test-hygiene_4b9d21.html`, plus the stale positioning line), one PR.

## 1. `onboarding_deps`: every program lookup through the seam

Checked each site's question before deciding — they all ask the same one, "is this program on this machine?", so they get the same answer as `resolve_executable` (`:339`) already does:

| site | asks | now |
|---|---|---|
| `detect_dep` → `requirements[].ok` | is each bootstrap binary (brew/curl/node/npm…) present, for the wizard's check step | `resolve_program` |
| `missing_requirements` | same list, as the install gate | `resolve_program` |
| `detect_ollama_status` | is `ollama` installed before running `ollama list` | `resolve_program` |
| `pull_model` | is `ollama` installed before handing `ollama pull` to a terminal | `resolve_program` |
| `start_ollama_service` | are `ollama` and `brew` installed | `resolve_program` ×2 |

The task named three (`:410`, `:727`, `:891`); the file had six — `pull_model` and `start_ollama_service` carry three more of the identical shape, so they are included. No site wanted a different semantics (none cared about "same name on PATH regardless of extension"), so nothing is kept with a why-not comment. Why it matters: on Windows the seam is what knows a bare `npm` is `npm.cmd`, and a presence check that disagrees with the launch that follows is a wizard that says "installed" and then cannot run it. `shutil.which` on a Windows interpreter would usually agree for a bare name, so this is consistency rather than a live bug — but the stated purpose of the seam is that lookup and launch can never disagree.

**Not changed**: the launches (`subprocess.run(["ollama","list"])`, the `ollama pull` / `brew services` terminal hand-offs) still use bare names. That is the "launch programs the way each platform can run them" line (#63/#68), not this one.

The orphaned `import shutil` is removed.

**The tests had to move with it — and that is the R5 shape, replayed on the test side.** Thirteen tests in `test_onboarding.py` / `test_onboarding_install_flow.py` stubbed `ob.shutil.which` to say "brew is present" / "ollama is missing". Once the product asks `resolve_program`, a `shutil.which` stub is simply never reached: the tests would consult the *real* machine, pass or fail on whether this developer happens to have ollama installed, and — on a machine that does — pass while exercising none of what they claim. Moving the product to the seam while leaving the tests pinned under it would have carried the exact hole #70's R5 exists to catch straight into the test suite. They now stub `ob.osplat.paths.resolve_program` (seam signature, `(name, *, path=None)`). Reverting one product site to `shutil.which` was tried with those seam stubs in place: the seam-pinning test `test_every_program_lookup_goes_through_the_seam` went red, while the two `ollama_status` tests stayed green because this machine has ollama — a live demonstration of why the pinning test is needed alongside the stubs.

## 2. `test_terminal_create_cancellation.py`: stub the seam

The rollback test stubbed `terminals_module.os.getpgid` / `os.killpg` under a module that goes through `osplat.process_tree.group_of` / `kill_group`. Now it stubs the seam and asserts the platform-neutral fact — `killed == [(9876, True)]` (which group, `force=True`) — rather than the signal, which is `_posix`'s business (`_signal_for` has its own tests). Bypassing the seam in the product (`os.killpg(os.getpgid(...))` directly) turns the test red (verified).

**Does this unlock the test on Windows? No.** The same test opens a real PTY through `_posix.pty.openpty` and `os.fstat`s the resulting fd, so the module-level `pytest.importorskip("fcntl")` still governs it; the stub level is now correct in form and the comment says the gate still applies. Not claimed as coverage.

## 3. `docs/{en-US,zh-TW,ja-JP}/product-positioning.md`

Line 110 said "unsigned v0.1.47 preview download". Aligned with README / getting-started in all three languages: macOS 13+ on Apple silicon, Linux x64, Windows x64; v0.2.1 macOS downloads signed with a Developer ID certificate and notarized; Linux/Windows installers built by release CI and shipping from the next release; Windows not code-signed.

One consequential edit beyond line 110: the "claims that are not currently supportable" list said *"A signed or notarized public download is available."* That is now true for macOS and would contradict the updated line, so it is narrowed to what is still unsupportable — *"for every supported platform (the Windows build is not code-signed, and the Linux and Windows installers have not shipped yet)"*. Same in zh-TW and ja-JP. Flagging it because it is the one change not literally on the line the task named.

## Verification (bare runs, exit codes kept)

- `uv --project backend run --locked ruff check backend` — exit 0
- `uv --project backend run --locked pytest backend/tests` — `5528 passed, 9 skipped in 463.78s`, exit 0
- No frontend files touched.
- Revert-to-red: (1) one lookup back to `shutil.which` → the seam-pinning test red; (2) product bypassing the seam → the cancellation test red. Both restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
