### PR TITLE
Report a watched plan path the way the wire spells it

### DIFF
--- a/src/main/plugins/plansBridge.test.ts
+++ b/src/main/plugins/plansBridge.test.ts
@@ -307,6 +307,10 @@ describe('Plans Host Bridge ports', () => {
       for (const { event, payload } of events) {
         expect(event).toBe('filesystem.changed')
         expect(payload).toMatchObject({ workspace_path: canonicalRoot, path: '.agent-team/plans/doc.html' })
+        // Vacuous on POSIX and the whole point on Windows, where fs.watch
+        // reports the host separator: this wire is posix, and the child
+        // rejects a workspace-relative path containing a backslash.
+        expect(String((payload as { path: string }).path)).not.toContain('\\')
       }
     } finally {
       controller.abort()

--- a/src/main/plugins/plansBridge.ts
+++ b/src/main/plugins/plansBridge.ts
@@ -720,8 +720,14 @@ export function createTestPlansFilesystemPort(): PlansFilesystemPort {
     // overflowed the Host→child output queue and took the child down; an
     // event without a filename cannot be classified and is still forwarded.
     const onEvent = (event: string, path: string | null): void => {
-      if (path !== null && !isPlanDocumentChangePath(path, root)) return
-      emitChanged(context, root, event, path)
+      // fs.watch reports the host's own separator, and this wire is posix:
+      // the classifier normalises before matching, the child rejects a path
+      // with a backslash outright, and the Plans app compares what arrives
+      // here against paths it built itself. Normalise once, at the boundary,
+      // so the half that classifies and the half that reports cannot disagree.
+      const relPath = path === null ? null : path.replace(/\\/g, '/')
+      if (relPath !== null && !isPlanDocumentChangePath(relPath, root)) return
+      emitChanged(context, root, event, relPath)
     }
     const watcherHandles: FSWatcher[] = []
     try {


### PR DESCRIPTION
main's `Frontend checks and build (Windows)` job is red: `plansBridge.test.ts > forwards watcher events for plan documents only` gets `.agent-team\plans\doc.html` where the wire is posix.

The watcher already normalises before classifying — `isPlanDocumentChangePath` does `replace(/\\/g, '/')` — but reports `fs.watch`'s raw filename, so the half that decides and the half that tells disagree on Windows. The Plans child rejects a workspace-relative path containing a backslash by name (`planRuntime.ts`, 'no backslashes'), and the app compares what arrives against paths it built itself, so this reaches the product and not just the test: `createHostPlansFilesystemPort` reuses this watcher.

Normalising once at the boundary fixes both halves. The new assertion is vacuous on POSIX and meaningful on Windows, where CI exercises it on every run — which is how the bug surfaced.

Verified: `vitest run src/main/plugins/plansBridge.test.ts` → 17 passed; `typecheck:node` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)