### PR TITLE
test: restore the platform to what the file loaded with, not the host

### DIFF
--- a/src/main/backend.test.ts
+++ b/src/main/backend.test.ts
@@ -11,7 +11,7 @@ vi.mock('./process-tree', () => ({ killProcessTree }))
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { normalizePlatformId, setPlatformId } from '../shared/osplat'
+import { platformId, setPlatformId } from '../shared/osplat'
 import {
   bindBackendPluginActivationCatalog,
   handConfirmKey,
@@ -22,6 +22,12 @@ import {
   stopBackendProcess,
   waitForHealth,
 } from './backend'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 describe('backend plugin activation environment', () => {
   it('replaces directory discovery with a path and exact-byte digest binding', () => {
@@ -107,7 +113,7 @@ describe('waitForHealth', () => {
 // notice when it moves.
 
 describe('the trust-confirmation key', () => {
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('goes over stdin once and closes the pipe', () => {
     // Not a file and not an environment variable, deliberately: `cat` and
@@ -256,7 +262,7 @@ const asChild = (proc: FakeProc): ChildProcess => proc as unknown as ChildProces
 describe('stopBackendProcess', () => {
   afterEach(() => {
     killProcessTree.mockReset()
-    setPlatformId(normalizePlatformId(process.platform))
+    setPlatformId(BASELINE)
     vi.useRealTimers()
   })
 

--- a/src/main/dock-tile-badge.test.ts
+++ b/src/main/dock-tile-badge.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { normalizePlatformId, setPlatformId } from '../shared/osplat'
+import { platformId, setPlatformId } from '../shared/osplat'
 import { setWindowDockTileBadge } from './dock-tile-badge'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 // Only the guards are exercised here. The FFI path sends real objc_msgSend
 // calls through koffi; driving it with a fake window handle on a mac would
@@ -16,7 +22,7 @@ function fakeWindow(destroyed: boolean) {
 }
 
 describe('setWindowDockTileBadge guards', () => {
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('returns false off macOS before touching the window', () => {
     setPlatformId('linux')

--- a/src/main/editors.test.ts
+++ b/src/main/editors.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { delimiter, join, sep } from 'node:path'
-import { normalizePlatformId, setPlatformId } from '../shared/osplat'
+import { platformId, setPlatformId } from '../shared/osplat'
 import {
   BUILT_IN_EDITORS,
   buildEditorArgv,
@@ -17,6 +17,12 @@ import {
   type EditorPreference,
   type EditorProcess
 } from './editors'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 const prefer = (editorId: string, customCommand: string[] = []): EditorPreference => ({
   editorId,
@@ -188,7 +194,7 @@ describe('whichIn', () => {
   // Windows runner checks the same contract, and the `on Windows` block below
   // opts into the suffixed lookup explicitly.
   beforeEach(() => setPlatformId('linux'))
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   const exists = (paths: string[]) => (p: string): boolean => paths.includes(p)
   const always = (): boolean => true
@@ -222,7 +228,7 @@ describe('whichIn', () => {
   })
 
   describe('on Windows', () => {
-    afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+    afterEach(() => setPlatformId(BASELINE))
 
     // VS Code and Cursor install `code.cmd` / `cursor.cmd` onto PATH; the bare
     // name that works from a shell there names nothing on disk.
@@ -265,7 +271,7 @@ describe('resolveEditorCommand', () => {
   // The fixtures are the POSIX shape (a bare `code` on PATH, an .app-bundled
   // CLI); pinned so the Windows runner checks the same contract.
   beforeEach(() => setPlatformId('linux'))
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   const vscode = BUILT_IN_EDITORS.find((e) => e.id === 'vscode')!
   const always = (): boolean => true
@@ -285,7 +291,7 @@ describe('resolveEditorCommand', () => {
       const hit = resolveEditorCommand(vscode, usrBin, (p) => p === bundled, always)
       expect(hit).toBe(bundled)
     } finally {
-      setPlatformId(normalizePlatformId(process.platform))
+      setPlatformId(BASELINE)
     }
   })
 
@@ -302,7 +308,7 @@ describe('resolveEditorCommand', () => {
     try {
       expect(resolveEditorCommand(vscode, usrBin, (p) => p === bundled, always)).toBe(bundled)
     } finally {
-      setPlatformId(normalizePlatformId(process.platform))
+      setPlatformId(BASELINE)
     }
   })
 
@@ -311,7 +317,7 @@ describe('resolveEditorCommand', () => {
     try {
       expect(vscode.bundledPaths().some((p) => p.includes('/Applications/'))).toBe(false)
     } finally {
-      setPlatformId(normalizePlatformId(process.platform))
+      setPlatformId(BASELINE)
     }
   })
 
@@ -324,7 +330,7 @@ describe('detectEditors', () => {
   // The fixtures are the POSIX shape (a bare `code` on PATH); pinned so the
   // Windows runner checks the same contract.
   beforeEach(() => setPlatformId('linux'))
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('reports availability per editor', () => {
     const cursor = join(usrBin, 'cursor')
@@ -480,7 +486,7 @@ describe('buildEditorArgv', () => {
 })
 
 describe('needsWindowsShell', () => {
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('routes .cmd and .bat through the shell on Windows only', () => {
     setPlatformId('win32')

--- a/src/main/external-terminal.test.ts
+++ b/src/main/external-terminal.test.ts
@@ -9,8 +9,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('node:child_process', () => ({ spawn: vi.fn() }))
 
 import { spawn } from 'node:child_process'
-import { normalizePlatformId, setPlatformId, type PlatformId } from '../shared/osplat'
+import { normalizePlatformId, platformId, setPlatformId, type PlatformId } from '../shared/osplat'
 import * as terminal from './external-terminal'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 // The real filesystem the suite runs on: NTFS has no executable bit to withhold.
 const hostIsWindows = normalizePlatformId(process.platform) === 'win32'
@@ -38,7 +44,7 @@ const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>
 
 beforeEach(() => spawnMock.mockReset())
 afterEach(() => {
-  setPlatformId(normalizePlatformId(process.platform))
+  setPlatformId(BASELINE)
   vi.restoreAllMocks()
 })
 

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { MenuItemConstructorOptions } from 'electron'
-import { normalizePlatformId, setPlatformId, type PlatformId } from '../shared/osplat'
+import { normalizePlatformId, platformId, setPlatformId, type PlatformId } from '../shared/osplat'
 import { setTerminalSelection, forgetTerminalSelection } from './terminal-selection-cache'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 // Shared, hoisted capture of the template passed to Menu.buildFromTemplate,
 // plus the clipboard / focused-WebContents doubles Edit > Copy drives.
@@ -122,7 +128,7 @@ describe('installApplicationMenu', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
-    setPlatformId(normalizePlatformId(process.platform))
+    setPlatformId(BASELINE)
   })
 
   /** Rebuild the menu as `platform` would see it. */

--- a/src/main/notify-ipc.test.ts
+++ b/src/main/notify-ipc.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { normalizePlatformId, setPlatformId } from '../shared/osplat'
+import { platformId, setPlatformId } from '../shared/osplat'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 // The renderer's useSystemNotify ends in two IPC channels owned by
 // `src/main/index.ts`: `window:notify` (desktop notification whose click brings
@@ -111,7 +117,7 @@ describe('window:notify / window:setBadgeCount IPC', () => {
     expect(setBadge).toBeTypeOf('function')
   }, 60_000)
 
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('shows a non-silent notification with the given title and body', () => {
     const res = notify({ sender: 'sender' }, { paneId: 'p1', title: 'CLI finished', body: 'x completed' })

--- a/src/main/permissions.test.ts
+++ b/src/main/permissions.test.ts
@@ -1,7 +1,13 @@
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { normalizePlatformId, setPlatformId } from '../shared/osplat'
+import { platformId, setPlatformId } from '../shared/osplat'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 // permissions.ts caches the last prompt result on disk because macOS exposes no
 // non-prompting TCC read to Electron. These tests pin the contract the Settings
@@ -64,7 +70,7 @@ describe('permissions (main)', () => {
     setPlatformId('darwin')
   })
   afterEach(() => {
-    setPlatformId(normalizePlatformId(process.platform))
+    setPlatformId(BASELINE)
   })
 
   it('reports every permission not-applicable off macOS without touching disk', async () => {

--- a/src/main/plansWindowRouting.test.ts
+++ b/src/main/plansWindowRouting.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { normalizePlatformId, setPlatformId } from '../shared/osplat'
+import { platformId, setPlatformId } from '../shared/osplat'
 import {
   createPlansWindowRouter,
   getContributionWindowConfig,
@@ -10,6 +10,12 @@ import {
   PLANS_PLUGIN_ID,
   type PluginLaunchDescriptor,
 } from './plugins/frontendPluginManager'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 describe('Plans window production routing unit tests', () => {
   function setupRouter(options: {
@@ -417,7 +423,7 @@ describe('Plans window production routing unit tests', () => {
   })
 
   describe('getContributionWindowConfig', () => {
-    afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+    afterEach(() => setPlatformId(BASELINE))
 
     it('uses legacy-compatible 1100x760 size and native titlebar for navide.plans.window', () => {
       const config = getContributionWindowConfig('navide.plans.window', 'Plans')

--- a/src/main/plugins/frontendPluginManager.test.ts
+++ b/src/main/plugins/frontendPluginManager.test.ts
@@ -3,8 +3,14 @@ import { createHash, generateKeyPairSync, sign as edSign } from 'node:crypto'
 import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
-import { normalizePlatformId, setPlatformId } from '../../shared/osplat'
+import { platformId, setPlatformId } from '../../shared/osplat'
 import { backendEntryOnDisk } from './installedPlugins'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 // The manager imports electron for its view lifecycle. A functional stub backs
 // both the registry tests (which touch none of it) and the view-lifecycle tests
@@ -5323,7 +5329,7 @@ describe('mini-IDE dedicated window (openMiniIdePluginView)', () => {
       if (!win.isDestroyed()) win.close()
     }
     frontendPluginManager.destroy(MINI_IDE_PLUGIN_ID)
-    setPlatformId(normalizePlatformId(process.platform))
+    setPlatformId(BASELINE)
   })
 
   function lastWindow(): FakeWindowLike {

--- a/src/main/plugins/fsSync.test.ts
+++ b/src/main/plugins/fsSync.test.ts
@@ -2,10 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { constants, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { normalizePlatformId, setPlatformId } from '../../shared/osplat'
+import { normalizePlatformId, platformId, setPlatformId } from '../../shared/osplat'
 import { fsyncFileSync, syncDirectory, syncDirectorySync, type SyncFileOps } from './fsSync'
 import { NodePluginStorageFileSystem } from './pluginStorage'
 import { PluginCapabilityGrantStore } from './pluginCapabilityGrantStore'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 // The real filesystem the suite runs on: NTFS refuses to fsync a directory handle.
 const hostIsWindows = normalizePlatformId(process.platform) === 'win32'
@@ -65,7 +71,7 @@ describe('fsSync', () => {
     opened.paths.length = 0
   })
   afterEach(() => {
-    setPlatformId(normalizePlatformId(process.platform))
+    setPlatformId(BASELINE)
     rmSync(root, { recursive: true, force: true })
   })
 

--- a/src/main/plugins/installedPlugins.platform.test.ts
+++ b/src/main/plugins/installedPlugins.platform.test.ts
@@ -2,8 +2,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isWindows, normalizePlatformId, setPlatformId } from '../../shared/osplat'
+import { isWindows, platformId, setPlatformId } from '../../shared/osplat'
 import { backendEntryOnDisk, loadPluginDir } from './installedPlugins'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 const FIXTURE = join(process.cwd(), 'docs/plugin-contracts/fixtures/valid/backend-only-skills.json')
 const ELF_HEADER = Buffer.from([0x7f, 0x45, 0x4c, 0x46])
@@ -15,7 +21,7 @@ describe('backend entry executability by platform', () => {
     mkdirSync(join(root, 'backend'), { recursive: true })
   })
   afterEach(() => {
-    setPlatformId(normalizePlatformId(process.platform))
+    setPlatformId(BASELINE)
     rmSync(root, { recursive: true, force: true })
   })
 

--- a/src/main/plugins/pluginInstaller.test.ts
+++ b/src/main/plugins/pluginInstaller.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { normalizePlatformId, setPlatformId } from '../../shared/osplat'
+import { platformId, setPlatformId } from '../../shared/osplat'
 import { spawnSync } from 'node:child_process'
 import { generateKeyPairSync, sign as edSign, type KeyObject } from 'node:crypto'
 import {
@@ -31,6 +31,12 @@ import {
 import { REGISTRY_TRUST_SNAPSHOT_NAME } from './pluginInstalledTrust'
 import { PLUGIN_QUARANTINE_DIR } from './pluginInstallPaths'
 import { makeZip, type ZipFile } from './zipFixture'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 const REQ_BASE = {
   registryUrl: 'http://localhost:8787',
@@ -199,7 +205,7 @@ describe('prepareInstall', () => {
   // carrying an exec bit); pinned so the Windows runner checks the same
   // contract, and the `on Windows` block opts into the .exe rule explicitly.
   beforeEach(() => setPlatformId('linux'))
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('rejects an install request without explicit provenance', async () => {
     const { bytes, digest } = pkg()
@@ -499,7 +505,7 @@ describe('prepareInstall', () => {
 
   describe('on Windows', () => {
     beforeEach(() => setPlatformId('win32'))
-    afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+    afterEach(() => setPlatformId(BASELINE))
 
     it('resolves a bare backend entry to the packaged .exe, exec bit or not', async () => {
       const { bytes, digest } = v2Pkg([
@@ -641,7 +647,7 @@ describe('commitInstall', () => {
   // carrying an exec bit); pinned so the Windows runner checks the same
   // contract.
   beforeEach(() => setPlatformId('linux'))
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('writes a backend-only package without creating a frontend descriptor', async () => {
     const { bytes, digest } = v2Pkg([

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { normalizePlatformId, setPlatformId } from '../shared/osplat'
+import { platformId, setPlatformId } from '../shared/osplat'
 import { descendantsFirst, killProcessTree } from './process-tree'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 const execFileSync = vi.hoisted(() => vi.fn())
 vi.mock('node:child_process', () => ({ execFileSync }))
@@ -65,7 +71,7 @@ describe('killProcessTree', () => {
 
   afterEach(() => {
     kill.mockRestore()
-    setPlatformId(normalizePlatformId(process.platform))
+    setPlatformId(BASELINE)
   })
 
   it('signals every process in the tree, not just the handle', () => {
@@ -115,7 +121,7 @@ describe('killProcessTree', () => {
 
   describe('on Windows', () => {
     beforeEach(() => setPlatformId('win32'))
-    afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+    afterEach(() => setPlatformId(BASELINE))
 
     it('lets taskkill walk the tree instead of parsing ps', () => {
       execFileSync.mockReturnValue('')

--- a/src/renderer/src/components/__tests__/WindowControls.test.ts
+++ b/src/renderer/src/components/__tests__/WindowControls.test.ts
@@ -1,8 +1,14 @@
 // @vitest-environment happy-dom
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { normalizePlatformId, setPlatformId, type PlatformId } from '../../../../shared/osplat'
+import { platformId, setPlatformId, type PlatformId } from '../../../../shared/osplat'
 import WindowControls from '../WindowControls.vue'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 type Bridge = {
   minimize: ReturnType<typeof vi.fn>
@@ -32,7 +38,7 @@ function installBridge(maximized = false): void {
 beforeEach(() => installBridge())
 
 afterEach(() => {
-  setPlatformId(normalizePlatformId(process.platform))
+  setPlatformId(BASELINE)
   delete (window as unknown as { agentTeam?: unknown }).agentTeam
 })
 

--- a/src/renderer/src/composables/__tests__/hostSurfacePorts.test.ts
+++ b/src/renderer/src/composables/__tests__/hostSurfacePorts.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { ref } from 'vue'
 import type { useBackend } from '../useBackend'
-import { normalizePlatformId, setPlatformId } from '../../../../shared/osplat'
+import { platformId, setPlatformId } from '../../../../shared/osplat'
 import { createHostTerminalDockPort } from '../hostSurfacePorts'
 import {
   runTerminalDockContract,
   type TerminalDockContractHarness,
   type TerminalDockRequestRecord,
 } from '../../ports/__tests__/terminalDock.contract'
+
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
 
 type HostBackend = ReturnType<typeof useBackend>
 
@@ -46,7 +52,7 @@ function createHarness(): TerminalDockContractHarness {
 runTerminalDockContract(createHarness)
 
 describe('Host terminal dock adapter', () => {
-  afterEach(() => setPlatformId(normalizePlatformId(process.platform)))
+  afterEach(() => setPlatformId(BASELINE))
 
   it('does not bind raw route details into the port consumer type', () => {
     expect(createHarness().port).toHaveProperty('create')

--- a/src/shared/osplat.test.ts
+++ b/src/shared/osplat.test.ts
@@ -16,6 +16,12 @@ import {
   type PlatformId,
 } from './osplat'
 
+// The platform to restore after a test that switched it: whatever this file
+// saw when it loaded — the host, or an injection from a vitest setup file.
+// Restoring to the host instead silently undid that injection for every
+// later test in the file (see src/shared/platformBaseline.test.ts).
+const BASELINE = platformId()
+
 // The module caches an injected value, so every test has to hand it back or
 // the next one inherits a platform it did not ask for.
 const asPlatform = (id: PlatformId, run: () => void): void => {
@@ -24,10 +30,9 @@ const asPlatform = (id: PlatformId, run: () => void): void => {
 }
 
 afterEach(() => {
-  // `process.platform` is what main and preload actually resolve against, so
-  // restoring to it rather than to a fixed id keeps the suite honest about
-  // which machine it is on.
-  setPlatformId(normalizePlatformId(process.platform))
+  // Back to what this file loaded with — the host, or a suite-wide
+  // injection — never to a fixed id.
+  setPlatformId(BASELINE)
 })
 
 describe('normalizePlatformId', () => {

--- a/src/shared/platformBaseline.test.ts
+++ b/src/shared/platformBaseline.test.ts
@@ -1,0 +1,103 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { isMac, normalizePlatformId, platformId, setPlatformId } from './osplat'
+
+// Every test file that switches the platform with setPlatformId has to hand it
+// back afterwards. Sixteen of them handed back `normalizePlatformId(
+// process.platform)` — the host — which reads as the safe choice and is the
+// wrong one. Vitest isolates each file, so a setup file saying "run everything
+// as win32" injects afresh per file; the host restore then discarded it at the
+// first test in the file that switched, and every later test in that file
+// silently ran as the host. Worse than a gap: osplat.test.ts's "resolves from
+// process.platform when nothing was injected" *passed* under injection,
+// because the injection had been wiped before it ran. "Run the whole
+// front-end suite as Windows on a Linux runner" is the cheapest
+// cross-platform check we have, and it needs the baseline to be whatever the
+// file *loaded with*, not the machine.
+//
+// Two tests here. The first shows the mechanism works in-process. The second
+// is the ratchet: no test file may restore to the host, because the host form
+// will always look safer to whoever touches the file next.
+
+/** Simulate a setup file: inject before anything below evaluates. */
+const HOST = normalizePlatformId(process.platform)
+const INJECTED = HOST === 'win32' ? 'linux' : 'win32'
+setPlatformId(INJECTED)
+// What every converted file does at its top.
+const BASELINE = platformId()
+
+describe('a load-time baseline keeps a suite-wide platform injection alive', () => {
+  afterEach(() => setPlatformId(BASELINE))
+
+  it('captured the injection, not the host', () => {
+    expect(BASELINE).toBe(INJECTED)
+    expect(BASELINE).not.toBe(HOST)
+  })
+
+  it('a test can switch platforms for its own purposes', () => {
+    setPlatformId('darwin')
+    expect(isMac()).toBe(true)
+  })
+
+  it('and the next test still sees the injection, not the host', () => {
+    expect(platformId()).toBe(INJECTED)
+  })
+
+  it('restoring to the host would have discarded it — the shape the ratchet bans', () => {
+    setPlatformId(normalizePlatformId(process.platform))
+    expect(platformId()).toBe(HOST)
+    expect(platformId()).not.toBe(INJECTED)
+  })
+})
+
+// ── the ratchet ──────────────────────────────────────────────────────────────
+
+const REPO_ROOT = resolve(__dirname, '..', '..')
+const TEST_DIRS = ['src', 'packages', 'plugins', 'tests']
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'out', 'dist-plugins', '.git'])
+
+function testFiles(): string[] {
+  const found: string[] = []
+  const walk = (dir: string): void => {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const name of entries) {
+      if (SKIP_DIRS.has(name)) continue
+      const full = join(dir, name)
+      if (statSync(full).isDirectory()) walk(full)
+      else if (/\.(test|spec)\.tsx?$/.test(name) && full !== __filename) found.push(full)
+    }
+  }
+  for (const dir of TEST_DIRS) walk(join(REPO_ROOT, dir))
+  return found.sort()
+}
+
+/** Restoring the platform to the host rather than to the load-time baseline. */
+export const HOST_RESTORE_RE = /setPlatformId\(\s*normalizePlatformId\(\s*process\.platform\s*\)\s*\)/
+
+describe('no test restores the platform to the host', () => {
+  it('every setPlatformId reset goes back to a load-time BASELINE', () => {
+    const offenders = testFiles()
+      .filter((f) => HOST_RESTORE_RE.test(readFileSync(f, 'utf8')))
+      .map((f) => relative(REPO_ROOT, f).split('\\').join('/'))
+    expect(
+      offenders,
+      'these tests restore the platform to normalizePlatformId(process.platform) — the host — ' +
+        'which discards an injected platform for the rest of that file. Capture ' +
+        '`const BASELINE = platformId()` at the top of the file and restore to that'
+    ).toEqual([])
+  })
+
+  it('still matches the shape it bans', () => {
+    expect(HOST_RESTORE_RE.test('afterEach(() => setPlatformId(normalizePlatformId(process.platform)))')).toBe(true)
+    expect(HOST_RESTORE_RE.test('setPlatformId( normalizePlatformId( process.platform ) )')).toBe(true)
+    expect(HOST_RESTORE_RE.test('afterEach(() => setPlatformId(BASELINE))')).toBe(false)
+    // Reading the host to *classify* the host (a kernel-fact gate) is not a restore.
+    expect(HOST_RESTORE_RE.test("const hostIsWindows = normalizePlatformId(process.platform) === 'win32'")).toBe(false)
+  })
+})


### PR DESCRIPTION
Follow-up to #74. Sixteen test files reset the platform after a test with `setPlatformId(normalizePlatformId(process.platform))` — the host. Each now captures `const BASELINE = platformId()` at module load and restores to that. No new API, no product change.

## Why it matters — the motivation #74 earned

#74 made the main process decide on the platform through `src/shared/osplat.ts`, and its Windows CI run showed the payoff: `menu.test.ts` ran **34 tests, none skipped, on the Windows runner** — the darwin menu arm asserted on Windows for the first time. Once a platform-specific branch is drivable, every runner re-verifies the other platforms' behaviour. The next step is to drive the *whole* suite that way — "run the front-end suite as Windows on a Linux runner" is the cheapest cross-platform check available — and that needs an injected platform to survive a test file. The host restore did not let it.

## What the host restore actually did (per file, not per suite)

Vitest isolates each test file, so a setup file that injects a platform does so afresh per file. Inside a file, the host restore discarded the injection at the first test that switched platforms, and every later test in that file ran as the host. It did worse than leave a gap: under an injected run, `osplat.test.ts` › *"resolves from process.platform when nothing was injected"* **passed** — the injection had been wiped before it ran, so a test about the un-injected path was green under injection.

## The guard: `src/shared/platformBaseline.test.ts`

- **Mechanism**: the file injects a platform *before* taking its own `BASELINE` (simulating a setup file), shows a later test's `setPlatformId('darwin')` does not leak into the next test, and shows the host restore *would* have discarded the injection.
- **Ratchet**: no test file may contain `setPlatformId(normalizePlatformId(process.platform))`; the message names the `BASELINE` form. Regex pinned against the banned shape and against the kernel-fact gate `hostIsWindows = normalizePlatformId(process.platform) === 'win32'`, which classifies the host and is not a restore.
- **Revert-to-red, as asked**: `dock-tile-badge.test.ts` put back to `setPlatformId(normalizePlatformId(process.platform))` → the ratchet fails naming that file. Restored. This is the test that stops "restoring to the host is safer" from being re-introduced — the intuition is reasonable, which is exactly why only a red test holds it off.

## Is a whole-suite `win32` run feasible now? Measured, not predicted

Throwaway setup file (`setPlatformId('win32')`, not committed) over the full vitest suite on a macOS host:

| | before this PR | after |
|---|---|---|
| result | `2 failed \| 8830 passed` | `2 failed \| 8824 passed` (+1 env-only load failure) |
| `osplat.test.ts` fallback test | **passed — falsely** (injection wiped mid-file) | fails, correctly: it is about the un-injected path |
| `gitStorageLifecycle.test.ts:70` | fails | fails (same real mismatch, below) |
| `platformBaseline.test.ts` ratchet | fails on the 16 files | passes |

So: **feasible in mechanism — 8824 of 8851 tests run correctly as win32 on macOS** — with the following still missing before it can be a gate. Listed here as the next step's spec; none fixed in this PR.

1. **`src/main/plugins/gitStorageLifecycle.test.ts:70` gates on the host but exercises a seam-driven decision.** `fsSync.ts:47/59` skip directory fsync via `isWindows()` (the seam); the test's `it.skipIf(hostIsWindows)` reads the real host, so under injection the product skips the flush and the test expects it. The gate should be `isWindows()`. This corrects my earlier reading in the #74 thread: of the three `hostIsWindows` gates, the two in `executionPolicyStore.test.ts` guard kernel facts (`O_NOFOLLOW`, `0o077`) and are right to read the host; this one guards a seam decision and is not. One-line fix, separate PR.
2. **`src/shared/osplat.test.ts` › "resolves from process.platform when nothing was injected" cannot coexist with a global injection** — by construction. It needs a test-only way to clear the injection (`setPlatformId(null)` / `unsetPlatformId()`), or to skip when one is present. Touches the seam's API; separate PR.
3. **The opt-in itself**: a committed `NAVIDE_TEST_PLATFORM`-driven setup file / config plus a CI job or script. Not here.
4. **Coverage this run cannot reach, by design**: kernel-fact code (`ownerOnlyJsonPersistence.ts` and its host-gated tests) correctly ignores the injection; the keybinding layer reads `navigator.platform`; only ~17 production files import osplat. An injected run validates seam-driven decisions, which is what it is for.
5. Environmental: `backend.forwardLog.test.ts` failed to *load* once in this worktree (`Electron failed to install correctly` — an offline `pnpm install` race), unrelated to platform.

## Verification (bare runs)

- `pnpm typecheck` — exit 0
- `pnpm vitest run` on the 17 touched files — 573 passed
- Ratchet revert-to-red as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
