### PR TITLE
test(git-storage): gate the directory-flush case on the seam the product decides with

### DIFF
--- a/src/main/plugins/gitStorageLifecycle.test.ts
+++ b/src/main/plugins/gitStorageLifecycle.test.ts
@@ -2,14 +2,18 @@ import * as fs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { normalizePlatformId } from '../../shared/osplat'
+import { isWindows } from '../../shared/osplat'
 import type { GitStorageLifecycleFileOps } from './gitStorageLifecycle'
 import { GitStorageLifecycleSelector } from './gitStorageLifecycle'
 
 const roots: string[] = []
 
-// The real filesystem the suite runs on: NTFS refuses to fsync a directory handle.
-const hostIsWindows = normalizePlatformId(process.platform) === 'win32'
+// Whether the product will flush the parent directory at all: fsSync skips it
+// through `isWindows()` (the seam), not by asking the kernel — so this gate
+// reads the same source, or an injected platform leaves the test expecting a
+// flush the product never attempts. (NTFS cannot fsync a directory handle,
+// which is why the seam answers that way on Windows.)
+const skipsDirectoryFlush = isWindows()
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
@@ -67,7 +71,7 @@ describe('Git storage lifecycle selector', () => {
   })
 
   // The directory flush is skipped on Windows, so there is no second fsync to fail.
-  it.skipIf(hostIsWindows)('keeps a complete new selector when the parent directory flush fails', () => {
+  it.skipIf(skipsDirectoryFlush)('keeps a complete new selector when the parent directory flush fails', () => {
     const root = fs.mkdtempSync(join(tmpdir(), 'navide-git-lifecycle-'))
     roots.push(root)
     const recordPath = join(root, 'lifecycle.json')


### PR DESCRIPTION
The one real product/gate mismatch that #76's whole-suite `win32` injection surfaced — item 1 of its "what's still missing" list. One line of substance, with the evidence a one-line fix otherwise never gets.

## What was wrong

`gitStorageLifecycle.test.ts:70` gated *"keeps a complete new selector when the parent directory flush fails"* on `hostIsWindows = normalizePlatformId(process.platform) === 'win32'` — the real host. But the behaviour it guards is decided by `fsSync.ts:47/59` through `isWindows()` — the **seam**, not the kernel. So the gate and the product read different sources, and under an injected platform they disagree.

This corrects a classification I made on the #74 thread: of the three `hostIsWindows` gates in the tree, the two in `executionPolicyStore.test.ts` guard kernel facts (`O_NOFOLLOW`, `0o077`) that the product also reads from the host — those stay. This one guards a seam decision dressed as a kernel fact, and the static read ("the product file has no osplat call") missed that the decision lives one import away in `fsSync.ts`. It took running the injection to see it.

## Evidence, not just "it's green now"

Same file, throwaway setup file injecting `win32` on a macOS host (not committed):

```
BEFORE (gate reads the host), injected win32:
  × keeps a complete new selector when the parent directory flush fails
    → expected true to be false
    (gate said "run"; the product, through the seam, skipped the directory
     flush; the second fsync the test arranged to fail never happened)

AFTER (gate reads isWindows()), injected win32:
  ✓ gitStorageLifecycle.test.ts (5 tests | 1 skipped)
    (gate and product both say "Windows: no directory flush")

AFTER, no injection (host macOS):
  ✓ gitStorageLifecycle.test.ts (5 tests)   — the case still runs where it applies
```

Before, gate and product parted ways; after, they answer from the same source in both directions.

## Why this one line is worth a PR

`main` now carries two complementary tools: the backend can run its whole suite with Windows path semantics on any host (`OSPLAT_SWAP=paths`, #75), and the front-end suite can run under an injected platform end to end (#76). This PR is **the first thing the front-end injection actually caught** — a gate and a product decision that agreed on every real runner and disagreed the moment the platform was injected. Before the fix, under injection, the test was neither red nor falsely green: it was waiting for a second fsync that the product, through the seam, would never issue. That is the concrete answer to "why make injection survive a file" — not a mechanism, a finding.

Both directions are verified for the same reason a one-directional check would be worthless: a gate that says "always skip" would also make the injected run green.

## Verification

- `pnpm typecheck` — exit 0
- `pnpm vitest run` on this file plus the three ratchets (`platformBaseline`, `noScatteredPlatformBranches`, `crossPlatformTestHygiene`) and `fsSync.test.ts` — 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
