### PR TITLE
fix(plans): the two Windows regressions that turned v0.2.2's CI red

### DIFF
--- a/plugins/navide-plans/backend/plans_backend.py
+++ b/plugins/navide-plans/backend/plans_backend.py
@@ -15,7 +15,6 @@ import queue
 import re
 import sys
 import threading
-import time
 import uuid
 from datetime import datetime, timezone
 from html import escape as html_escape
@@ -86,10 +85,14 @@ _subscriptions: dict[str, dict[str, Any]] = {}
 _bridge_pending: dict[str, queue.Queue[tuple[str, Any]]] = {}
 _bridge_origin_ids: dict[str, set[str]] = {}
 _bridge_watch_origins: set[str] = set()
-# In-flight plans.list scan: {"done": threading.Event, "started_at": float,
+# In-flight plans.list scan: {"done": threading.Event, "generation": int,
 # "result": list | None, "error": BaseException | None}. Callers that arrive
 # while it runs wait for it, then share the one scan started after them.
+# The generation counts scans, not time: a clock coarse enough to read the
+# same value twice a millisecond apart (Windows ticks every ~15.6 ms) cannot
+# order a caller against a scan that started beside it.
 _list_flight: dict[str, Any] | None = None
+_list_generation = 0
 
 SERVER_INFO = {"name": "navide.plans", "version": "0.1.0"}
 
@@ -868,23 +871,25 @@ def _list_plans_single_flight(origin: dict[str, Any]) -> list[dict[str, Any]]:
     a scan started after it arrived: a scan already past some directory when
     the caller's write landed would hand it a pre-write snapshot.
     """
-    global _list_flight
-    arrived_at = time.monotonic()
+    global _list_flight, _list_generation
+    with _state_lock:
+        arrived_after = _list_generation
     while True:
         with _state_lock:
             flight = _list_flight
             leader = flight is None
             if leader:
+                _list_generation += 1
                 flight = _list_flight = {
                     "done": threading.Event(),
-                    "started_at": time.monotonic(),
+                    "generation": _list_generation,
                     "result": None,
                     "error": None,
                 }
         assert flight is not None
         if not leader:
             flight["done"].wait()
-            if flight["started_at"] < arrived_at:
+            if flight["generation"] <= arrived_after:
                 continue
             error = flight["error"]
             # A leader cancelled by its own caller says nothing about ours:

--- a/src/main/plugins/plansDirectories.test.ts
+++ b/src/main/plugins/plansDirectories.test.ts
@@ -402,10 +402,16 @@ describe('plansDirectories', () => {
       expect(vi.mocked(statSync)).not.toHaveBeenCalled()
     })
 
-    it('keeps directory events for plan directories and their ancestors, which is all a move sends', () => {
+    it('keeps directory events for plan directories, but not for the ancestors that also name ordinary traffic', () => {
       vi.mocked(statSync).mockClear()
-      for (const directory of ['.agent-team', '.agent-team/plans', 'docs', 'docs/reports', 'packages/child/.agent-team', 'packages/child/.cursor/plans']) {
+      for (const directory of ['.agent-team/plans', 'docs/reports', 'packages/child/.cursor/plans']) {
         expect(isPlanDocumentChangePath(directory, tempWorkspace), directory).toBe(true)
+      }
+      // A watcher that reports the parent of a changed file — Windows does —
+      // names these for every database write beside the plans and every edit
+      // under docs, so an ancestor cannot mean "a plan directory moved".
+      for (const ancestor of ['.agent-team', 'docs', '.claude', '.cursor', 'packages/child/.agent-team']) {
+        expect(isPlanDocumentChangePath(ancestor, tempWorkspace), ancestor).toBe(false)
       }
       for (const other of ['.agent-team/state', 'documents', 'packages/child', 'node_modules/.agent-team-x']) {
         expect(isPlanDocumentChangePath(other, tempWorkspace), other).toBe(false)

--- a/src/main/plugins/plansDirectories.ts
+++ b/src/main/plugins/plansDirectories.ts
@@ -294,15 +294,13 @@ export function isAllowedPlanDocumentPath(relPath: string, workspaceRoot: string
   return false
 }
 
-/** Every plan directory and every ancestor of one, e.g. `.agent-team` and
- * `.agent-team/plans`: a directory moved in or out of the workspace arrives
- * as a single event naming the directory, never its documents. */
-const PLAN_DIRECTORY_PATHS: readonly string[] = Array.from(new Set(
-  PLAN_DOC_DIRS.flatMap((planDir) => {
-    const segments = planDir.split('/')
-    return segments.map((_, index) => segments.slice(0, index + 1).join('/'))
-  }),
-))
+/** The plan directories themselves: one moved in or out of the workspace
+ * arrives as a single event naming the directory, never its documents.
+ * Deliberately not their ancestors. A host whose watcher reports the parent
+ * of a changed file — Windows does — names `.agent-team` for every database
+ * and log write beside the plans, and `docs` for every ordinary edit under
+ * it: exactly the storm this filter exists to stop. */
+const PLAN_DIRECTORY_PATHS: readonly string[] = PLAN_DOC_DIRS
 
 /**
  * Decide whether a watcher event names a plan document, or a directory whose


### PR DESCRIPTION
`9201410f` (Plans v2, second round) landed two defects that only Windows reports. Both Windows jobs went red on it and stayed red through the `v0.2.2` tag; macOS and Linux were green throughout, which is why it reached a release.

## 1. The watcher filter accepted plan-directory ancestors

`PLAN_DIRECTORY_PATHS` was built by expanding every ancestor of every plan directory, so the set contained bare `.agent-team`, `.claude`, `.cursor` and **`docs`**. A watcher that reports the parent of a changed file — Windows does — then names `.agent-team` for every `navide.db` and log write beside the plans, and `docs` for every ordinary edit under it. That is precisely the storm the filter exists to stop.

`forwards watcher events for plan documents only` saw three forwarded events where it expects none.

The directory-move case that motivated the ancestors never needed them: renaming `.agent-team/plans` names *that* path. The set is now `PLAN_DOC_DIRS`, and `plansDirectories.test.ts` pins the exclusions — a test that fails against the old classifier **on macOS**, so this cannot slip past a non-Windows run again.

## 2. Scan freshness was decided by a clock too coarse to decide it

`_list_plans_single_flight` let a caller take a scan only if it started after the caller arrived, comparing two `time.monotonic()` readings taken milliseconds apart with a strict `<`. Windows ticks that clock every ~15.6 ms, so both readings land in the same tick and the comparison answers "started after you" when it did not.

- `test_list_caller_arriving_mid_scan_sees_the_write_the_scan_missed` — `assert [] == ['.agent-team/plans/new.html']`: the caller got the pre-write snapshot.
- `test_overlapping_list_calls_share_one_follow_up_scan` — both followers took the leader's result, so the follow-up scan never happened and no bridge frame arrived within 2 s.

Shipped, this means a plan saved a moment ago is missing from the list on Windows. The same race exists everywhere; a fine clock just makes it rare.

Replaced with a generation counter incremented under the lock that hands out the flight: exact ordering, no clock resolution involved.

## Verification (macOS)

- `plansDirectories` + `plansBridge`: 44/44
- backend suite: **5559 passed, 9 skipped, 0 failed**
- `test_navide_plans_backend_wire.py` under `OSPLAT_SWAP=paths`: 23/23
- `pnpm typecheck`, `pnpm build`: exit 0
- full `pnpm test:run`: 8983+ passed. The handful of failures were `vitest` worker RPC timeouts under machine load (different set on each run, all ~5 s, none in the touched files); all four files pass in isolation.
- The new classifier test was run against the old code to confirm it fails there.

**The Windows jobs are the real verdict** — the watcher behaviour behind defect 1 and the clock resolution behind defect 2 cannot be reproduced on macOS.

## Not fixed here

`plugins/navide-plans/backend/plans_backend.py` has an unused `import os` that predates this branch. CI's backend lint only covers `backend/`, so nothing under `plugins/*/backend/` is linted at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)