### PR TITLE
test: run the backend suite with osplat.paths swapped to Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ dist-test-fixtures/
 backend/*.egg-info/
 backend/.mypy_cache/
 backend/.ruff_cache/
+# Written next to the package at import by osplat's Windows askpass launcher
+# (on Windows, and on any host running the suite with -p tests.osplat_win_swap).
+backend/agent_team_backend/git_askpass_helper.cmd
 # Note: backend/.python-version is intentionally tracked (uv uses it to pin Python)
 
 # ─── macOS ──────────────────────────────────────────────────────────────────

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,11 @@ real program says so through the seam too:
 `osplat.paths.executable_candidates("gh") != ["gh"]` for a `#!/bin/sh` fake
 found by bare name. (The run also writes
 `backend/agent_team_backend/git_askpass_helper.cmd`, as Windows does; it is
-gitignored.)
+gitignored.) The swapped run finishes sooner only because those skipped
+tests are the subprocess-heavy ones — every `git_service` test spawns real
+git several times — not because anything runs faster; it runs fewer tests,
+so it is a second pass before pushing, never a replacement for the normal
+run.
 
 What it verifies: path and environment arithmetic (`APPDATA`, `USERPROFILE`,
 `PATHEXT` candidate lists, `cmd.exe` argv shapes), seam-keyed skips, and the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,12 +180,60 @@ of asking the seam the code under test asks. Two rules keep that out:
   does exactly this: the macOS runner asserts the Linux answer by driving
   `_linux.LinuxLayout` directly and comparing with the Python side.
 
+**Running the backend suite as Windows before pushing**
+
+The Windows CI job takes 20+ minutes round-trip, and most of what it catches
+is the first rule above. `backend/tests/osplat_win_swap.py` catches that class
+on this machine in minutes: it swaps `osplat.paths` (optionally
+`osplat.platform_id`) for the Windows implementation before anything imports
+the feature code, so every `home_env_var()` / `config_home()` /
+`shell_command()` caller computes the Windows answer and every seam-keyed
+skip falls the way it falls on Windows.
+
+```sh
+# the files you touched — seconds
+OSPLAT_SWAP=paths uv --project backend run pytest backend/tests/test_host_shell.py -p tests.osplat_win_swap
+# the whole suite — a couple of minutes
+OSPLAT_SWAP=paths,platform_id uv --project backend run pytest backend/tests -p tests.osplat_win_swap
+```
+
+Expected result: green apart from the suite's known-flaky tests, with about
+300 extra skips — the tests that drive a real `git`/`gh` through the seam,
+which the Windows resolver (`PATHEXT`: `git.exe`, never `git`) cannot find
+on a POSIX host. A new red here is a test that answered a platform question
+by a different route than the code under test — fix the test the way the
+rule above says, not by gating it on `sys.platform`. A test that needs a
+real program says so through the seam too:
+`skipif(osplat.paths.resolve_program("git") is None)` for a binary,
+`osplat.paths.executable_candidates("gh") != ["gh"]` for a `#!/bin/sh` fake
+found by bare name. (The run also writes
+`backend/agent_team_backend/git_askpass_helper.cmd`, as Windows does; it is
+gitignored.)
+
+What it verifies: path and environment arithmetic (`APPDATA`, `USERPROFILE`,
+`PATHEXT` candidate lists, `cmd.exe` argv shapes), seam-keyed skips, and the
+feature code that branches on `platform_id`. What it cannot verify — nothing
+below has a stub-free test on any platform, and only a real Windows host
+(CI, or a VM) exercises it: a real DPAPI round-trip (`CryptProtectData`),
+real `icacls` ACLs, the `ctypes.WinDLL` prototype bindings and `_win_error`,
+real `CommandLineToArgvW` parsing, Job Object kill-on-close semantics,
+ConPTY I/O / EOF / resize, the `WinError 1314` symlink branch, psutil's
+Windows-only `private` / `peak_wset` fields, whether the rendered PowerShell
+hook scripts actually run, and the win-only `sys.platform` arms inside the
+`test_osplat.py` allowlist. Do not swap `secret_files`, `terminal_backend`,
+`process_tree` or `resource_probe` to get at those: their Windows
+implementations reach `WinDLL`, `winpty` and `icacls` at call time, so on a
+POSIX host every caller fails on the missing binding, not on anything the
+test asserts (the plugin refuses them for that reason).
+
 > 請與現有程式碼風格保持一致。Python 提交前請執行完整 backend tests。
 > 新增 CLI 整合請依 `docs/adding-a-cli-vendor.md`，一家一檔，不要在共用模組加分支。
 > 測試要在三個平台都過：不要繞過被測程式用的 seam 自己造路徑／平台答案
 > （`join()`、`os.pathsep`、`osplat.*`——被測程式怎麼拿，測試就怎麼拿；stub 停在 seam，
 > 不停在 seam 底下的 `os.kill`）；算別的平台的路徑時把 platform 當參數傳、不要問 host，
 > 這樣三個平台的答案在任何 runner 都能斷言。
+> 推 CI 前先用 `-p tests.osplat_win_swap` 把後端 suite 當 Windows 跑一次（改到的檔案幾秒、全套約十分鐘）；
+> 它只換 `osplat.paths`／`platform_id`，換不到 DPAPI／ConPTY／Job Object 那些真實行為——那些只有 Windows CI 或 VM 驗得到。
 
 ---
 

--- a/backend/tests/osplat_win_swap.py
+++ b/backend/tests/osplat_win_swap.py
@@ -1,0 +1,86 @@
+"""pytest plugin: run the suite on a POSIX host with `osplat.paths` swapped to
+the Windows implementation.
+
+    OSPLAT_SWAP=paths uv --project backend run pytest backend/tests -p tests.osplat_win_swap
+
+Not a Windows emulator. It catches one class of bug minutes before the
+Windows CI job would: a test that builds a platform-dependent value by a
+different route than the module under test (a `HOME` set where the code reads
+`paths.home_env_var()`, a `~/.config` literal where the code asks
+`paths.config_home()`, an `os.name` branch picking the expected value). Those
+tests pass on the platform they were written on and fail on exactly one
+other. With the seam swapped they fail here, on the fastest runner. What it
+verifies and what it cannot is written up in CONTRIBUTING.md.
+
+Loaded with `-p tests.osplat_win_swap`, which works from any cwd because the
+editable install puts `backend/` on `sys.path` (so `tests` is importable).
+
+THE SWAP HAPPENS AT MODULE IMPORT TIME, ON PURPOSE. Do not move it into
+`pytest_configure`. `-p` plugins are imported during option preparsing, before
+`tests/conftest.py`; that conftest imports `app` and `ws_handlers`, which
+transitively execute every bound-style `from .osplat import paths` in the
+feature code — `git_service.py`, `host_shell.py`, `push_delivery.py`,
+`mcp_server/wiring.py`, `cli_vendors/base.py` (re-exported by
+`cli_vendors/cursor.py`) bind the object at import and never look at
+`osplat.paths` again. A swap in `pytest_configure` runs after that conftest,
+so those five modules would keep the host implementation and the run would
+go green while exercising nothing. Import-time is the only point that reaches
+them. (Verified 2026-09-13 with an identity check on each module's `paths`
+after loading the conftest.)
+
+Only `paths` and `platform_id` are swappable:
+
+- `paths` is pure path arithmetic over environment variables and runs
+  anywhere; swapping it makes every seam-keyed skip (`enforces_posix_modes()`,
+  `login_path_probe() is None`) fall the way it falls on Windows, and every
+  `home_env_var()` / `config_home()` / `shell_command()` caller compute the
+  Windows answer. Full suite on 2026-09-13: 5185 passed, 352 skipped, 0 failed.
+- `platform_id` is harmless and adds little: the feature code that reads it
+  (`onboarding_deps`, `executions_service`, `server_link`) is tested with the
+  value monkeypatched, and the win-only skips key on `sys.platform`.
+- `secret_files`, `terminal_backend`, `process_tree`, `resource_probe` are NOT
+  swappable and are refused below. Their Windows implementations reach
+  `ctypes.WinDLL` (crypt32 for DPAPI, kernel32 for Job Objects), `icacls`, and
+  `import winpty` at call time; none exist on macOS or Linux, so a swap turns
+  every caller red with `AttributeError: module 'ctypes' has no attribute
+  'WinDLL'` / `No module named 'winpty'` — measured at 70 and 8 failures for
+  three and five test files respectively. That is noise, not signal; the
+  stubbed seam tests (`test_osplat_windows_terminal.py`,
+  `test_secret_file_protection.py`) already cover those code paths.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from agent_team_backend import osplat
+from agent_team_backend.osplat import _windows
+
+_SWAPPABLE = ("paths", "platform_id")
+
+SEAMS: tuple[str, ...] = tuple(
+    s.strip() for s in os.environ.get("OSPLAT_SWAP", "paths").split(",") if s.strip()
+)
+
+_unknown = [s for s in SEAMS if s not in _SWAPPABLE]
+if _unknown:
+    raise pytest.UsageError(
+        f"OSPLAT_SWAP={','.join(SEAMS)}: only {', '.join(_SWAPPABLE)} can be swapped "
+        f"on a POSIX host; {', '.join(_unknown)} would fail on missing WinDLL/winpty/"
+        "icacls, not on anything the tests assert (see the module docstring)"
+    )
+
+for _seam in SEAMS:
+    if _seam == "platform_id":
+        osplat.platform_id = "win32"
+    else:
+        setattr(osplat, _seam, getattr(_windows, _seam))
+
+
+def pytest_report_header(config: pytest.Config) -> list[str]:
+    return [
+        f"osplat_win_swap: swapped={list(SEAMS)} "
+        f"paths={type(osplat.paths).__name__} platform_id={osplat.platform_id}"
+    ]

--- a/backend/tests/test_app_worktree_handlers.py
+++ b/backend/tests/test_app_worktree_handlers.py
@@ -15,7 +15,13 @@ from typing import Any
 
 import pytest
 
-from agent_team_backend import app
+from agent_team_backend import app, osplat
+
+# Real `git worktree` calls through the seam; see test_git_service.py.
+pytestmark = pytest.mark.skipif(
+    osplat.paths.resolve_program("git") is None,
+    reason="git is not resolvable through osplat.paths on this host",
+)
 
 
 class FakeWebSocket:

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -10,7 +10,17 @@ from typing import Any
 import pytest
 
 from agent_team_backend import app as app_module
-from agent_team_backend import git_service
+from agent_team_backend import git_service, osplat
+
+# Every test here drives a real `git`, found through the seam
+# (`host_shell` resolves argv[0] with `osplat.paths.resolve_program`). Gate
+# on that lookup, not on the OS: a host where this platform's resolver cannot
+# see git — none installed, or the seam swapped to another platform's
+# implementation (`-p tests.osplat_win_swap`) — has nothing to run.
+pytestmark = pytest.mark.skipif(
+    osplat.paths.resolve_program("git") is None,
+    reason="git is not resolvable through osplat.paths on this host",
+)
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_host_shell.py
+++ b/backend/tests/test_host_shell.py
@@ -3,11 +3,10 @@ import os
 import shlex
 import shutil
 import subprocess
-import sys
 
 import pytest
 
-from agent_team_backend import host_shell
+from agent_team_backend import host_shell, osplat
 from agent_team_backend.host_shell import (
     HOST_SHELL_EXECUTABLE_ALLOWLIST,
     parse_allowlisted_command,
@@ -329,11 +328,17 @@ async def test_public_git_diff_driver_command_is_rejected_before_spawn(tmp_path)
     assert "public shell policy" in stderr
 
 
+#: The fake-CLI harness writes `#!/bin/sh` scripts found by bare name. Ask the
+#: seam whether it would ever pick such a file up: on Windows
+#: `executable_candidates("gh")` is `gh.com`, `gh.exe`, ... — never `gh` —
+#: so no launcher written next to the script could be found, and the same is
+#: true here when the seam is swapped (`-p tests.osplat_win_swap`).
+_BARE_NAME_IS_RUNNABLE = osplat.paths.executable_candidates("gh") == ["gh"]
+_GIT_ON_HOST = osplat.paths.resolve_program("git") is not None
+
+
 def _write_fake_cli(bin_dir, name: str, script: str):
-    if os.name != "posix":
-        # The fakes are `#!/bin/sh` scripts found by bare name: the product
-        # execs `gh`/`glab` as given, which on Windows resolves only `.exe`,
-        # so no launcher written next to the script could be picked up.
+    if not _BARE_NAME_IS_RUNNABLE:
         pytest.skip("fake-CLI harness is a /bin/sh script exec'd by bare name")
     executable = bin_dir / name
     executable.write_text(f"#!/bin/sh\nset -eu\n{script}\n", encoding="utf-8")
@@ -352,18 +357,17 @@ def _init_repo_with_origin(repo, remote_url: str) -> None:
 
 
 def test_glab_config_path_matches_platform_default(tmp_path, monkeypatch) -> None:
+    # The code under test reads the home from `paths.home_env_var()` and
+    # derives the config dir from `paths.config_home()`; ask the same seam
+    # for both rather than branching on `os.name` here, so the test still
+    # agrees with the code when the seam is swapped to another platform's
+    # implementation (`-p tests.osplat_win_swap`).
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv(osplat.paths.home_env_var(), str(home))
     monkeypatch.delenv("GLAB_CONFIG_DIR", raising=False)
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-    if os.name == "nt":
-        appdata = home / "AppData" / "Roaming"
-        monkeypatch.setenv("APPDATA", str(appdata))
-        expected_home = appdata
-    elif sys.platform == "darwin":
-        expected_home = home / "Library" / "Application Support"
-    else:
-        expected_home = home / ".config"
+    monkeypatch.delenv("APPDATA", raising=False)
+    expected_home = osplat.paths.config_home(home)
 
     assert host_shell._provider_config_path("glab") == expected_home / "glab-cli" / "config.yml"
 
@@ -855,6 +859,8 @@ async def test_public_glab_context_hides_local_config_from_installed_glab(tmp_pa
     real_glab = shutil.which("glab")
     if real_glab is None:
         pytest.skip("glab CLI is not installed")
+    if not _BARE_NAME_IS_RUNNABLE:
+        pytest.skip("the glab wrapper is a /bin/sh script exec'd by bare name")
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -924,6 +930,7 @@ async def test_public_runner_strips_execution_environment_and_injects_fixed_git_
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not _GIT_ON_HOST, reason="git is not resolvable through osplat.paths on this host")
 async def test_git_runs_through_exec_broker() -> None:
     rc, stdout, stderr = await run_allowlisted_text(["git", "--version"])
     assert rc == 0
@@ -1010,6 +1017,7 @@ def _repo_with_large_diff(path, line_count: int) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not _GIT_ON_HOST, reason="git is not resolvable through osplat.paths on this host")
 async def test_capped_run_stops_at_the_cap_and_reports_truncation(tmp_path) -> None:
     _repo_with_large_diff(tmp_path, 4000)
     rc, stdout, stderr, truncated = await run_allowlisted_capped(
@@ -1024,6 +1032,7 @@ async def test_capped_run_stops_at_the_cap_and_reports_truncation(tmp_path) -> N
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not _GIT_ON_HOST, reason="git is not resolvable through osplat.paths on this host")
 async def test_capped_run_returns_whole_output_below_the_cap(tmp_path) -> None:
     _repo_with_large_diff(tmp_path, 2)
     rc, stdout, stderr, truncated = await run_allowlisted_capped(

--- a/backend/tests/test_issue_service.py
+++ b/backend/tests/test_issue_service.py
@@ -11,7 +11,7 @@ import subprocess
 
 import pytest
 
-from agent_team_backend import issue_service
+from agent_team_backend import issue_service, osplat
 
 
 # ── canned CLI output (trimmed real shapes) ────────────────────────────────────
@@ -260,9 +260,10 @@ class TestListIssues:
 
     @pytest.mark.asyncio
     async def test_trusted_issue_route_inherits_existing_gh_auth_config(self, tmp_path, monkeypatch):
-        if os.name != "posix":
+        if osplat.paths.executable_candidates("gh") != ["gh"]:
             # Same harness as test_host_shell: a `#!/bin/sh` fake exec'd by
-            # bare name, which Windows resolves only as `gh.exe`.
+            # bare name, which this platform's resolver would never pick up
+            # (Windows resolves only `gh.exe`; see _BARE_NAME_IS_RUNNABLE there).
             pytest.skip("fake-CLI harness is a /bin/sh script exec'd by bare name")
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
@@ -406,6 +407,9 @@ async def test_run_timeout_kills_and_reaps(monkeypatch):
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
     monkeypatch.setattr(asyncio, "wait_for", fast_wait_for)
+    # The broker resolves `gh` through the seam before exec; without this a
+    # host with no gh (or the seam swapped) reports 127 before the fake runs.
+    monkeypatch.setattr(osplat.paths, "resolve_program", lambda name, *, path=None: name)
 
     rc, _out, err = await issue_service._run(["gh", "issue", "list"], "/ws")
     assert rc == 128

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -180,6 +180,9 @@ def test_install_unknown_id_rejected() -> None:
 def test_install_needs_terminal_returns_command_without_running(monkeypatch: pytest.MonkeyPatch) -> None:
     # homebrew is needs_terminal → must NOT shell out, just hand back the command.
     monkeypatch.setattr(ob.osplat, "platform_id", "darwin")
+    # The bootstrap gate asks the seam for each required binary; answer for
+    # it so the test is about needs_terminal, not about what this host has.
+    monkeypatch.setattr(ob.osplat.paths, "resolve_program", lambda name, *, path=None: f"/usr/bin/{name}")
     called = {"ran": False}
     def boom(*_a, **_k):
         called["ran"] = True

--- a/backend/tests/test_plugin_capabilities.py
+++ b/backend/tests/test_plugin_capabilities.py
@@ -232,6 +232,22 @@ def test_terminal_run_rejects_unregistered_cwd(
         asyncio.run(TerminalCapability().run("echo hi", cwd=str(tmp_path)))
 
 
+def _host_has_the_seam_shell() -> bool:
+    """`TerminalCapability.run` execs whatever `osplat.paths.shell_command()`
+    names. Gate on that program being on this host — not on which OS this
+    is — so the two tests below skip, rather than die on FileNotFoundError,
+    when the seam is swapped to another platform's implementation
+    (`-p tests.osplat_win_swap`)."""
+    import shutil
+
+    from agent_team_backend import osplat
+
+    return shutil.which(osplat.paths.shell_command("")[0]) is not None
+
+
+@pytest.mark.skipif(
+    not _host_has_the_seam_shell(), reason="the seam's shell is not on this host"
+)
 def test_terminal_run_allows_registered_subdir(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -248,6 +264,9 @@ def test_terminal_run_allows_registered_subdir(
     assert result["exit_code"] == 0
 
 
+@pytest.mark.skipif(
+    not _host_has_the_seam_shell(), reason="the seam's shell is not on this host"
+)
 def test_terminal_run_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     import asyncio
 

--- a/backend/tests/test_ws_handlers_shell_run.py
+++ b/backend/tests/test_ws_handlers_shell_run.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from agent_team_backend import app, ws_handlers
+from agent_team_backend import app, osplat, ws_handlers
 
 
 class FakeWebSocket:
@@ -120,8 +119,10 @@ async def test_public_broker_rejects_git_template_without_creating_hooks(
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="fake `gh` is a #!/bin/sh script on a /usr/bin:/bin PATH (the test_host_shell fake-CLI harness)",
+    osplat.paths.executable_candidates("gh") != ["gh"]
+    or osplat.paths.resolve_program("git") is None,
+    reason="fake `gh` is a #!/bin/sh script found by bare name, next to a real git "
+    "(the test_host_shell fake-CLI harness)",
 )
 async def test_public_broker_does_not_return_provider_auth_fixture(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## What

`backend/tests/osplat_win_swap.py` — a pytest plugin that swaps `osplat.paths` (optionally `osplat.platform_id`) for the Windows implementation on a POSIX host, so the class of failure the Windows CI job mostly reports — a test that built a platform value by a different route than the module under test — shows up here in seconds.

```sh
# the files you touched
OSPLAT_SWAP=paths uv --project backend run pytest backend/tests/test_host_shell.py -p tests.osplat_win_swap
# the whole suite
OSPLAT_SWAP=paths,platform_id uv --project backend run pytest backend/tests -p tests.osplat_win_swap
```

Usage, what it verifies and what it cannot (the 11 classes of Windows behaviour with no stub-free test on any platform) are in `CONTRIBUTING.md` → "Running the backend suite as Windows before pushing".

## Where it lives and why

`backend/tests/osplat_win_swap.py`, loaded as `-p tests.osplat_win_swap`. `tests` is importable from any cwd because the editable install puts `backend/` on `sys.path`; `-p` plugins load before `pythonpath`/rootdir insertion, so a module that only `backend/tests` could see would not work. It is not a `test_*.py`, so neither collection nor the hygiene ratchet touches it.

## The mechanism that must not be "simplified" (also in the module docstring)

The swap runs at **plugin import time**, not in `pytest_configure`. `tests/conftest.py:30` imports `app`/`ws_handlers`, which execute every bound-style `from .osplat import paths` in the feature code — `git_service.py`, `host_shell.py`, `push_delivery.py`, `mcp_server/wiring.py`, `cli_vendors/base.py` (re-exported by `cli_vendors/cursor.py`). A swap in `pytest_configure` runs after that conftest, so those five modules keep the host implementation and the run goes green while exercising nothing. Verified with an identity check on each module's `paths` after loading the conftest.

Only `paths` and `platform_id` are accepted; `secret_files` / `terminal_backend` / `process_tree` / `resource_probe` are refused with a `UsageError`. Their Windows implementations reach `ctypes.WinDLL`, `winpty` and `icacls` at call time, so on a POSIX host every caller fails on the missing binding — measured at 70 / 8 failures for three / five files — which is noise, not signal; the stubbed seam tests already cover those paths.

## Making the swapped run green

The first swapped run after `feat/windows-shim-passthrough` landed had 166 failures, 140 of them `test_git_service.py`: `host_shell` now resolves argv[0] through `paths.resolve_program`, and the Windows resolver (`PATHEXT`: `git.exe`, never `git`) cannot see a POSIX `git`. Fixed by asking the seam, not the OS:

- `test_git_service.py`, `test_app_worktree_handlers.py`: module-level `skipif(osplat.paths.resolve_program("git") is None)`; three real-git tests in `test_host_shell.py` and one in `test_ws_handlers_shell_run.py` get the same per-test gate (replacing a `sys.platform == "win32"` skip in the latter).
- `#!/bin/sh` fake-CLI harness (`_write_fake_cli`, the glab wrapper, `test_issue_service`): gate on `osplat.paths.executable_candidates("gh") == ["gh"]` — "would this platform's resolver ever pick up a bare-named script" — replacing the `os.name != "posix"` checks.
- `test_plugin_capabilities` `terminal.run` ×2: skip when `shutil.which(osplat.paths.shell_command("")[0])` is None (`cmd.exe` on this host).
- `test_host_shell::test_glab_config_path_matches_platform_default`: expected value from `osplat.paths.home_env_var()` / `config_home()` instead of an `os.name`/`sys.platform` branch — exactly the shape the plugin exists to catch.
- `test_issue_service::test_run_timeout_kills_and_reaps`, `test_onboarding::test_install_needs_terminal_returns_command_without_running`: stub `resolve_program` at the seam; their subject is the timeout / needs_terminal branch, and both already depended on the host having `gh` / the homebrew prerequisites.

On real Windows every gate resolves the same way it did before (git.exe is found; bare-name scripts are not), so CI coverage there is unchanged.

`.gitignore`: `backend/agent_team_backend/git_askpass_helper.cmd` — the Windows askpass launcher writes it next to the package at `git_service` import, on Windows and on any host running the swap.

## Verification (bare runs, this branch, macOS)

```
$ uv --project backend run ruff check backend
All checks passed!

$ uv --project backend run pytest backend/tests -q -p no:cacheprovider --timeout 90 -rfE
5528 passed, 9 skipped, 14 warnings in 201.32s (0:03:21)

$ OSPLAT_SWAP=paths,platform_id uv --project backend run pytest backend/tests -q -p no:cacheprovider -p tests.osplat_win_swap --timeout 90 -rfEs
5185 passed, 352 skipped, 14 warnings in 99.44s (0:01:39)
```

Swapped-run skip reasons (all seam-keyed):

```
297  git is not resolvable through osplat.paths on this host
 14  fake-CLI harness is a /bin/sh script exec'd by bare name
 12  POSIX mode bits
 11  login-shell PATH probe is None on this platform (Windows) by design
  4  drives a real ConPTY; the other hosts run the stubbed suite instead
  3  opt-in vendor probe; set AGENT_TEAM_VENDOR_PROBE=1 to run
  2  the seam's shell is not on this host
  2  chmod(0o000) cannot make a directory unreadable without POSIX mode bits
  2  POSIX mode bits: NTFS has none, secret_files hardens with an ACL
  1  the glab wrapper is a /bin/sh script exec'd by bare name
  1  preserving a user file's 0o755 is POSIX mode-bit behaviour; NTFS has none
  1  filesystem rejects this name
  1  fake `gh` is a #!/bin/sh script found by bare name, next to a real git
  1  a real ACL needs a real NTFS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
