### PR TITLE
refactor(main): decide on the platform through osplat, and ratchet the rest

### DIFF
--- a/src/main/dock-tile-badge.test.ts
+++ b/src/main/dock-tile-badge.test.ts
@@ -1,13 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { normalizePlatformId, setPlatformId } from '../shared/osplat'
 import { setWindowDockTileBadge } from './dock-tile-badge'
 
 // Only the guards are exercised here. The FFI path sends real objc_msgSend
 // calls through koffi; driving it with a fake window handle on a mac would
 // dereference garbage, so it stays a manual check.
 
-function setPlatform(p: string): void {
-  Object.defineProperty(process, 'platform', { value: p, configurable: true })
-}
 
 function fakeWindow(destroyed: boolean) {
   const getNativeWindowHandle = vi.fn()
@@ -18,18 +16,17 @@ function fakeWindow(destroyed: boolean) {
 }
 
 describe('setWindowDockTileBadge guards', () => {
-  const realPlatform = process.platform
-  afterEach(() => setPlatform(realPlatform))
+  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
 
   it('returns false off macOS before touching the window', () => {
-    setPlatform('linux')
+    setPlatformId('linux')
     const { win, getNativeWindowHandle } = fakeWindow(false)
     expect(setWindowDockTileBadge(win, '3')).toBe(false)
     expect(getNativeWindowHandle).not.toHaveBeenCalled()
   })
 
   it('returns false for a destroyed window before loading the FFI', () => {
-    setPlatform('darwin')
+    setPlatformId('darwin')
     const { win, getNativeWindowHandle } = fakeWindow(true)
     expect(setWindowDockTileBadge(win, '')).toBe(false)
     expect(getNativeWindowHandle).not.toHaveBeenCalled()

--- a/src/main/dock-tile-badge.ts
+++ b/src/main/dock-tile-badge.ts
@@ -1,5 +1,7 @@
 import type { BrowserWindow } from 'electron'
 
+import { isMac } from '../shared/osplat'
+
 // macOS per-window Dock tile badge (Terminal.app-style): when a window is
 // minimized, its Dock tile can carry the same system red badge as the app icon
 // via NSWindow.dockTile.badgeLabel. Electron has no API for this, so we call
@@ -46,7 +48,7 @@ function loadApi(): ObjcApi | null {
 
 /** Set (or clear, with '') the red badge on a window's minimized Dock tile. */
 export function setWindowDockTileBadge(win: BrowserWindow, label: string): boolean {
-  if (process.platform !== 'darwin' || win.isDestroyed()) return false
+  if (!isMac() || win.isDestroyed()) return false
   const a = loadApi()
   if (!a) return false
   try {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -166,7 +166,7 @@ if (
   )
 }
 
-if (process.platform === 'darwin') {
+if (isMac()) {
   app.dock?.setIcon(nativeImage.createFromPath(join(__dirname, '../../resources/icon.png')))
 }
 
@@ -3127,7 +3127,7 @@ ipcMain.handle(
 // unseen done/attention activity. The renderer tracks WHEN to update it
 // (useSystemNotify's pendingCount); main just reflects the count.
 ipcMain.on('window:setBadgeCount', (event, count: number) => {
-  if (process.platform !== 'darwin') return
+  if (!isMac()) return
   app.dock?.setBadge(count > 0 ? String(count) : '')
   // Mirror the count onto the sender window's own Dock tile (Terminal.app-style):
   // the system red badge shows on its thumbnail while the window is minimized.
@@ -4114,7 +4114,7 @@ app.whenReady().then(async () => {
 })
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit()
+  if (!isMac()) app.quit()
 })
 
 // Shutdown budgets. They are deliberately SEPARATE: a single shared deadline

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { MenuItemConstructorOptions } from 'electron'
+import { normalizePlatformId, setPlatformId, type PlatformId } from '../shared/osplat'
 import { setTerminalSelection, forgetTerminalSelection } from './terminal-selection-cache'
 
 // Shared, hoisted capture of the template passed to Menu.buildFromTemplate,
@@ -54,7 +55,11 @@ const focused = {
   reload: (): void => { focused.reloadCalls++ }
 }
 
-const isMac = process.platform === 'darwin'
+// The menu's shape is a platform decision (`isMac()` in menu.ts), so every
+// arm is driven here with setPlatformId and asserted on every host — this
+// file used to read process.platform itself and assert only the host's arm,
+// so a macOS runner never saw the Linux/Windows menu and vice versa.
+const NON_MAC: PlatformId[] = ['linux', 'win32']
 
 function submenuOf(label: string): MenuItemConstructorOptions[] {
   const top = h.template.find((i) => i.label === label)
@@ -112,15 +117,27 @@ describe('installApplicationMenu', () => {
     focused.reloadCalls = 0
     forgetTerminalSelection(FOCUSED_ID) // module state outlives a single case
     h.focusedWebContents = focused
-    installApplicationMenu(hooks)
+    installOn(normalizePlatformId(process.platform))
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
+    setPlatformId(normalizePlatformId(process.platform))
   })
 
-  it('app menu (macOS) / File menu (non-macOS) has Settings… with ⌘, and Check for Updates…', () => {
-    const menu = isMac ? submenuOf('Agent-Team') : submenuOf('File')
+  /** Rebuild the menu as `platform` would see it. */
+  function installOn(platform: PlatformId): void {
+    setPlatformId(platform)
+    installApplicationMenu(hooks)
+  }
+
+  it.each([
+    ['darwin', 'Agent-Team'],
+    ['linux', 'File'],
+    ['win32', 'File'],
+  ] as const)('on %s the %s menu has Settings… with ⌘, and Check for Updates…', (platform, top) => {
+    installOn(platform)
+    const menu = submenuOf(top)
     const settings = itemIn(menu, 'Settings…')
     expect(settings.accelerator).toBe('CmdOrCtrl+,')
     const updates = itemIn(menu, 'Check for Updates…')
@@ -358,17 +375,19 @@ describe('installApplicationMenu', () => {
     })
   })
 
-  it.runIf(isMac)('File has no Close Window on macOS (deliberate omission)', () => {
+  it('File has no Close Window on macOS (deliberate omission)', () => {
     // `role: 'close'` owns ⌘W, which fires in the main process ahead of the
     // renderer's closeActiveEditor. Putting it back silently kills tab-closing
     // while leaving the binding visible in Settings.
+    installOn('darwin')
     const closeRoles = submenuOf('File').filter(
       (i) => typeof i.role === 'string' && i.role.toLowerCase() === 'close'
     )
     expect(closeRoles).toEqual([])
   })
 
-  it.runIf(!isMac)('Window keeps Close off macOS, where Ctrl+W is free', () => {
+  it.each(NON_MAC)('Window keeps Close on %s, where Ctrl+W is free', (platform) => {
+    installOn(platform)
     const closeRoles = submenuOf('Window').filter(
       (i) => typeof i.role === 'string' && i.role.toLowerCase() === 'close'
     )
@@ -395,9 +414,13 @@ describe('installApplicationMenu', () => {
     expect(zoomRoles).toEqual([])
   })
 
-  it('builds and clicks safely with no hooks at all', () => {
+  it.each([
+    ['darwin', 'Agent-Team'],
+    ['linux', 'File'],
+  ] as const)('builds and clicks safely with no hooks at all on %s', (platform, top) => {
+    setPlatformId(platform)
     expect(() => installApplicationMenu()).not.toThrow()
-    const menu = isMac ? submenuOf('Agent-Team') : submenuOf('File')
+    const menu = submenuOf(top)
     expect(() => fire(itemIn(menu, 'Settings…'))).not.toThrow()
     expect(() => fire(itemIn(submenuOf('Window'), 'Pipeline Manager'))).not.toThrow()
     expect(() => fire(itemIn(submenuOf('Window'), 'Resource Manager'))).not.toThrow()

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,6 @@
 import { app, clipboard, Menu, webContents, type BrowserWindow, type MenuItemConstructorOptions } from 'electron'
 import { LEGAL_LABELS, LEGAL_ROUTES, type LegalRoute } from '../shared/legalLinks'
+import { isMac } from '../shared/osplat'
 import { getTerminalSelection } from './terminal-selection-cache'
 
 /**
@@ -114,7 +115,7 @@ export function installApplicationMenu(
   hooks: AppMenuHooks = {},
   recents: RecentMenuEntry[] = []
 ): void {
-  const isMac = process.platform === 'darwin'
+  const mac = isMac()
 
   // `role: 'copy'` copies the DOM selection, which a terminal pane never has
   // (`.xterm` is user-select: none), so Edit > Copy was inert while a CLI was
@@ -211,7 +212,7 @@ export function installApplicationMenu(
   }
 
   const template: MenuItemConstructorOptions[] = [
-    ...(isMac
+    ...(mac
       ? [
           {
             label: app.name,
@@ -254,7 +255,7 @@ export function installApplicationMenu(
         // No app menu off macOS — surface the same entries under File. macOS
         // gets nothing here: its Settings… live in the app menu, and `close` is
         // omitted so ⌘W reaches the renderer (see the doc comment above).
-        ...(isMac
+        ...(mac
           ? []
           : [
               { type: 'separator' } as MenuItemConstructorOptions,
@@ -274,7 +275,7 @@ export function installApplicationMenu(
         { role: 'cut' },
         copyItem,
         { role: 'paste' },
-        ...(isMac
+        ...(mac
           ? [
               { role: 'pasteAndMatchStyle' } as MenuItemConstructorOptions,
               { role: 'delete' } as MenuItemConstructorOptions,
@@ -319,7 +320,7 @@ export function installApplicationMenu(
         // macOS "zoom" = maximize the window frame. Unrelated to content zoom,
         // has no accelerator, and is part of the standard Window menu.
         { role: 'zoom' },
-        ...(isMac
+        ...(mac
           ? [
               { type: 'separator' } as MenuItemConstructorOptions,
               { role: 'front' } as MenuItemConstructorOptions

--- a/src/main/noScatteredPlatformBranches.test.ts
+++ b/src/main/noScatteredPlatformBranches.test.ts
@@ -1,0 +1,135 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// The TS side of backend/tests/test_osplat.py::TestNoScatteredPlatformBranches.
+//
+// `src/shared/osplat.ts` is the one place the desktop side asks which
+// operating system this is; everything else asks it for a capability
+// (`isMac()`, `needsDrawnWindowControls()`, …). A module that compares
+// `process.platform` itself re-derives a decision osplat already makes, and
+// — the reason this is a test and not a style note — a test cannot drive
+// that decision with `setPlatformId`, so its other arms are asserted only on
+// the runner that happens to be that platform, or never. `menu.test.ts`
+// asserted only the host's menu until menu.ts went through the seam.
+//
+// Not every read is a decision. Three shapes read the real value on purpose
+// and are not matched here: a boundary that hands the host platform to
+// osplat or to a function that takes it as a parameter
+// (`platform: process.platform` into resolveBackendDataDir,
+// `resolveOsCacheRoot(process.platform, …)`, preload's bridge value); a
+// value that is not branched on (`${process.platform}-${process.arch}` as a
+// plugin target); and the allowlisted comparisons below, which describe the
+// kernel this process is actually running on and must never follow an
+// injected platform id.
+
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const PRODUCTION_DIRS = ['src', 'packages/plugin-contracts/src', 'packages/plugin-sdk/src', 'packages/plugin-ui/src', 'plugins/navide-git/src', 'plugins/navide-plans/src']
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'out', 'dist-plugins', '.git', '__tests__'])
+/** The one module allowed to ask. */
+const SEAM = 'src/shared/osplat.ts'
+
+function productionFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string): void => {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const name of entries) {
+      if (SKIP_DIRS.has(name)) continue
+      const full = join(dir, name)
+      if (statSync(full).isDirectory()) walk(full)
+      else if (/\.(ts|vue)$/.test(name) && !/\.(test|spec)\.tsx?$/.test(name) && full !== __filename) found.push(full)
+    }
+  }
+  for (const dir of PRODUCTION_DIRS) walk(join(REPO_ROOT, dir))
+  return found.sort()
+}
+
+/**
+ * A decision made on `process.platform` directly: a comparison either way
+ * round, or a `switch` on it. A bare read that is passed along or
+ * interpolated is not a decision and does not match.
+ */
+export const PLATFORM_BRANCH_RE =
+  /process\.platform\s*(?:===|!==|==|!=)|(?:===|!==|==|!=)\s*process\.platform|switch\s*\(\s*process\.platform/
+
+/**
+ * Comparisons that must describe the host, not the injected platform, with
+ * the reason each one stays. A ratchet: an entry that stops matching fails
+ * the stale-entry test and has to be removed.
+ */
+export const PLATFORM_BRANCH_ALLOWLIST: ReadonlyMap<string, string> = new Map([
+  [
+    'src/main/plugins/ownerOnlyJsonPersistence.ts',
+    'O_NOFOLLOW and the 0o077 owner-only check are facts about the filesystem this ' +
+      'process opens files on. Following an injected platform id would drop the ' +
+      'no-follow flag on a real POSIX fs, or call a 0o644 file owner-only on Windows.',
+  ],
+  [
+    'src/main/plugins/executionPolicySourceStore.ts',
+    'Same O_NOFOLLOW flag as ownerOnlyJsonPersistence: a syscall flag for the real kernel.',
+  ],
+])
+
+function offenders(files: string[]): Set<string> {
+  const out = new Set<string>()
+  for (const file of files) {
+    const rel = relative(REPO_ROOT, file).split('\\').join('/')
+    if (rel === SEAM) continue
+    if (PLATFORM_BRANCH_RE.test(readFileSync(file, 'utf8'))) out.add(rel)
+  }
+  return out
+}
+
+describe('no scattered platform branches (TS)', () => {
+  it('only the seam and the allowlist decide on process.platform', () => {
+    const fresh = [...offenders(productionFiles())].filter((f) => !PLATFORM_BRANCH_ALLOWLIST.has(f))
+    expect(
+      fresh,
+      'these modules compare process.platform themselves; ask src/shared/osplat.ts ' +
+        '(isMac() / isWindows() / isLinux() / platformId()) instead, so a test can drive ' +
+        'every arm with setPlatformId. If the comparison genuinely describes the host ' +
+        'kernel rather than a platform behaviour, allowlist it here with that reason'
+    ).toEqual([])
+  })
+
+  it('has no stale allowlist entries', () => {
+    const stale = [...PLATFORM_BRANCH_ALLOWLIST.keys()].filter((f) => {
+      let text: string
+      try {
+        text = readFileSync(join(REPO_ROOT, f), 'utf8')
+      } catch {
+        return true
+      }
+      return !PLATFORM_BRANCH_RE.test(text)
+    })
+    expect(stale, 'already clean, drop from the allowlist').toEqual([])
+  })
+
+  it('still matches the shapes it guards, and not the three that read on purpose', () => {
+    // Decisions — what the rule bans.
+    expect(PLATFORM_BRANCH_RE.test("const isMac = process.platform === 'darwin'")).toBe(true)
+    expect(PLATFORM_BRANCH_RE.test("if (process.platform !== 'darwin') return")).toBe(true)
+    expect(PLATFORM_BRANCH_RE.test("const flag = process.platform === 'win32' ? 0 : O_NOFOLLOW")).toBe(true)
+    expect(PLATFORM_BRANCH_RE.test("if ('win32' === process.platform) {")).toBe(true)
+    expect(PLATFORM_BRANCH_RE.test('switch (process.platform) {')).toBe(true)
+    // Boundary: the real value handed to something that takes the platform as input.
+    expect(PLATFORM_BRANCH_RE.test('platform: process.platform,')).toBe(false)
+    expect(PLATFORM_BRANCH_RE.test('resolveOsCacheRoot(process.platform, homedir())')).toBe(false)
+    expect(PLATFORM_BRANCH_RE.test('platform: normalizePlatformId(process.platform),')).toBe(false)
+    // Value: interpolated, never branched on.
+    expect(PLATFORM_BRANCH_RE.test('return `${process.platform}-${process.arch}`')).toBe(false)
+    // The seam's own answer.
+    expect(PLATFORM_BRANCH_RE.test("if (!isMac() || win.isDestroyed()) return false")).toBe(false)
+  })
+
+  it('leaves the seam out of the scan', () => {
+    // osplat.ts reads process.platform by design; if it ever compared it the
+    // rule must still not fire on it.
+    expect(offenders([join(REPO_ROOT, SEAM)])).toEqual(new Set())
+  })
+})

--- a/src/main/notify-ipc.test.ts
+++ b/src/main/notify-ipc.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalizePlatformId, setPlatformId } from '../shared/osplat'
 
 // The renderer's useSystemNotify ends in two IPC channels owned by
 // `src/main/index.ts`: `window:notify` (desktop notification whose click brings
@@ -87,12 +88,8 @@ vi.mock('electron', () => {
 type NotifyHandler = (event: { sender: unknown }, args: Record<string, unknown>) => { ok: boolean }
 type BadgeHandler = (event: { sender: unknown }, count: number) => void
 
-function setPlatform(p: string): void {
-  Object.defineProperty(process, 'platform', { value: p, configurable: true })
-}
 
 describe('window:notify / window:setBadgeCount IPC', () => {
-  const realPlatform = process.platform
   let notify: NotifyHandler
   let setBadge: BadgeHandler
 
@@ -114,7 +111,7 @@ describe('window:notify / window:setBadgeCount IPC', () => {
     expect(setBadge).toBeTypeOf('function')
   }, 60_000)
 
-  afterEach(() => setPlatform(realPlatform))
+  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
 
   it('shows a non-silent notification with the given title and body', () => {
     const res = notify({ sender: 'sender' }, { paneId: 'p1', title: 'CLI finished', body: 'x completed' })
@@ -159,28 +156,28 @@ describe('window:notify / window:setBadgeCount IPC', () => {
   })
 
   it('setBadgeCount mirrors the count to the app Dock and the sender window tile', () => {
-    setPlatform('darwin')
+    setPlatformId('darwin')
     setBadge({ sender: 'sender' }, 3)
     expect(dockSetBadge).toHaveBeenCalledWith('3')
     expect(setWindowDockTileBadge).toHaveBeenCalledWith(fakeWin, '3')
   })
 
   it('setBadgeCount(0) clears both badges', () => {
-    setPlatform('darwin')
+    setPlatformId('darwin')
     setBadge({ sender: 'sender' }, 0)
     expect(dockSetBadge).toHaveBeenCalledWith('')
     expect(setWindowDockTileBadge).toHaveBeenCalledWith(fakeWin, '')
   })
 
   it('setBadgeCount skips the window tile when the sender has no window', () => {
-    setPlatform('darwin')
+    setPlatformId('darwin')
     setBadge({ sender: 'orphan' }, 2)
     expect(dockSetBadge).toHaveBeenCalledWith('2')
     expect(setWindowDockTileBadge).not.toHaveBeenCalled()
   })
 
   it('setBadgeCount is a no-op off macOS', () => {
-    setPlatform('linux')
+    setPlatformId('linux')
     setBadge({ sender: 'sender' }, 5)
     expect(dockSetBadge).not.toHaveBeenCalled()
     expect(setWindowDockTileBadge).not.toHaveBeenCalled()

--- a/src/main/permissions.test.ts
+++ b/src/main/permissions.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalizePlatformId, setPlatformId } from '../shared/osplat'
 
 // permissions.ts caches the last prompt result on disk because macOS exposes no
 // non-prompting TCC read to Electron. These tests pin the contract the Settings
@@ -51,12 +52,8 @@ vi.mock('node:child_process', () => ({ execFile: vi.fn() }))
 // differently from the code under test and every cached read would miss.
 const CACHE = join(USER_DATA, 'permissions.json')
 
-function setPlatform(p: string): void {
-  Object.defineProperty(process, 'platform', { value: p, configurable: true })
-}
 
 describe('permissions (main)', () => {
-  const realPlatform = process.platform
 
   beforeEach(() => {
     files.clear()
@@ -64,14 +61,14 @@ describe('permissions (main)', () => {
     notificationsSupported = true
     showThrows = false
     openExternal.mockClear()
-    setPlatform('darwin')
+    setPlatformId('darwin')
   })
   afterEach(() => {
-    setPlatform(realPlatform)
+    setPlatformId(normalizePlatformId(process.platform))
   })
 
   it('reports every permission not-applicable off macOS without touching disk', async () => {
-    setPlatform('linux')
+    setPlatformId('linux')
     const { getPermissionStatuses, requestPermission } = await import('./permissions')
     expect(await getPermissionStatuses()).toEqual({
       automation: 'not-applicable',
@@ -136,7 +133,7 @@ describe('permissions (main)', () => {
   })
 
   it('openPermissionSettings is a no-op off macOS', async () => {
-    setPlatform('win32')
+    setPlatformId('win32')
     const { openPermissionSettings } = await import('./permissions')
     await openPermissionSettings('notifications')
     expect(openExternal).not.toHaveBeenCalled()

--- a/src/main/permissions.ts
+++ b/src/main/permissions.ts
@@ -5,6 +5,8 @@ import { readFile, writeFile, rename, readdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+import { isMac } from '../shared/osplat'
+
 const execFileAsync = promisify(execFile)
 
 export type PermissionKey = 'automation' | 'notifications' | 'folders' | 'fullDisk'
@@ -16,8 +18,6 @@ const SETTINGS_PANES: Record<PermissionKey, string> = {
   folders: 'x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders',
   fullDisk: 'x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles',
 }
-
-const isMac = (): boolean => process.platform === 'darwin'
 
 // macOS exposes no non-prompting TCC check to Electron for automation /
 // notifications / folders — probing them IS the prompt — so the last known


### PR DESCRIPTION
The TS side of `backend/tests/test_osplat.py::TestNoScatteredPlatformBranches`: every production read of `process.platform` re-verified and sorted into "a decision osplat should make" vs "a read of the real host that is correct as written", the former converted with seam-driven tests, and a ratchet so the split holds.

## Every read, classified

The criterion: does this line ask **"is this the platform whose behaviour is X?"** (→ osplat, so `setPlatformId` can drive every arm in a test) or **"what is this machine actually?"** (→ direct read is right: a boundary, a value, a parameter, or a fact about the kernel).

| file:line | shape | verdict | why |
|---|---|---|---|
| `src/main/menu.ts:117` | `const isMac = process.platform === 'darwin'` → app menu vs File menu | **seam** | a platform *convention*; `menu.test.ts` read `process.platform` itself and asserted only the host's arm |
| `src/main/permissions.ts:20` | `const isMac = () => process.platform === 'darwin'` → TCC only on macOS | **seam** | behaviour; the test rolled its own `Object.defineProperty(process,'platform')` (and this is the file that was red on the first Windows run) |
| `src/main/dock-tile-badge.ts:49` | `process.platform !== 'darwin'` → skip Dock tile | **seam** | behaviour; same hand-rolled override in its test. A wrong answer here is benign: the FFI load fails and returns `false` |
| `src/main/index.ts:169 / 3130 / 4117` | dock icon, badge count, quit-on-last-window | **seam** | conventions; `index.ts` already imported `isMac` — these were inconsistencies |
| `src/main/index.ts:1463 / 3539`, `src/main/backend.ts:445` | `platform: process.platform` → `resolveBackendDataDir(...)` | **direct** | platform passed as a **parameter** — the pattern CONTRIBUTING asks for; the parity test pins the platform explicitly |
| `src/main/storage-ipc.ts:49` | `resolveOsCacheRoot(process.platform, homedir())` | **direct** | same: parameter |
| `src/preload/index.ts:174` | `platform: normalizePlatformId(process.platform)` | **direct** | the **boundary** osplat reads from in the renderer |
| `src/main/plugins/pluginTarget.ts:5` | `` `${process.platform}-${process.arch}` `` | **direct** | a **value** (plugin target triple), never branched on |
| `src/main/plugins/ownerOnlyJsonPersistence.ts:20, :73` | `NO_FOLLOW_FLAG = … 'win32' ? 0 : O_NOFOLLOW`; `isOwnerOnly = 'win32' \|\| (mode & 0o077) === 0` | **direct, allowlisted** | these describe the **kernel this process runs on**, not a behaviour we choose. `setPlatformId` is an injected override; routing these through it would let a test (or anything) drop `O_NOFOLLOW` on a real POSIX fs, or call a `0o644` file owner-only on Windows. Same reason the Python seam's `enforces_posix_modes()` is selected by `sys.platform` at import, not by a runtime knob |
| `src/main/plugins/executionPolicySourceStore.ts:42` | same `NO_FOLLOW_FLAG` | **direct, allowlisted** | same |

Where I differ from the initial list: `index.ts` had five reads, not one — three are decisions (converted), two are the parameter shape (kept). The three "應該改" you named are all confirmed; the two `NO_FOLLOW`/owner-only files are the interesting "should not change" case, because they *look* like decisions but are the one shape where following the injected platform would be actively wrong.

### And the test side of that same exemption

`gitStorageLifecycle.test.ts:12`, `executionPolicyStore.test.ts:27` and `executionPolicySourceStore.hardening.test.ts:18` gate a few cases with `hostIsWindows = normalizePlatformId(process.platform) === 'win32'` rather than `isWindows()`. That is deliberate and stays: the cases they gate — "does not follow a policy symlink", "owner-only write", "parent-directory flush fails" — are the kernel facts `ownerOnlyJsonPersistence.ts` reads from the real host. If the gate followed the injected id, a suite-wide `setPlatformId('win32')` on macOS would *skip* those cases while the product still opened with `O_NOFOLLOW` and checked `0o077` against the real filesystem — gate and product disagreeing, which is the bug shape everything here is trying to remove. Where the product reads a kernel fact, its tests gate on the same source.

## The conversions come with tests that drive every arm on every host

- `menu.test.ts`: was `const isMac = process.platform === 'darwin'` + `it.runIf(isMac)` / `it.runIf(!isMac)` — the host's arm only. Now `installOn(platform)` rebuilds the menu under `setPlatformId`, and the platform-shaped tests are `it.each` over darwin/linux/win32. **30 tests with one host-dependent skip → 34 tests, none skipped.**
- `permissions.test.ts`, `notify-ipc.test.ts`, `dock-tile-badge.test.ts`: `Object.defineProperty(process, 'platform', …)` → `setPlatformId`, reset via `normalizePlatformId(process.platform)` like the 13 files already doing it. (`backend-ws-token-parity.test.ts` keeps its `process.platform` override on purpose: it tests the parameter boundary, which `setPlatformId` does not touch.)
- Revert-to-red, each site: `menu.ts` → 5 red; `dock-tile-badge.ts` → 1 red; `permissions.ts` → 2 red; `index.ts:3130` → 1 red (notify-ipc). Restored.

## The ratchet: `src/main/noScatteredPlatformBranches.test.ts`

Production `.ts`/`.vue` under `src/`, `packages/*/src`, `plugins/*/src` (tests and the seam excluded) may not **compare or switch on** `process.platform`. The regex matches decisions only — `=== / !== / switch (process.platform` — so the parameter, boundary and value reads above are structurally unmatched and need no allowlist. The allowlist is a `Map<file, reason>` with the two kernel-fact files. Three self-checks as on the Python side: new offenders fail naming the seam; a stale entry fails; the regex is pinned against each shape it must catch **and** each of the three it must not.

**Run against `main` before the conversions it names exactly the four converted files and nothing else** — the classification and the regex agree.

## Verification (bare runs)

- `pnpm typecheck` — exit 0
- `pnpm vitest run` on the eight touched/related files — 95 passed, 0 skipped
- Ratchet revert-to-red: `permissions.ts` back to a direct read → red; a clean file added to the allowlist → stale-entry red. Restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
